### PR TITLE
feat: add logging capabilities to API client and refactor handleAPIResponse to include context

### DIFF
--- a/internal/client/blueprints.go
+++ b/internal/client/blueprints.go
@@ -150,7 +150,7 @@ func (c *Client) GetBlueprints(ctx context.Context, sort []string, search string
 			return nil, fmt.Errorf("failed to list blueprints: %w", err)
 		}
 		var result BlueprintOverviewPagedResponse
-		if err := c.handleAPIResponse(resp, 200, &result); err != nil {
+		if err := c.handleAPIResponse(ctx, resp, 200, &result); err != nil {
 			return nil, err
 		}
 		allResults = append(allResults, result.Results...)
@@ -170,7 +170,7 @@ func (c *Client) GetBlueprintByID(ctx context.Context, blueprintID string) (*Blu
 		return nil, fmt.Errorf("failed to get blueprint %s: %w", blueprintID, err)
 	}
 	var result BlueprintDetail
-	if err := c.handleAPIResponse(resp, 200, &result); err != nil {
+	if err := c.handleAPIResponse(ctx, resp, 200, &result); err != nil {
 		return nil, err
 	}
 	return &result, nil
@@ -201,7 +201,7 @@ func (c *Client) CreateBlueprint(ctx context.Context, request *BlueprintCreateRe
 		return nil, fmt.Errorf("failed to create blueprint: %w", err)
 	}
 	var result BlueprintCreateResponse
-	if err := c.handleAPIResponse(resp, 201, &result); err != nil {
+	if err := c.handleAPIResponse(ctx, resp, 201, &result); err != nil {
 		return nil, err
 	}
 	return &result, nil
@@ -214,7 +214,7 @@ func (c *Client) UpdateBlueprint(ctx context.Context, blueprintID string, reques
 	if err != nil {
 		return fmt.Errorf("failed to update blueprint %s: %w", blueprintID, err)
 	}
-	if err := c.handleAPIResponse(resp, 204, nil); err != nil {
+	if err := c.handleAPIResponse(ctx, resp, 204, nil); err != nil {
 		return err
 	}
 	return nil
@@ -227,7 +227,7 @@ func (c *Client) DeleteBlueprint(ctx context.Context, blueprintID string) error 
 	if err != nil {
 		return fmt.Errorf("failed to delete blueprint %s: %w", blueprintID, err)
 	}
-	if err := c.handleAPIResponse(resp, 204, nil); err != nil {
+	if err := c.handleAPIResponse(ctx, resp, 204, nil); err != nil {
 		return err
 	}
 	return nil
@@ -240,7 +240,7 @@ func (c *Client) DeployBlueprint(ctx context.Context, blueprintID string) error 
 	if err != nil {
 		return fmt.Errorf("failed to deploy blueprint %s: %w", blueprintID, err)
 	}
-	if err := c.handleAPIResponse(resp, 202, nil); err != nil {
+	if err := c.handleAPIResponse(ctx, resp, 202, nil); err != nil {
 		return err
 	}
 	return nil
@@ -262,7 +262,7 @@ func (c *Client) GetBlueprintComponents(ctx context.Context) ([]BlueprintCompone
 			return nil, fmt.Errorf("failed to list blueprint components: %w", err)
 		}
 		var result BlueprintComponentDescriptionPagedResponse
-		if err := c.handleAPIResponse(resp, 200, &result); err != nil {
+		if err := c.handleAPIResponse(ctx, resp, 200, &result); err != nil {
 			return nil, err
 		}
 		allResults = append(allResults, result.Results...)
@@ -282,7 +282,7 @@ func (c *Client) GetBlueprintComponentByID(ctx context.Context, identifier strin
 		return nil, fmt.Errorf("failed to get blueprint component %s: %w", identifier, err)
 	}
 	var result BlueprintComponentDescription
-	if err := c.handleAPIResponse(resp, 200, &result); err != nil {
+	if err := c.handleAPIResponse(ctx, resp, 200, &result); err != nil {
 		return nil, err
 	}
 	return &result, nil

--- a/internal/client/cbengine.go
+++ b/internal/client/cbengine.go
@@ -178,7 +178,7 @@ func (c *Client) GetCBEngineBaselines(ctx context.Context) (*CBEngineBaselinesRe
 	}
 
 	var result CBEngineBaselinesResponse
-	if err := c.handleAPIResponse(resp, 200, &result); err != nil {
+	if err := c.handleAPIResponse(ctx, resp, 200, &result); err != nil {
 		return nil, err
 	}
 
@@ -195,7 +195,7 @@ func (c *Client) CreateCBEngineBenchmark(ctx context.Context, request *CBEngineB
 	}
 
 	var result CBEngineBenchmarkResponse
-	if err := c.handleAPIResponse(resp, 202, &result); err != nil {
+	if err := c.handleAPIResponse(ctx, resp, 202, &result); err != nil {
 		return nil, err
 	}
 
@@ -210,7 +210,7 @@ func (c *Client) GetCBEngineBenchmarks(ctx context.Context) (*CBEngineBenchmarks
 	}
 
 	var result CBEngineBenchmarksResponse
-	if err := c.handleAPIResponse(resp, 200, &result); err != nil {
+	if err := c.handleAPIResponse(ctx, resp, 200, &result); err != nil {
 		return nil, err
 	}
 
@@ -227,7 +227,7 @@ func (c *Client) GetCBEngineBenchmarkByID(ctx context.Context, id string) (*CBEn
 	}
 
 	var result CBEngineBenchmarkResponse
-	if err := c.handleAPIResponse(resp, 200, &result); err != nil {
+	if err := c.handleAPIResponse(ctx, resp, 200, &result); err != nil {
 		return nil, err
 	}
 
@@ -243,7 +243,7 @@ func (c *Client) DeleteCBEngineBenchmark(ctx context.Context, id string) error {
 		return fmt.Errorf("failed to delete benchmark %s: %w", id, err)
 	}
 
-	if err := c.handleAPIResponse(resp, 204, nil); err != nil {
+	if err := c.handleAPIResponse(ctx, resp, 204, nil); err != nil {
 		return err
 	}
 
@@ -278,7 +278,7 @@ func (c *Client) GetCBEngineRules(ctx context.Context, baselineID string) (*CBEn
 	}
 
 	var result CBEngineSourcedRules
-	if err := c.handleAPIResponse(resp, 200, &result); err != nil {
+	if err := c.handleAPIResponse(ctx, resp, 200, &result); err != nil {
 		return nil, err
 	}
 

--- a/internal/client/client_oauth.go
+++ b/internal/client/client_oauth.go
@@ -262,7 +262,6 @@ func (c *OAuthClient) AuthenticatedRequest(ctx context.Context, method, url stri
 // Do performs an authenticated HTTP request. The body is provided as a
 // byte slice so retries can recreate the request body reader.
 func (c *OAuthClient) Do(ctx context.Context, method, url string, body []byte) (*http.Response, error) {
-	// First attempt
 	req, err := c.AuthenticatedRequest(ctx, method, url, body)
 	if err != nil {
 		return nil, err

--- a/internal/client/inventory_computer.go
+++ b/internal/client/inventory_computer.go
@@ -494,7 +494,7 @@ func (c *Client) GetInventoryComputerByID(ctx context.Context, id string) (*Inve
 		return nil, fmt.Errorf("failed to get computer by id: %w", err)
 	}
 	var result InventoryComputer
-	if err := c.handleAPIResponse(resp, 200, &result); err != nil {
+	if err := c.handleAPIResponse(ctx, resp, 200, &result); err != nil {
 		return nil, err
 	}
 	return &result, nil
@@ -521,7 +521,7 @@ func (c *Client) GetInventoryComputers(ctx context.Context, page, pageSize int, 
 		return nil, fmt.Errorf("failed to list computers: %w", err)
 	}
 	var result InventoryComputerSearchResults
-	if err := c.handleAPIResponse(resp, 200, &result); err != nil {
+	if err := c.handleAPIResponse(ctx, resp, 200, &result); err != nil {
 		return nil, err
 	}
 	return &result, nil

--- a/internal/client/inventory_mobile_devices.go
+++ b/internal/client/inventory_mobile_devices.go
@@ -317,7 +317,7 @@ func (c *Client) GetInventoryMobileDeviceByID(ctx context.Context, id string, se
 		return nil, fmt.Errorf("failed to get mobile device by id: %w", err)
 	}
 	var result InventoryMobileDevice
-	if err := c.handleAPIResponse(resp, 200, &result); err != nil {
+	if err := c.handleAPIResponse(ctx, resp, 200, &result); err != nil {
 		return nil, err
 	}
 	return &result, nil
@@ -346,7 +346,7 @@ func (c *Client) GetInventoryMobileDevices(ctx context.Context, page, pageSize i
 		return nil, fmt.Errorf("failed to list mobile devices: %w", err)
 	}
 	var result InventoryMobileDeviceSearchResults
-	if err := c.handleAPIResponse(resp, 200, &result); err != nil {
+	if err := c.handleAPIResponse(ctx, resp, 200, &result); err != nil {
 		return nil, err
 	}
 	return &result, nil

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -108,9 +108,12 @@ func (p *JamfPlatformProvider) Configure(ctx context.Context, req provider.Confi
 		clientSecret = getenv(envClientSecret)
 	}
 
-	client := client.NewClient(baseURL, clientID, clientSecret)
-	resp.DataSourceData = client
-	resp.ResourceData = client
+	apiClient := client.NewClient(baseURL, clientID, clientSecret)
+
+	apiClient.SetLogger(NewTerraformLogger())
+
+	resp.DataSourceData = apiClient
+	resp.ResourceData = apiClient
 }
 
 // Resources returns the list of resource constructors for the provider.

--- a/internal/provider/tflogger.go
+++ b/internal/provider/tflogger.go
@@ -1,0 +1,52 @@
+// Copyright 2025 Jamf Software LLC.
+
+package provider
+
+import (
+	"context"
+
+	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/client"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+)
+
+// Ensure TerraformLogger implements client.Logger interface
+var _ client.Logger = (*TerraformLogger)(nil)
+
+// TerraformLogger implements the client.Logger interface using tflog
+type TerraformLogger struct{}
+
+// NewTerraformLogger creates a new TerraformLogger
+func NewTerraformLogger() *TerraformLogger {
+	return &TerraformLogger{}
+}
+
+// LogRequest logs HTTP request details using tflog at DEBUG level
+func (l *TerraformLogger) LogRequest(ctx context.Context, method, url string, body []byte) {
+	fields := map[string]interface{}{
+		"method": method,
+		"url":    url,
+	}
+
+	if len(body) > 0 {
+		fields["request_body"] = string(body)
+	}
+
+	tflog.Debug(ctx, "HTTP Request", fields)
+}
+
+// LogResponse logs HTTP response details using tflog at DEBUG level
+func (l *TerraformLogger) LogResponse(ctx context.Context, statusCode int, body []byte) {
+	fields := map[string]interface{}{
+		"status_code": statusCode,
+	}
+
+	if len(body) > 0 {
+		bodyStr := string(body)
+		if len(bodyStr) > 5000 {
+			bodyStr = bodyStr[:5000] + "... (truncated)"
+		}
+		fields["response_body"] = bodyStr
+	}
+
+	tflog.Debug(ctx, "HTTP Response", fields)
+}


### PR DESCRIPTION
Will be extremely useful for providing feedback as the API is still in beta so may have quirks. When setting `TF_LOG=DEBUG` we will now get debug logs containing all raw HTTP request and response bodies.

By default these are not logged - it has to be set intentionally, e.g:

`TF_LOG=DEBUG tofu apply`

Example debug output is now much more comprehensive - see the `HTTP Request` and `HTTP Response` statements in the example below.

```
2025-10-14T16:53:11.232+0100 [DEBUG] provider.terraform-provider-jamfplatform: HTTP Request: @caller=/Users/Shared/GitHub/terraform-provider-jamfplatform/internal/provider/tflogger.go:34 tf_req_id=48d6a608-09b6-0766-13cf-0ea9ba332946 url=https://eu.apigw.jamf.com/api/blueprints/v1/blueprints @module=jamfplatform method=POST request_body="{\"name\":\"Audio Accessory Settings\",\"description\":\"Managed by Terraform\",\"scope\":{\"deviceGroups\":[\"23dadc09-b51a-4534-a8ac-1f93e74afd73\"]},\"steps\":[{\"name\":\"Declaration group\",\"components\":[{\"identifier\":\"com.jamf.ddm.audio-accessory-settings\",\"configuration\":{\"TemporaryPairing\":{\"Configuration\":{\"UnpairingTime\":{\"Hour\":22,\"Policy\":\"Hour\"}},\"Disabled\":false,\"Included\":true}}}]}]}" tf_provider_addr=registry.terraform.io/Jamf-Concepts/jamfplatform tf_resource_type=jamfplatform_blueprints_blueprint tf_rpc=ApplyResourceChange timestamp="2025-10-14T16:53:11.232+0100"
2025-10-14T16:53:14.247+0100 [DEBUG] provider.terraform-provider-jamfplatform: HTTP Response: status_code=201 tf_resource_type=jamfplatform_blueprints_blueprint tf_rpc=ApplyResourceChange @module=jamfplatform response_body="{\"id\":\"821f0ef5-86d2-4449-bd07-5ec3c02cf29c\",\"href\":\"https://eu.apigw.jamf.com/api/blueprints/v1/blueprints/821f0ef5-86d2-4449-bd07-5ec3c02cf29c\"}" tf_provider_addr=registry.terraform.io/Jamf-Concepts/jamfplatform tf_req_id=48d6a608-09b6-0766-13cf-0ea9ba332946 @caller=/Users/Shared/GitHub/terraform-provider-jamfplatform/internal/provider/tflogger.go:51 timestamp="2025-10-14T16:53:14.247+0100"
2025-10-14T16:53:14.247+0100 [DEBUG] provider.terraform-provider-jamfplatform: HTTP Request: tf_provider_addr=registry.terraform.io/Jamf-Concepts/jamfplatform tf_req_id=48d6a608-09b6-0766-13cf-0ea9ba332946 tf_rpc=ApplyResourceChange url=https://eu.apigw.jamf.com/api/blueprints/v1/blueprints/821f0ef5-86d2-4449-bd07-5ec3c02cf29c/deploy @module=jamfplatform tf_resource_type=jamfplatform_blueprints_blueprint @caller=/Users/Shared/GitHub/terraform-provider-jamfplatform/internal/provider/tflogger.go:34 method=POST timestamp="2025-10-14T16:53:14.247+0100"
2025-10-14T16:53:19.074+0100 [DEBUG] provider.terraform-provider-jamfplatform: HTTP Response: @caller=/Users/Shared/GitHub/terraform-provider-jamfplatform/internal/provider/tflogger.go:51 tf_provider_addr=registry.terraform.io/Jamf-Concepts/jamfplatform tf_req_id=48d6a608-09b6-0766-13cf-0ea9ba332946 tf_rpc=ApplyResourceChange @module=jamfplatform status_code=202 tf_resource_type=jamfplatform_blueprints_blueprint timestamp="2025-10-14T16:53:19.074+0100"
2025-10-14T16:53:19.074+0100 [DEBUG] provider.terraform-provider-jamfplatform: HTTP Request: @caller=/Users/Shared/GitHub/terraform-provider-jamfplatform/internal/provider/tflogger.go:34 @module=jamfplatform tf_resource_type=jamfplatform_blueprints_blueprint method=GET tf_provider_addr=registry.terraform.io/Jamf-Concepts/jamfplatform tf_req_id=48d6a608-09b6-0766-13cf-0ea9ba332946 tf_rpc=ApplyResourceChange url=https://eu.apigw.jamf.com/api/blueprints/v1/blueprints/821f0ef5-86d2-4449-bd07-5ec3c02cf29c timestamp="2025-10-14T16:53:19.074+0100"
2025-10-14T16:53:20.391+0100 [DEBUG] provider.terraform-provider-jamfplatform: HTTP Response: tf_req_id=48d6a608-09b6-0766-13cf-0ea9ba332946 tf_resource_type=jamfplatform_blueprints_blueprint @module=jamfplatform response_body="{\"id\":\"821f0ef5-86d2-4449-bd07-5ec3c02cf29c\",\"name\":\"Audio Accessory Settings\",\"description\":\"Managed by Terraform\",\"scope\":{\"deviceGroups\":[\"23dadc09-b51a-4534-a8ac-1f93e74afd73\"]},\"created\":\"2025-10-14T15:53:14.293281Z\",\"updated\":\"2025-10-14T15:53:18.330085Z\",\"deploymentState\":{\"state\":\"DEPLOYED\",\"lastDeployment\":{\"started\":\"2025-10-14T15:53:18.329361Z\",\"state\":\"SUCCEEDED\"}},\"steps\":[{\"name\":\"Declaration group\",\"components\":[{\"identifier\":\"com.jamf.ddm.audio-accessory-settings\",\"configuration\":{\"TemporaryPairing\":{\"Disabled\":false,\"Included\":true,\"Configuration\":{\"UnpairingTime\":{\"Hour\":22,\"Policy\":\"Hour\"}}}}}]}]}" status_code=200 tf_rpc=ApplyResourceChange @caller=/Users/Shared/GitHub/terraform-provider-jamfplatform/internal/provider/tflogger.go:51 tf_provider_addr=registry.terraform.io/Jamf-Concepts/jamfplatform timestamp="2025-10-14T16:53:20.390+0100"
```