### PR TITLE
refactor: move benchmark polling logic from client to provider

### DIFF
--- a/internal/resources/cbengine/benchmark/helpers.go
+++ b/internal/resources/cbengine/benchmark/helpers.go
@@ -1,6 +1,93 @@
 package benchmark
 
-import "strings"
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/client"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+)
+
+// WaitForBenchmarkSync polls until the benchmark reaches a terminal state
+// (SYNCED or FAILED) or the provided context is canceled. The interval
+// controls how often the API is polled.
+func waitForBenchmarkSync(ctx context.Context, c *client.Client, id string, interval time.Duration) (*client.CBEngineBenchmark, error) {
+	for {
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-time.After(interval):
+			benchmarks, err := c.GetCBEngineBenchmarks(ctx)
+			if err != nil {
+				tflog.Debug(ctx, "polling benchmarks failed", map[string]interface{}{"error": err.Error()})
+				return nil, fmt.Errorf("failed to poll benchmarks: %w", err)
+			}
+			var found *client.CBEngineBenchmark
+			for _, b := range benchmarks.Benchmarks {
+				if b.ID == id {
+					found = &b
+					break
+				}
+			}
+			if found == nil {
+				tflog.Debug(ctx, "benchmark not present yet", map[string]interface{}{"benchmark_id": id})
+				continue
+			}
+			tflog.Debug(ctx, "benchmark syncState", map[string]interface{}{"benchmark_id": id, "sync_state": found.SyncState})
+			switch found.SyncState {
+			case "PENDING":
+				continue
+			case "SYNCED":
+				return found, nil
+			case "FAILED":
+				return found, fmt.Errorf("benchmark %s in FAILED state", id)
+			default:
+				return found, fmt.Errorf("unexpected syncState for benchmark %s: %s", id, found.SyncState)
+			}
+		}
+	}
+}
+
+// WaitForBenchmarkDeletion polls until the benchmark is no longer present or
+// the context is canceled. Returns nil when the benchmark is absent. If the
+// API reports a DELETE_FAILED state an error is returned.
+func waitForBenchmarkDeletion(ctx context.Context, c *client.Client, id string, interval time.Duration) error {
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(interval):
+			benchmarks, err := c.GetCBEngineBenchmarks(ctx)
+			if err != nil {
+				tflog.Debug(ctx, "polling benchmarks failed", map[string]interface{}{"error": err.Error()})
+				return fmt.Errorf("failed to poll benchmarks: %w", err)
+			}
+			present := false
+			for _, b := range benchmarks.Benchmarks {
+				if b.ID == id {
+					present = true
+					tflog.Debug(ctx, "benchmark still present during deletion poll", map[string]interface{}{
+						"benchmark_id": b.ID,
+						"sync_state":   b.SyncState,
+					})
+					if b.SyncState == "DELETING" {
+						break
+					}
+					if b.SyncState == "DELETE_FAILED" {
+						return fmt.Errorf("benchmark %s deletion failed: syncState=DELETE_FAILED", id)
+					}
+					return fmt.Errorf("benchmark %s still present after delete, syncState=%s", id, b.SyncState)
+				}
+			}
+			if !present {
+				tflog.Debug(ctx, "benchmark absent after delete", map[string]interface{}{"benchmark_id": id})
+				return nil
+			}
+		}
+	}
+}
 
 // isNotFoundError checks if the error is a 404 not found error
 func isNotFoundError(err error) bool {


### PR DESCRIPTION
This simplifies the client package to just handle straight HTTP transport operations. Moved the polling logic to the provider - so this is all handled there now (no change in behaviour/functionality for usage):

* When a benchmark is created, poll with GetCBEngineBenchmarks method until SyncState is SYNCED
* When a benchmark is deleted, poll with GetCBEngineBenchmarks while the SyncState is DELETING and succeed when the benchmark ID no longer exists

This means that the provider can output relevant debug logs, and has more context available about what's going on so can quickly cancel an operation if it receives a break signal etc (with the logic in the client, the provider is just waiting for the create/delete function to complete and doesn't know if it's polling etc).

It's better practice to do it this way as I've since learned, when implementing Blueprints...