### PR TITLE
fix: change blueprint device_groups from List to Set for unordered handling

### DIFF
--- a/docs/data-sources/blueprints_blueprint.md
+++ b/docs/data-sources/blueprints_blueprint.md
@@ -39,7 +39,7 @@ output "blueprint_example_all" {
 - `created` (String) Created at (RFC3339).
 - `deployment_state` (String) Deployment state.
 - `description` (String) Description.
-- `device_groups` (List of String) Device groups in scope.
+- `device_groups` (Set of String) Device groups in scope (unordered).
 - `updated` (String) Updated at (RFC3339).
 
 <a id="nestedatt--component"></a>

--- a/docs/resources/blueprints_blueprint.md
+++ b/docs/resources/blueprints_blueprint.md
@@ -96,7 +96,7 @@ resource "jamfplatform_blueprints_blueprint" "legacy_payloads_example" {
 
 ### Required
 
-- `device_groups` (List of String) List of device group Platform IDs to target. Specified as a list of strings in UUID format. The Platform ID can be sourced from the response body of the /api/v1/groups Jamf Pro API endpoint.
+- `device_groups` (Set of String) Set of device group Platform IDs to target. Specified as a set of strings in UUID format. The Platform ID can be sourced from the response body of the /api/v1/groups Jamf Pro API endpoint. Order does not matter.
 - `name` (String) Blueprint name.
 
 ### Optional

--- a/internal/resources/blueprints/blueprint/crud.go
+++ b/internal/resources/blueprints/blueprint/crud.go
@@ -19,9 +19,11 @@ func (r *BlueprintResource) Create(ctx context.Context, req resource.CreateReque
 		return
 	}
 
-	deviceGroups := make([]string, len(data.DeviceGroups))
-	for i, dg := range data.DeviceGroups {
-		deviceGroups[i] = dg.ValueString()
+	var deviceGroupsSet []string
+	diags := data.DeviceGroups.ElementsAs(ctx, &deviceGroupsSet, false)
+	if diags.HasError() {
+		resp.Diagnostics.Append(diags...)
+		return
 	}
 
 	allComponents, diags := r.collectAllComponents(ctx, &data)
@@ -41,7 +43,7 @@ func (r *BlueprintResource) Create(ctx context.Context, req resource.CreateReque
 		Name:        data.Name.ValueString(),
 		Description: data.Description.ValueString(),
 		Scope: client.BlueprintCreateScope{
-			DeviceGroups: deviceGroups,
+			DeviceGroups: deviceGroupsSet,
 		},
 		Steps: steps,
 	}
@@ -120,9 +122,11 @@ func (r *BlueprintResource) Update(ctx context.Context, req resource.UpdateReque
 		return
 	}
 
-	deviceGroups := make([]string, len(data.DeviceGroups))
-	for i, dg := range data.DeviceGroups {
-		deviceGroups[i] = dg.ValueString()
+	var deviceGroupsSet []string
+	diags := data.DeviceGroups.ElementsAs(ctx, &deviceGroupsSet, false)
+	if diags.HasError() {
+		resp.Diagnostics.Append(diags...)
+		return
 	}
 
 	allComponents, diags := r.collectAllComponents(ctx, &data)
@@ -142,7 +146,7 @@ func (r *BlueprintResource) Update(ctx context.Context, req resource.UpdateReque
 		Name:        data.Name.ValueString(),
 		Description: data.Description.ValueString(),
 		Scope: client.BlueprintUpdateScope{
-			DeviceGroups: deviceGroups,
+			DeviceGroups: deviceGroupsSet,
 		},
 		Steps: steps,
 	}

--- a/internal/resources/blueprints/blueprint/data_source.go
+++ b/internal/resources/blueprints/blueprint/data_source.go
@@ -61,8 +61,8 @@ func (d *BlueprintDataSource) Schema(ctx context.Context, req datasource.SchemaR
 				Description: "Deployment state.",
 				Computed:    true,
 			},
-			"device_groups": schema.ListAttribute{
-				Description: "Device groups in scope.",
+			"device_groups": schema.SetAttribute{
+				Description: "Device groups in scope (unordered).",
 				ElementType: types.StringType,
 				Computed:    true,
 			},
@@ -145,10 +145,7 @@ func (d *BlueprintDataSource) Read(ctx context.Context, req datasource.ReadReque
 		return
 	}
 
-	var deviceGroups []types.String
-	for _, g := range bp.Scope.DeviceGroups {
-		deviceGroups = append(deviceGroups, types.StringValue(g))
-	}
+	deviceGroupsSet, _ := types.SetValueFrom(context.Background(), types.StringType, bp.Scope.DeviceGroups)
 
 	var components []ComponentModel
 	if len(bp.Steps) > 0 {
@@ -179,7 +176,7 @@ func (d *BlueprintDataSource) Read(ctx context.Context, req datasource.ReadReque
 		Created:         types.StringValue(bp.Created),
 		Updated:         types.StringValue(bp.Updated),
 		DeploymentState: types.StringValue(bp.DeploymentState.State),
-		DeviceGroups:    deviceGroups,
+		DeviceGroups:    deviceGroupsSet,
 		Components:      components,
 	}
 

--- a/internal/resources/blueprints/blueprint/helpers.go
+++ b/internal/resources/blueprints/blueprint/helpers.go
@@ -29,11 +29,8 @@ func updateModelFromAPIResponse(model *BlueprintResourceModel, blueprint *client
 	model.Updated = types.StringValue(blueprint.Updated)
 	model.DeploymentState = types.StringValue(blueprint.DeploymentState.State)
 
-	deviceGroups := make([]types.String, len(blueprint.Scope.DeviceGroups))
-	for i, dg := range blueprint.Scope.DeviceGroups {
-		deviceGroups[i] = types.StringValue(dg)
-	}
-	model.DeviceGroups = deviceGroups
+	deviceGroupsSet, _ := types.SetValueFrom(context.Background(), types.StringType, blueprint.Scope.DeviceGroups)
+	model.DeviceGroups = deviceGroupsSet
 
 	if len(blueprint.Steps) > 0 {
 		step := blueprint.Steps[0]

--- a/internal/resources/blueprints/blueprint/resource.go
+++ b/internal/resources/blueprints/blueprint/resource.go
@@ -10,6 +10,7 @@ import (
 	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/client"
 	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/resources/blueprints/blueprint/components"
 	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/setvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -54,13 +55,13 @@ func (r *BlueprintResource) Schema(ctx context.Context, req resource.SchemaReque
 				Description: "Blueprint description.",
 				Optional:    true,
 			},
-			"device_groups": schema.ListAttribute{
-				Description: "List of device group Platform IDs to target. Specified as a list of strings in UUID format. The Platform ID can be sourced from the response body of the /api/v1/groups Jamf Pro API endpoint.",
+			"device_groups": schema.SetAttribute{
+				Description: "Set of device group Platform IDs to target. Specified as a set of strings in UUID format. The Platform ID can be sourced from the response body of the /api/v1/groups Jamf Pro API endpoint. Order does not matter.",
 				Required:    true,
 				ElementType: types.StringType,
-				Validators: []validator.List{
-					listvalidator.SizeAtLeast(1),
-					listvalidator.ValueStringsAre(stringvalidator.RegexMatches(
+				Validators: []validator.Set{
+					setvalidator.SizeAtLeast(1),
+					setvalidator.ValueStringsAre(stringvalidator.RegexMatches(
 						regexp.MustCompile(`^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$`),
 						"Each device group ID must be a valid UUID",
 					)),

--- a/internal/resources/blueprints/blueprint/types.go
+++ b/internal/resources/blueprints/blueprint/types.go
@@ -18,7 +18,7 @@ type BlueprintResourceModel struct {
 	ID                        types.String                                    `tfsdk:"id"`
 	Name                      types.String                                    `tfsdk:"name"`
 	Description               types.String                                    `tfsdk:"description"`
-	DeviceGroups              []types.String                                  `tfsdk:"device_groups"`
+	DeviceGroups              types.Set                                       `tfsdk:"device_groups"`
 	Components                []ComponentModel                                `tfsdk:"raw_component"`
 	AudioAccessorySettings    []components.AudioAccessorySettingsComponent    `tfsdk:"audio_accessory_settings"`
 	DiskManagementSettings    []components.DiskManagementPolicyComponent      `tfsdk:"disk_management_settings"`
@@ -51,7 +51,7 @@ type BlueprintDataSourceModel struct {
 	Created         types.String     `tfsdk:"created"`
 	Updated         types.String     `tfsdk:"updated"`
 	DeploymentState types.String     `tfsdk:"deployment_state"`
-	DeviceGroups    []types.String   `tfsdk:"device_groups"`
+	DeviceGroups    types.Set        `tfsdk:"device_groups"`
 	Components      []ComponentModel `tfsdk:"component"`
 }
 


### PR DESCRIPTION
Fixes #42 

This may force a replacement of existing blueprint resources that have multiple device groups in scope (it will definitely do this if the resource creation generated the error in the above issue as they will be tainted regardless - cannot be avoided):

```
  # jamfplatform_blueprints_blueprint.disk_management is tainted, so must be replaced
-/+ resource "jamfplatform_blueprints_blueprint" "disk_management" {
      ~ created          = "2025-10-17T07:32:11.810520Z" -> (known after apply)
      ~ deployment_state = "DEPLOYED" -> (known after apply)
      ~ id               = "88e32820-0a37-43f6-ac04-e723844d6320" -> (known after apply)
        name             = "Disk Management"
      ~ updated          = "2025-10-17T07:32:15.441977Z" -> (known after apply)
        # (2 unchanged attributes hidden)

        # (1 unchanged block hidden)
    }
```