### PR TITLE
fix: Bump jamfplatform-go-sdk to v0.4.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/Jamf-Concepts/terraform-provider-jamfplatform
 go 1.26.2
 
 require (
-	github.com/Jamf-Concepts/jamfplatform-go-sdk v0.3.0
+	github.com/Jamf-Concepts/jamfplatform-go-sdk v0.4.0
 	github.com/hashicorp/terraform-plugin-framework v1.19.0
 	github.com/hashicorp/terraform-plugin-framework-timeouts v0.7.0
 	github.com/hashicorp/terraform-plugin-framework-validators v0.19.0

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 dario.cat/mergo v1.0.0 h1:AGCNq9Evsj31mOgNPcLyXc+4PNABt905YmuqPYYpBWk=
 dario.cat/mergo v1.0.0/go.mod h1:uNxQE+84aUszobStD9th8a29P2fMDhsBdgRYvZOxGmk=
-github.com/Jamf-Concepts/jamfplatform-go-sdk v0.3.0 h1:W5sL0Fl8RDwRuwTgHRuWoScUrAi6XHeYJWMydjagHh8=
-github.com/Jamf-Concepts/jamfplatform-go-sdk v0.3.0/go.mod h1:aNjapJAdC8d/9KsGnMK8ouZU7KBl9sS1RF/yLQkHgO8=
+github.com/Jamf-Concepts/jamfplatform-go-sdk v0.4.0 h1:CFZvi3lM5xG25RY2LDX7qSw0hnUDGT5RmCofTX98+vY=
+github.com/Jamf-Concepts/jamfplatform-go-sdk v0.4.0/go.mod h1:aNjapJAdC8d/9KsGnMK8ouZU7KBl9sS1RF/yLQkHgO8=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
 github.com/ProtonMail/go-crypto v1.4.1 h1:9RfcZHqEQUvP8RzecWEUafnZVtEvrBVL9BiF67IQOfM=

--- a/internal/resources/blueprints/blueprint/crud.go
+++ b/internal/resources/blueprints/blueprint/crud.go
@@ -53,7 +53,7 @@ func (r *BlueprintResource) Create(ctx context.Context, req resource.CreateReque
 	reqBody := &jamfplatform.CreateBlueprintRequest{
 		Name:        data.Name.ValueString(),
 		Description: data.Description.ValueStringPointer(),
-		Scope: &jamfplatform.CreateScope{
+		Scope: jamfplatform.CreateScope{
 			DeviceGroups: deviceGroups,
 		},
 		Steps: steps,
@@ -218,7 +218,7 @@ func (r *BlueprintResource) Update(ctx context.Context, req resource.UpdateReque
 		Scope: &jamfplatform.BlueprintScope{
 			DeviceGroups: deviceGroups,
 		},
-		Steps: steps,
+		Steps: &steps,
 	}
 
 	if err := r.client.UpdateBlueprint(updateCtx, data.ID.ValueString(), updateReq); err != nil {

--- a/internal/resources/cbengine/benchmark/input_builders.go
+++ b/internal/resources/cbengine/benchmark/input_builders.go
@@ -15,7 +15,7 @@ func buildBenchmarkRequest(data *BenchmarkResourceModel) *jamfplatform.Benchmark
 		SourceBaselineID: data.SourceBaselineID.ValueString(),
 		Sources:          make([]jamfplatform.Source, len(data.Sources)),
 		Rules:            make([]jamfplatform.RuleRequest, len(data.Rules)),
-		Target: &jamfplatform.TargetV2{
+		Target: jamfplatform.TargetV2{
 			DeviceGroups: []string{data.TargetDeviceGroup.ValueString()},
 		},
 		EnforcementMode: data.EnforcementMode.ValueString(),

--- a/internal/resources/device_group/crud.go
+++ b/internal/resources/device_group/crud.go
@@ -61,7 +61,8 @@ func (r *DeviceGroupResource) Create(ctx context.Context, req resource.CreateReq
 
 	switch strings.ToLower(plan.GroupType.ValueString()) {
 	case "smart":
-		reqBody.Criteria = expandDeviceGroupCriteria(plan.Criteria)
+		criteria := expandDeviceGroupCriteria(plan.Criteria)
+		reqBody.Criteria = &criteria
 	case "static":
 		if manageMembers {
 			members, diags := helpers.SetToStringSlice(createCtx, plan.Members)
@@ -69,7 +70,7 @@ func (r *DeviceGroupResource) Create(ctx context.Context, req resource.CreateReq
 			if resp.Diagnostics.HasError() {
 				return
 			}
-			reqBody.Members = members
+			reqBody.Members = &members
 		}
 	}
 
@@ -226,7 +227,8 @@ func (r *DeviceGroupResource) Update(ctx context.Context, req resource.UpdateReq
 	}
 
 	if strings.ToLower(plan.GroupType.ValueString()) == "smart" {
-		updateReq.Criteria = expandDeviceGroupCriteria(plan.Criteria)
+		criteria := expandDeviceGroupCriteria(plan.Criteria)
+		updateReq.Criteria = &criteria
 	}
 
 	if err := r.client.UpdateDeviceGroup(updateCtx, plan.ID.ValueString(), updateReq); err != nil {
@@ -252,9 +254,12 @@ func (r *DeviceGroupResource) Update(ctx context.Context, req resource.UpdateReq
 
 		added, removed := diffStringSlices(current, desired)
 		if len(added) > 0 || len(removed) > 0 {
-			patch := &jamfplatform.DeviceGroupMemberPatchRepresentationV1{
-				Added:   added,
-				Removed: removed,
+			patch := &jamfplatform.DeviceGroupMemberPatchRepresentationV1{}
+			if len(added) > 0 {
+				patch.Added = &added
+			}
+			if len(removed) > 0 {
+				patch.Removed = &removed
 			}
 			if err := r.client.UpdateDeviceGroupMembers(updateCtx, plan.ID.ValueString(), patch); err != nil {
 				resp.Diagnostics.AddError("Error updating device group members", err.Error())

--- a/internal/resources/device_group/resource_acceptance_test.go
+++ b/internal/resources/device_group/resource_acceptance_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/common/helpers"
 	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/testhelpers"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
@@ -227,6 +228,92 @@ func TestAccDataSource_DeviceGroups(t *testing.T) {
 				`,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet("data.jamfplatform_device_groups.all", "device_groups.#"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccResource_DeviceGroup_DescriptionNullVsEmpty(t *testing.T) {
+	testhelpers.AccPreCheck(t)
+	suffix := testhelpers.RunSuffix()
+	name := "tf-acc-desc-nullempty-" + suffix
+	rn := "jamfplatform_device_group.test"
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testhelpers.AccTestProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckDeviceGroupDestroy(t),
+		Steps: []resource.TestStep{
+			// Step 1: create with a real description value
+			{
+				Config: fmt.Sprintf(`
+					resource "jamfplatform_device_group" "test" {
+						name        = %q
+						description = "initial value"
+						group_type  = "static"
+						device_type = "computer"
+					}
+				`, name),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet(rn, "id"),
+					resource.TestCheckResourceAttr(rn, "description", "initial value"),
+				),
+			},
+			// Step 2: set description to explicit empty string — must be preserved as ""
+			{
+				Config: fmt.Sprintf(`
+					resource "jamfplatform_device_group" "test" {
+						name        = %q
+						description = ""
+						group_type  = "static"
+						device_type = "computer"
+					}
+				`, name),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(rn, "description", ""),
+				),
+			},
+			// Step 3: set description to explicit null — must become unset in state
+			{
+				Config: fmt.Sprintf(`
+					resource "jamfplatform_device_group" "test" {
+						name        = %q
+						description = null
+						group_type  = "static"
+						device_type = "computer"
+					}
+				`, name),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckNoResourceAttr(rn, "description"),
+				),
+			},
+			// Step 4: omit description entirely — equivalent to null, plan must be empty
+			{
+				Config: fmt.Sprintf(`
+					resource "jamfplatform_device_group" "test" {
+						name        = %q
+						group_type  = "static"
+						device_type = "computer"
+					}
+				`, name),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+			// Step 5: re-add description to verify it can be restored after being unset
+			{
+				Config: fmt.Sprintf(`
+					resource "jamfplatform_device_group" "test" {
+						name        = %q
+						description = "restored"
+						group_type  = "static"
+						device_type = "computer"
+					}
+				`, name),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(rn, "description", "restored"),
 				),
 			},
 		},

--- a/internal/testhelpers/acceptance_client.go
+++ b/internal/testhelpers/acceptance_client.go
@@ -115,7 +115,7 @@ func RequireSmartGroupFixture(t *testing.T) string {
 			Description: strPtr("Terraform provider acceptance test fixture — safe to delete"),
 			DeviceType:  "COMPUTER",
 			GroupType:   "SMART",
-			Criteria: []jamfplatform.DeviceGroupCriteriaRepresentationV1{
+			Criteria: &[]jamfplatform.DeviceGroupCriteriaRepresentationV1{
 				{
 					Order:          0,
 					AttributeName:  "Serial Number",


### PR DESCRIPTION
## Summary
- Bumps `jamfplatform-go-sdk` from v0.3.0 to v0.4.0
- Adapts all request struct construction to match the SDK's pointer semantics changes — fields that gained `*[]` pointers (`Criteria`, `Members`, `Steps`, `Added`, `Removed`) now use `&slice` to distinguish declared-null from omitted; fields that lost pointers (`Target`, `Scope`) drop the `&`
- Adds `TestAccResource_DeviceGroup_DescriptionNullVsEmpty` acceptance test that verifies `""` → `null` → omit → restore round-trip with plan stability checks

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` unit tests all pass
- [x] `TestAccResource_DeviceGroup_DescriptionNullVsEmpty` passes against live tenant (9.6s)
- [ ] Run full acceptance suite (`go test -tags=acceptance ./... -p=1`)