### PR TITLE
refactor: migrate blueprint components to jamfplatform-go-sdk v0.7.0

### DIFF
--- a/docs/list-resources/blueprints_blueprint.md
+++ b/docs/list-resources/blueprints_blueprint.md
@@ -14,11 +14,11 @@ Searches for Jamf Blueprints with an optional case-insensitive substring filter.
 
 ```terraform
 list "jamfplatform_blueprints_blueprint" "software_update" {
-    provider = jamfplatform
+  provider = jamfplatform
 
-    config {
-        search = "software update"
-    }
+  config {
+    search = "software update"
+  }
 }
 ```
 

--- a/docs/list-resources/cbengine_benchmark.md
+++ b/docs/list-resources/cbengine_benchmark.md
@@ -14,11 +14,11 @@ Searches for Jamf Compliance Benchmarks with an optional case-insensitive substr
 
 ```terraform
 list "jamfplatform_cbengine_benchmark" "cis_benchmarks" {
-    provider = jamfplatform
+  provider = jamfplatform
 
-    config {
-        search = "CIS"
-    }
+  config {
+    search = "CIS"
+  }
 }
 ```
 

--- a/examples/list-resources/jamfplatform_blueprints_blueprint/list-resource.tfquery.hcl
+++ b/examples/list-resources/jamfplatform_blueprints_blueprint/list-resource.tfquery.hcl
@@ -1,7 +1,7 @@
 list "jamfplatform_blueprints_blueprint" "software_update" {
-    provider = jamfplatform
+  provider = jamfplatform
 
-    config {
-        search = "software update"
-    }
+  config {
+    search = "software update"
+  }
 }

--- a/examples/list-resources/jamfplatform_cbengine_benchmark/list-resource.tfquery.hcl
+++ b/examples/list-resources/jamfplatform_cbengine_benchmark/list-resource.tfquery.hcl
@@ -1,7 +1,7 @@
 list "jamfplatform_cbengine_benchmark" "cis_benchmarks" {
-    provider = jamfplatform
+  provider = jamfplatform
 
-    config {
-        search = "CIS"
-    }
+  config {
+    search = "CIS"
+  }
 }

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/Jamf-Concepts/terraform-provider-jamfplatform
 go 1.26.2
 
 require (
-	github.com/Jamf-Concepts/jamfplatform-go-sdk v0.6.0
+	github.com/Jamf-Concepts/jamfplatform-go-sdk v0.7.0
 	github.com/hashicorp/terraform-plugin-framework v1.19.0
 	github.com/hashicorp/terraform-plugin-framework-timeouts v0.7.0
 	github.com/hashicorp/terraform-plugin-framework-validators v0.19.0

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 dario.cat/mergo v1.0.0 h1:AGCNq9Evsj31mOgNPcLyXc+4PNABt905YmuqPYYpBWk=
 dario.cat/mergo v1.0.0/go.mod h1:uNxQE+84aUszobStD9th8a29P2fMDhsBdgRYvZOxGmk=
-github.com/Jamf-Concepts/jamfplatform-go-sdk v0.6.0 h1:1xSA/voO5ovOIBDxL5BAu0ngWFUIL1xxE3paa6jAH+s=
-github.com/Jamf-Concepts/jamfplatform-go-sdk v0.6.0/go.mod h1:aNjapJAdC8d/9KsGnMK8ouZU7KBl9sS1RF/yLQkHgO8=
+github.com/Jamf-Concepts/jamfplatform-go-sdk v0.7.0 h1:l2v2GtRLLHy16sU/ilPNX8G9KD2NeqNJ4GBFGBnHeDk=
+github.com/Jamf-Concepts/jamfplatform-go-sdk v0.7.0/go.mod h1:aNjapJAdC8d/9KsGnMK8ouZU7KBl9sS1RF/yLQkHgO8=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
 github.com/ProtonMail/go-crypto v1.4.1 h1:9RfcZHqEQUvP8RzecWEUafnZVtEvrBVL9BiF67IQOfM=

--- a/internal/resources/blueprints/blueprint/components/audio_accessory_settings.go
+++ b/internal/resources/blueprints/blueprint/components/audio_accessory_settings.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 
 	"github.com/Jamf-Concepts/jamfplatform-go-sdk/jamfplatform/blueprints"
-	"github.com/Jamf-Concepts/jamfplatform-go-sdk/jamfplatform/bpcomponents/declarations"
 	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/common/helpers"
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
@@ -60,7 +59,7 @@ func AudioAccessorySettingsComponentSchema() map[string]schema.Attribute {
 
 // ToRawConfiguration converts the typed component to raw JSON configuration.
 func (c *AudioAccessorySettingsComponent) ToRawConfiguration() (json.RawMessage, error) {
-	cfg := declarations.AudioAccessorySettingsConfiguration{}
+	cfg := blueprints.AudioAccessorySettingsConfiguration{}
 
 	hasTemporaryPairing := helpers.IsConfiguredValue(c.TemporaryPairingDisabled) ||
 		helpers.IsConfiguredValue(c.UnpairingTimePolicy) ||
@@ -68,7 +67,7 @@ func (c *AudioAccessorySettingsComponent) ToRawConfiguration() (json.RawMessage,
 
 	if hasTemporaryPairing {
 		trueVal := true
-		tp := &declarations.TemporaryPairing{
+		tp := &blueprints.TemporaryPairing{
 			Included: &trueVal,
 		}
 
@@ -81,7 +80,7 @@ func (c *AudioAccessorySettingsComponent) ToRawConfiguration() (json.RawMessage,
 			helpers.IsConfiguredValue(c.UnpairingTimeHour)
 
 		if hasUnpairingSettings {
-			unpairingTime := declarations.UnpairingTime{}
+			unpairingTime := blueprints.UnpairingTime{}
 
 			if helpers.IsConfiguredValue(c.UnpairingTimePolicy) {
 				unpairingTime.Policy = c.UnpairingTimePolicy.ValueString()
@@ -92,7 +91,7 @@ func (c *AudioAccessorySettingsComponent) ToRawConfiguration() (json.RawMessage,
 				unpairingTime.Hour = &hour
 			}
 
-			tp.Configuration = &declarations.Configuration{
+			tp.Configuration = &blueprints.TemporaryPairingConfig{
 				UnpairingTime: unpairingTime,
 			}
 		}
@@ -109,7 +108,7 @@ func (c *AudioAccessorySettingsComponent) FromRawConfiguration(raw json.RawMessa
 	c.UnpairingTimePolicy = types.StringNull()
 	c.UnpairingTimeHour = types.Int64Null()
 
-	var cfg declarations.AudioAccessorySettingsConfiguration
+	var cfg blueprints.AudioAccessorySettingsConfiguration
 	if err := json.Unmarshal(raw, &cfg); err != nil {
 		return err
 	}

--- a/internal/resources/blueprints/blueprint/components/disk_management_policy.go
+++ b/internal/resources/blueprints/blueprint/components/disk_management_policy.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 
 	"github.com/Jamf-Concepts/jamfplatform-go-sdk/jamfplatform/blueprints"
-	"github.com/Jamf-Concepts/jamfplatform-go-sdk/jamfplatform/bpcomponents/declarations"
 	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/common/helpers"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
@@ -46,19 +45,19 @@ func DiskManagementPolicyComponentSchema() map[string]schema.Attribute {
 func (c *DiskManagementPolicyComponent) ToRawConfiguration() (json.RawMessage, error) {
 	trueVal := true
 	falseVal := false
-	cfg := declarations.DiskManagementSettingsConfigurationV2{Version: 2}
-	restrictions := &declarations.RestrictionsV2{}
+	cfg := blueprints.DiskManagementSettingsConfiguration{Version: 2}
+	restrictions := &blueprints.Restrictions{}
 
 	if helpers.IsConfiguredValue(c.ExternalStorage) {
-		restrictions.ExternalStorage = &declarations.StorageModeV2{Included: &trueVal, Value: c.ExternalStorage.ValueString()}
+		restrictions.ExternalStorage = &blueprints.StorageMode{Included: &trueVal, Value: c.ExternalStorage.ValueString()}
 	} else {
-		restrictions.ExternalStorage = &declarations.StorageModeV2{Included: &falseVal, Value: "Allowed"}
+		restrictions.ExternalStorage = &blueprints.StorageMode{Included: &falseVal, Value: "Allowed"}
 	}
 
 	if helpers.IsConfiguredValue(c.NetworkStorage) {
-		restrictions.NetworkStorage = &declarations.StorageModeV2{Included: &trueVal, Value: c.NetworkStorage.ValueString()}
+		restrictions.NetworkStorage = &blueprints.StorageMode{Included: &trueVal, Value: c.NetworkStorage.ValueString()}
 	} else {
-		restrictions.NetworkStorage = &declarations.StorageModeV2{Included: &falseVal, Value: "Allowed"}
+		restrictions.NetworkStorage = &blueprints.StorageMode{Included: &falseVal, Value: "Allowed"}
 	}
 
 	cfg.Restrictions = restrictions
@@ -67,7 +66,7 @@ func (c *DiskManagementPolicyComponent) ToRawConfiguration() (json.RawMessage, e
 
 // FromRawConfiguration populates the typed component from raw JSON configuration.
 func (c *DiskManagementPolicyComponent) FromRawConfiguration(raw json.RawMessage) error {
-	var cfg declarations.DiskManagementSettingsConfigurationV2
+	var cfg blueprints.DiskManagementSettingsConfiguration
 	if err := json.Unmarshal(raw, &cfg); err != nil {
 		return err
 	}

--- a/internal/resources/blueprints/blueprint/components/math_settings.go
+++ b/internal/resources/blueprints/blueprint/components/math_settings.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 
 	"github.com/Jamf-Concepts/jamfplatform-go-sdk/jamfplatform/blueprints"
-	"github.com/Jamf-Concepts/jamfplatform-go-sdk/jamfplatform/bpcomponents/declarations"
 	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/common/helpers"
 	"github.com/hashicorp/terraform-plugin-framework-validators/boolvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -85,11 +84,11 @@ func MathSettingsComponentSchema() map[string]schema.Attribute {
 
 // ToRawConfiguration converts the typed component to raw JSON configuration.
 func (c *MathSettingsComponent) ToRawConfiguration() (json.RawMessage, error) {
-	cfg := declarations.MathSettingsConfiguration{}
+	cfg := blueprints.MathSettingsConfiguration{}
 
-	calc := &declarations.Calculator{}
+	calc := &blueprints.Calculator{}
 
-	calc.BasicMode = &declarations.BasicMode{
+	calc.BasicMode = &blueprints.BasicMode{
 		Included:      new(helpers.IsConfiguredValue(c.CalculatorBasicModeAddSquareRoot)),
 		AddSquareRoot: c.CalculatorBasicModeAddSquareRoot.ValueBool(),
 	}
@@ -97,7 +96,7 @@ func (c *MathSettingsComponent) ToRawConfiguration() (json.RawMessage, error) {
 		calc.BasicMode.AddSquareRoot = true
 	}
 
-	calc.ScientificMode = &declarations.ScientificMode{
+	calc.ScientificMode = &blueprints.ScientificMode{
 		Included: new(helpers.IsConfiguredValue(c.CalculatorScientificModeEnabled)),
 		Enabled:  c.CalculatorScientificModeEnabled.ValueBool(),
 	}
@@ -105,7 +104,7 @@ func (c *MathSettingsComponent) ToRawConfiguration() (json.RawMessage, error) {
 		calc.ScientificMode.Enabled = true
 	}
 
-	calc.ProgrammerMode = &declarations.ProgrammerMode{
+	calc.ProgrammerMode = &blueprints.ProgrammerMode{
 		Included: new(helpers.IsConfiguredValue(c.CalculatorProgrammerModeEnabled)),
 		Enabled:  c.CalculatorProgrammerModeEnabled.ValueBool(),
 	}
@@ -113,7 +112,7 @@ func (c *MathSettingsComponent) ToRawConfiguration() (json.RawMessage, error) {
 		calc.ProgrammerMode.Enabled = true
 	}
 
-	calc.MathNotesMode = &declarations.MathNotesMode{
+	calc.MathNotesMode = &blueprints.MathNotesMode{
 		Included: new(helpers.IsConfiguredValue(c.CalculatorMathNotesModeEnabled)),
 		Enabled:  c.CalculatorMathNotesModeEnabled.ValueBool(),
 	}
@@ -132,7 +131,7 @@ func (c *MathSettingsComponent) ToRawConfiguration() (json.RawMessage, error) {
 	if helpers.IsConfiguredValue(c.CalculatorInputModesRPN) {
 		rpn = c.CalculatorInputModesRPN.ValueBool()
 	}
-	calc.InputModes = &declarations.InputModes{
+	calc.InputModes = &blueprints.InputModes{
 		Included:       new(hasInputModes),
 		UnitConversion: unitConversion,
 		RPN:            rpn,
@@ -151,7 +150,7 @@ func (c *MathSettingsComponent) ToRawConfiguration() (json.RawMessage, error) {
 	if helpers.IsConfiguredValue(c.SystemBehaviorMathNotes) {
 		mathNotes = c.SystemBehaviorMathNotes.ValueBool()
 	}
-	cfg.SystemBehavior = &declarations.SystemBehavior{
+	cfg.SystemBehavior = &blueprints.SystemBehavior{
 		Included:            new(hasSystemBehavior),
 		KeyboardSuggestions: keyboardSuggestions,
 		MathNotes:           mathNotes,
@@ -162,7 +161,7 @@ func (c *MathSettingsComponent) ToRawConfiguration() (json.RawMessage, error) {
 
 // FromRawConfiguration populates the typed component from raw JSON configuration.
 func (c *MathSettingsComponent) FromRawConfiguration(raw json.RawMessage) error {
-	var cfg declarations.MathSettingsConfiguration
+	var cfg blueprints.MathSettingsConfiguration
 	if err := json.Unmarshal(raw, &cfg); err != nil {
 		return err
 	}

--- a/internal/resources/blueprints/blueprint/components/passcode_policy.go
+++ b/internal/resources/blueprints/blueprint/components/passcode_policy.go
@@ -8,7 +8,6 @@ import (
 	"encoding/json"
 
 	"github.com/Jamf-Concepts/jamfplatform-go-sdk/jamfplatform/blueprints"
-	"github.com/Jamf-Concepts/jamfplatform-go-sdk/jamfplatform/bpcomponents/declarations"
 	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/common/helpers"
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
@@ -111,128 +110,128 @@ func PasscodePolicyComponentSchema() map[string]schema.Attribute {
 }
 
 // boolPtrFromBool converts a configured types.Bool field to a *bool pointer with Included envelope.
-func buildChangeAtNextAuth(field types.Bool) *declarations.ChangeAtNextAuth {
+func buildChangeAtNextAuth(field types.Bool) *blueprints.ChangeAtNextAuth {
 	if !helpers.IsConfiguredValue(field) {
 		return nil
 	}
 	v := field.ValueBool()
 	t := true
-	return &declarations.ChangeAtNextAuth{Included: &t, Value: &v}
+	return &blueprints.ChangeAtNextAuth{Included: &t, Value: &v}
 }
 
 // buildRequireBool builds a bool wrapper struct with Included envelope.
-func buildRequireAlphanumeric(field types.Bool) *declarations.RequireAlphanumericPasscode {
+func buildRequireAlphanumeric(field types.Bool) *blueprints.RequireAlphanumericPasscode {
 	if !helpers.IsConfiguredValue(field) {
 		return nil
 	}
 	v := field.ValueBool()
 	t := true
-	return &declarations.RequireAlphanumericPasscode{Included: &t, Value: &v}
+	return &blueprints.RequireAlphanumericPasscode{Included: &t, Value: &v}
 }
 
 // buildRequireComplex builds a require complex passcode wrapper with Included envelope.
-func buildRequireComplex(field types.Bool) *declarations.RequireComplexPasscode {
+func buildRequireComplex(field types.Bool) *blueprints.RequireComplexPasscode {
 	if !helpers.IsConfiguredValue(field) {
 		return nil
 	}
 	v := field.ValueBool()
 	t := true
-	return &declarations.RequireComplexPasscode{Included: &t, Value: &v}
+	return &blueprints.RequireComplexPasscode{Included: &t, Value: &v}
 }
 
 // buildRequirePasscode builds a require passcode wrapper with Included envelope.
-func buildRequirePasscode(field types.Bool) *declarations.RequirePasscode {
+func buildRequirePasscode(field types.Bool) *blueprints.RequirePasscode {
 	if !helpers.IsConfiguredValue(field) {
 		return nil
 	}
 	v := field.ValueBool()
 	t := true
-	return &declarations.RequirePasscode{Included: &t, Value: &v}
+	return &blueprints.RequirePasscode{Included: &t, Value: &v}
 }
 
 // buildFailedAttemptsReset builds a FailedAttemptsResetInMinutes wrapper.
-func buildFailedAttemptsReset(field types.Int64) *declarations.FailedAttemptsResetInMinutes {
+func buildFailedAttemptsReset(field types.Int64) *blueprints.FailedAttemptsResetInMinutes {
 	if !helpers.IsConfiguredValue(field) {
 		return nil
 	}
 	v := int(field.ValueInt64())
 	t := true
-	return &declarations.FailedAttemptsResetInMinutes{Included: &t, Value: &v}
+	return &blueprints.FailedAttemptsResetInMinutes{Included: &t, Value: &v}
 }
 
 // buildMaximumFailedAttempts builds a MaximumFailedAttempts wrapper.
-func buildMaximumFailedAttempts(field types.Int64) *declarations.MaximumFailedAttempts {
+func buildMaximumFailedAttempts(field types.Int64) *blueprints.MaximumFailedAttempts {
 	if !helpers.IsConfiguredValue(field) {
 		return nil
 	}
 	v := int(field.ValueInt64())
 	t := true
-	return &declarations.MaximumFailedAttempts{Included: &t, Value: &v}
+	return &blueprints.MaximumFailedAttempts{Included: &t, Value: &v}
 }
 
 // buildMaximumGracePeriod builds a MaximumGracePeriodInMinutes wrapper.
-func buildMaximumGracePeriod(field types.Int64) *declarations.MaximumGracePeriodInMinutes {
+func buildMaximumGracePeriod(field types.Int64) *blueprints.MaximumGracePeriodInMinutes {
 	if !helpers.IsConfiguredValue(field) {
 		return nil
 	}
 	v := int(field.ValueInt64())
 	t := true
-	return &declarations.MaximumGracePeriodInMinutes{Included: &t, Value: &v}
+	return &blueprints.MaximumGracePeriodInMinutes{Included: &t, Value: &v}
 }
 
 // buildMaximumInactivity builds a MaximumInactivityInMinutes wrapper.
-func buildMaximumInactivity(field types.Int64) *declarations.MaximumInactivityInMinutes {
+func buildMaximumInactivity(field types.Int64) *blueprints.MaximumInactivityInMinutes {
 	if !helpers.IsConfiguredValue(field) {
 		return nil
 	}
 	v := int(field.ValueInt64())
 	t := true
-	return &declarations.MaximumInactivityInMinutes{Included: &t, Value: &v}
+	return &blueprints.MaximumInactivityInMinutes{Included: &t, Value: &v}
 }
 
 // buildMaximumPasscodeAge builds a MaximumPasscodeAgeInDays wrapper.
-func buildMaximumPasscodeAge(field types.Int64) *declarations.MaximumPasscodeAgeInDays {
+func buildMaximumPasscodeAge(field types.Int64) *blueprints.MaximumPasscodeAgeInDays {
 	if !helpers.IsConfiguredValue(field) {
 		return nil
 	}
 	v := int(field.ValueInt64())
 	t := true
-	return &declarations.MaximumPasscodeAgeInDays{Included: &t, Value: &v}
+	return &blueprints.MaximumPasscodeAgeInDays{Included: &t, Value: &v}
 }
 
 // buildMinimumComplexChars builds a MinimumComplexCharacters wrapper.
-func buildMinimumComplexChars(field types.Int64) *declarations.MinimumComplexCharacters {
+func buildMinimumComplexChars(field types.Int64) *blueprints.MinimumComplexCharacters {
 	if !helpers.IsConfiguredValue(field) {
 		return nil
 	}
 	v := int(field.ValueInt64())
 	t := true
-	return &declarations.MinimumComplexCharacters{Included: &t, Value: &v}
+	return &blueprints.MinimumComplexCharacters{Included: &t, Value: &v}
 }
 
 // buildMinimumLength builds a MinimumLength wrapper.
-func buildMinimumLength(field types.Int64) *declarations.MinimumLength {
+func buildMinimumLength(field types.Int64) *blueprints.MinimumLength {
 	if !helpers.IsConfiguredValue(field) {
 		return nil
 	}
 	v := int(field.ValueInt64())
 	t := true
-	return &declarations.MinimumLength{Included: &t, Value: &v}
+	return &blueprints.MinimumLength{Included: &t, Value: &v}
 }
 
 // buildPasscodeReuseLimit builds a PasscodeReuseLimit wrapper.
-func buildPasscodeReuseLimit(field types.Int64) *declarations.PasscodeReuseLimit {
+func buildPasscodeReuseLimit(field types.Int64) *blueprints.PasscodeReuseLimit {
 	if !helpers.IsConfiguredValue(field) {
 		return nil
 	}
 	v := int(field.ValueInt64())
 	t := true
-	return &declarations.PasscodeReuseLimit{Included: &t, Value: &v}
+	return &blueprints.PasscodeReuseLimit{Included: &t, Value: &v}
 }
 
 // ToRawConfiguration converts the typed component to raw JSON configuration.
 func (c *PasscodePolicyComponent) ToRawConfiguration() (json.RawMessage, error) {
-	cfg := declarations.PasscodeSettingsConfigurationV2{Version: 2}
+	cfg := blueprints.PasscodeSettingsConfiguration{Version: 2}
 
 	cfg.ChangeAtNextAuth = buildChangeAtNextAuth(c.ChangeAtNextAuth)
 	cfg.FailedAttemptsResetInMinutes = buildFailedAttemptsReset(c.FailedAttemptsResetInMinutes)
@@ -252,7 +251,7 @@ func (c *PasscodePolicyComponent) ToRawConfiguration() (json.RawMessage, error) 
 
 	if hasCustomRegex {
 		trueVal := true
-		customRegex := &declarations.CustomRegex{
+		customRegex := &blueprints.CustomRegex{
 			Included: &trueVal,
 		}
 		if helpers.IsConfiguredValue(c.CustomRegexPattern) {
@@ -275,7 +274,6 @@ func (c *PasscodePolicyComponent) ToRawConfiguration() (json.RawMessage, error) 
 }
 
 // FromRawConfiguration populates the typed component from raw JSON configuration.
-// Handles both V2 envelope format ({Value, Included}) and V1 flat format for backwards compatibility.
 func (c *PasscodePolicyComponent) FromRawConfiguration(raw json.RawMessage) error {
 	c.ChangeAtNextAuth = types.BoolNull()
 	c.FailedAttemptsResetInMinutes = types.Int64Null()
@@ -292,20 +290,9 @@ func (c *PasscodePolicyComponent) FromRawConfiguration(raw json.RawMessage) erro
 	c.CustomRegexPattern = types.StringNull()
 	c.CustomRegexDescription = types.MapNull(types.StringType)
 
-	var cfg declarations.PasscodeSettingsConfigurationV2
+	var cfg blueprints.PasscodeSettingsConfiguration
 	if err := json.Unmarshal(raw, &cfg); err != nil {
-		var v1 declarations.PasscodeSettingsConfigurationV1
-		if err2 := json.Unmarshal(raw, &v1); err2 != nil {
-			return err
-		}
-		return c.fromV1Config(v1)
-	}
-
-	if cfg.Version == 0 {
-		var v1 declarations.PasscodeSettingsConfigurationV1
-		if err := json.Unmarshal(raw, &v1); err == nil && v1.RequirePasscode != nil {
-			return c.fromV1Config(v1)
-		}
+		return err
 	}
 
 	if f := cfg.ChangeAtNextAuth; f != nil && f.Included != nil && *f.Included && f.Value != nil {
@@ -365,66 +352,6 @@ func (c *PasscodePolicyComponent) FromRawConfiguration(raw json.RawMessage) erro
 		}
 	}
 
-	return nil
-}
-
-// fromV1Config populates the component from a V1 flat passcode configuration.
-func (c *PasscodePolicyComponent) fromV1Config(v1 declarations.PasscodeSettingsConfigurationV1) error {
-	if v1.ChangeAtNextAuth != nil {
-		c.ChangeAtNextAuth = types.BoolValue(*v1.ChangeAtNextAuth)
-	}
-	if v1.FailedAttemptsResetInMinutes != nil {
-		c.FailedAttemptsResetInMinutes = types.Int64Value(int64(*v1.FailedAttemptsResetInMinutes))
-	}
-	if v1.MaximumFailedAttempts != nil {
-		c.MaximumFailedAttempts = types.Int64Value(int64(*v1.MaximumFailedAttempts))
-	}
-	if v1.MaximumGracePeriodInMinutes != nil {
-		c.MaximumGracePeriodInMinutes = types.Int64Value(int64(*v1.MaximumGracePeriodInMinutes))
-	}
-	if v1.MaximumInactivityInMinutes != nil {
-		c.MaximumInactivityInMinutes = types.Int64Value(int64(*v1.MaximumInactivityInMinutes))
-	}
-	if v1.MaximumPasscodeAgeInDays != nil {
-		c.MaximumPasscodeAgeInDays = types.Int64Value(int64(*v1.MaximumPasscodeAgeInDays))
-	}
-	if v1.MinimumComplexCharacters != nil {
-		c.MinimumComplexCharacters = types.Int64Value(int64(*v1.MinimumComplexCharacters))
-	}
-	if v1.MinimumLength != nil {
-		c.MinimumLength = types.Int64Value(int64(*v1.MinimumLength))
-	}
-	if v1.PasscodeReuseLimit != nil {
-		c.PasscodeReuseLimit = types.Int64Value(int64(*v1.PasscodeReuseLimit))
-	}
-	if v1.RequireAlphanumericPasscode != nil {
-		c.RequireAlphanumericPasscode = types.BoolValue(*v1.RequireAlphanumericPasscode)
-	}
-	if v1.RequireComplexPasscode != nil {
-		c.RequireComplexPasscode = types.BoolValue(*v1.RequireComplexPasscode)
-	}
-	if v1.RequirePasscode != nil {
-		c.RequirePasscode = types.BoolValue(*v1.RequirePasscode)
-	}
-	if cr := v1.CustomRegex; cr != nil {
-		if cr.Included == nil || *cr.Included {
-			if cr.Regex != nil {
-				c.CustomRegexPattern = types.StringValue(*cr.Regex)
-			}
-			if cr.Description != nil {
-				elems := make(map[string]types.String, len(*cr.Description))
-				for k, v := range *cr.Description {
-					elems[k] = types.StringValue(v)
-				}
-				if len(elems) > 0 {
-					tfMap, diags := types.MapValueFrom(context.Background(), types.StringType, elems)
-					if !diags.HasError() {
-						c.CustomRegexDescription = tfMap
-					}
-				}
-			}
-		}
-	}
 	return nil
 }
 

--- a/internal/resources/blueprints/blueprint/components/passcode_policy_test.go
+++ b/internal/resources/blueprints/blueprint/components/passcode_policy_test.go
@@ -266,32 +266,6 @@ func TestPasscodePolicy_FromRawConfiguration_V2Format(t *testing.T) {
 	}
 }
 
-func TestPasscodePolicy_FromRawConfiguration_V1FlatFormat(t *testing.T) {
-	inputMap := map[string]any{
-		"ChangeAtNextAuth":             true,
-		"FailedAttemptsResetInMinutes": float64(15),
-		"MaximumFailedAttempts":        float64(10),
-		"MinimumLength":                float64(8),
-		"RequirePasscode":              true,
-	}
-	raw, _ := json.Marshal(inputMap)
-
-	c := &PasscodePolicyComponent{}
-	if err := c.FromRawConfiguration(raw); err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-
-	if c.ChangeAtNextAuth.ValueBool() != true {
-		t.Errorf("expected ChangeAtNextAuth true, got %v", c.ChangeAtNextAuth.ValueBool())
-	}
-	if c.FailedAttemptsResetInMinutes.ValueInt64() != 15 {
-		t.Errorf("expected FailedAttemptsResetInMinutes 15, got %d", c.FailedAttemptsResetInMinutes.ValueInt64())
-	}
-	if c.MinimumLength.ValueInt64() != 8 {
-		t.Errorf("expected MinimumLength 8, got %d", c.MinimumLength.ValueInt64())
-	}
-}
-
 func TestPasscodePolicy_FromRawConfiguration_V2NotIncluded(t *testing.T) {
 	inputMap := map[string]any{
 		"version": float64(2),

--- a/internal/resources/blueprints/blueprint/components/safari_bookmarks.go
+++ b/internal/resources/blueprints/blueprint/components/safari_bookmarks.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 
 	"github.com/Jamf-Concepts/jamfplatform-go-sdk/jamfplatform/blueprints"
-	"github.com/Jamf-Concepts/jamfplatform-go-sdk/jamfplatform/bpcomponents/declarations"
 	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/common/helpers"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
@@ -108,12 +107,12 @@ func SafariBookmarksComponentSchema() map[string]schema.Attribute {
 // ToRawConfiguration converts the typed component to raw JSON configuration.
 func (c *SafariBookmarksComponent) ToRawConfiguration() (json.RawMessage, error) {
 	if len(c.ManagedBookmarks) == 0 {
-		return json.Marshal(declarations.SafariBookmarksConfiguration{ManagedBookmarks: []declarations.BookmarkGroup{}})
+		return json.Marshal(blueprints.SafariBookmarksConfiguration{ManagedBookmarks: []blueprints.BookmarkGroup{}})
 	}
 
-	groups := make([]declarations.BookmarkGroup, 0, len(c.ManagedBookmarks))
+	groups := make([]blueprints.BookmarkGroup, 0, len(c.ManagedBookmarks))
 	for _, group := range c.ManagedBookmarks {
-		g := declarations.BookmarkGroup{}
+		g := blueprints.BookmarkGroup{}
 
 		if helpers.IsConfiguredValue(group.GroupIdentifier) {
 			g.GroupIdentifier = group.GroupIdentifier.ValueString()
@@ -122,54 +121,45 @@ func (c *SafariBookmarksComponent) ToRawConfiguration() (json.RawMessage, error)
 			g.Title = group.Title.ValueString()
 		}
 
-		bookmarks := make([]any, 0, len(group.Bookmarks))
+		bookmarks := make([]blueprints.BookmarkItem, 0, len(group.Bookmarks))
 		for _, bookmark := range group.Bookmarks {
-			bm := make(map[string]any)
-
-			if helpers.IsConfiguredValue(bookmark.Type) {
-				typeValue := bookmark.Type.ValueString()
-				switch typeValue {
-				case "bookmark", "url":
-					bm["Type"] = "BOOKMARK"
-				case "folder":
-					bm["Type"] = "FOLDER"
-				default:
-					bm["Type"] = typeValue
+			typeValue := bookmark.Type.ValueString()
+			switch typeValue {
+			case "bookmark", "url", "":
+				item := blueprints.URLBookmarkItem{
+					Type:  "BOOKMARK",
+					Title: bookmark.Title.ValueString(),
+					URL:   bookmark.URL.ValueString(),
 				}
-			}
-			if helpers.IsConfiguredValue(bookmark.Title) {
-				bm["Title"] = bookmark.Title.ValueString()
-			}
-			if helpers.IsConfiguredValue(bookmark.URL) {
-				bm["URL"] = bookmark.URL.ValueString()
-			}
-			if len(bookmark.Folder) > 0 {
-				folder := make([]any, 0, len(bookmark.Folder))
-				for _, urlBookmark := range bookmark.Folder {
-					ub := map[string]any{"Type": "BOOKMARK"}
-					if helpers.IsConfiguredValue(urlBookmark.Title) {
-						ub["Title"] = urlBookmark.Title.ValueString()
-					}
-					if helpers.IsConfiguredValue(urlBookmark.URL) {
-						ub["URL"] = urlBookmark.URL.ValueString()
-					}
-					folder = append(folder, ub)
+				bookmarks = append(bookmarks, blueprints.BookmarkItem{Type: "BOOKMARK", BOOKMARK: &item})
+			case "folder":
+				folder := make([]blueprints.URLBookmarkItem, 0, len(bookmark.Folder))
+				for _, ub := range bookmark.Folder {
+					folder = append(folder, blueprints.URLBookmarkItem{
+						Type:  "BOOKMARK",
+						Title: ub.Title.ValueString(),
+						URL:   ub.URL.ValueString(),
+					})
 				}
-				bm["Folder"] = folder
+				item := blueprints.FolderBookmarkItem{
+					Type:   "FOLDER",
+					Title:  bookmark.Title.ValueString(),
+					Folder: &folder,
+				}
+				bookmarks = append(bookmarks, blueprints.BookmarkItem{Type: "FOLDER", FOLDER: &item})
 			}
-			bookmarks = append(bookmarks, bm)
 		}
 		g.Bookmarks = bookmarks
 		groups = append(groups, g)
 	}
 
-	cfg := declarations.SafariBookmarksConfiguration{ManagedBookmarks: groups}
+	cfg := blueprints.SafariBookmarksConfiguration{ManagedBookmarks: groups}
 	return json.Marshal(cfg)
 }
 
 // FromRawConfiguration populates the typed component from raw JSON configuration.
 func (c *SafariBookmarksComponent) FromRawConfiguration(raw json.RawMessage) error {
-	var cfg declarations.SafariBookmarksConfiguration
+	var cfg blueprints.SafariBookmarksConfiguration
 	if err := json.Unmarshal(raw, &cfg); err != nil {
 		return err
 	}
@@ -184,39 +174,30 @@ func (c *SafariBookmarksComponent) FromRawConfiguration(raw json.RawMessage) err
 		bookmarks := make([]BookmarkModel, 0, len(g.Bookmarks))
 		for _, bRaw := range g.Bookmarks {
 			bm := BookmarkModel{}
-			if bmMap, ok := bRaw.(map[string]any); ok {
-				if t, ok := bmMap["Type"].(string); ok {
-					switch t {
-					case "BOOKMARK":
-						bm.Type = types.StringValue("bookmark")
-					case "FOLDER":
-						bm.Type = types.StringValue("folder")
-					default:
-						bm.Type = types.StringValue(t)
-					}
+			switch bRaw.Type {
+			case "BOOKMARK":
+				bm.Type = types.StringValue("bookmark")
+				if bRaw.BOOKMARK != nil {
+					bm.Title = types.StringValue(bRaw.BOOKMARK.Title)
+					bm.URL = types.StringValue(bRaw.BOOKMARK.URL)
 				}
-				if title, ok := bmMap["Title"].(string); ok {
-					bm.Title = types.StringValue(title)
-				}
-				if url, ok := bmMap["URL"].(string); ok {
-					bm.URL = types.StringValue(url)
-				}
-				if folderRaw, ok := bmMap["Folder"].([]any); ok {
-					folder := make([]UrlBookmarkModel, 0, len(folderRaw))
-					for _, ubRaw := range folderRaw {
-						if ubMap, ok := ubRaw.(map[string]any); ok {
-							ub := UrlBookmarkModel{}
-							if title, ok := ubMap["Title"].(string); ok {
-								ub.Title = types.StringValue(title)
-							}
-							if url, ok := ubMap["URL"].(string); ok {
-								ub.URL = types.StringValue(url)
-							}
-							folder = append(folder, ub)
+			case "FOLDER":
+				bm.Type = types.StringValue("folder")
+				if bRaw.FOLDER != nil {
+					bm.Title = types.StringValue(bRaw.FOLDER.Title)
+					if bRaw.FOLDER.Folder != nil {
+						folder := make([]UrlBookmarkModel, 0, len(*bRaw.FOLDER.Folder))
+						for _, ub := range *bRaw.FOLDER.Folder {
+							folder = append(folder, UrlBookmarkModel{
+								Title: types.StringValue(ub.Title),
+								URL:   types.StringValue(ub.URL),
+							})
 						}
+						bm.Folder = folder
 					}
-					bm.Folder = folder
 				}
+			default:
+				bm.Type = types.StringValue(bRaw.Type)
 			}
 			bookmarks = append(bookmarks, bm)
 		}

--- a/internal/resources/blueprints/blueprint/components/safari_extensions.go
+++ b/internal/resources/blueprints/blueprint/components/safari_extensions.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 
 	"github.com/Jamf-Concepts/jamfplatform-go-sdk/jamfplatform/blueprints"
-	"github.com/Jamf-Concepts/jamfplatform-go-sdk/jamfplatform/bpcomponents/declarations"
 	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/common/helpers"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
@@ -93,14 +92,14 @@ func SafariExtensionsComponentSchema() map[string]schema.Attribute {
 
 // ToRawConfiguration converts the typed component to raw JSON configuration.
 func (c *SafariExtensionsComponent) ToRawConfiguration() (json.RawMessage, error) {
-	managedExtensions := make(map[string]declarations.ManagedExtension)
+	managedExtensions := make(map[string]blueprints.ManagedExtension)
 
 	for _, ext := range c.ManagedExtensions {
 		if !helpers.IsConfiguredValue(ext.ExtensionID) {
 			continue
 		}
 
-		extConfig := declarations.ManagedExtension{}
+		extConfig := blueprints.ManagedExtension{}
 
 		if helpers.IsConfiguredValue(ext.State) {
 			s := ext.State.ValueString()
@@ -112,10 +111,10 @@ func (c *SafariExtensionsComponent) ToRawConfiguration() (json.RawMessage, error
 		}
 
 		if len(ext.AllowedDomains) > 0 {
-			allowed := make([]declarations.ManagedExtensionDomain, 0, len(ext.AllowedDomains))
+			allowed := make([]blueprints.ManagedExtensionDomain, 0, len(ext.AllowedDomains))
 			for _, d := range ext.AllowedDomains {
 				if helpers.IsConfiguredValue(d.Domain) {
-					allowed = append(allowed, declarations.ManagedExtensionDomain{Domain: d.Domain.ValueString()})
+					allowed = append(allowed, blueprints.ManagedExtensionDomain{Domain: d.Domain.ValueString()})
 				}
 			}
 			if len(allowed) > 0 {
@@ -124,10 +123,10 @@ func (c *SafariExtensionsComponent) ToRawConfiguration() (json.RawMessage, error
 		}
 
 		if len(ext.DeniedDomains) > 0 {
-			denied := make([]declarations.ManagedExtensionDomain, 0, len(ext.DeniedDomains))
+			denied := make([]blueprints.ManagedExtensionDomain, 0, len(ext.DeniedDomains))
 			for _, d := range ext.DeniedDomains {
 				if helpers.IsConfiguredValue(d.Domain) {
-					denied = append(denied, declarations.ManagedExtensionDomain{Domain: d.Domain.ValueString()})
+					denied = append(denied, blueprints.ManagedExtensionDomain{Domain: d.Domain.ValueString()})
 				}
 			}
 			if len(denied) > 0 {
@@ -138,13 +137,13 @@ func (c *SafariExtensionsComponent) ToRawConfiguration() (json.RawMessage, error
 		managedExtensions[ext.ExtensionID.ValueString()] = extConfig
 	}
 
-	cfg := declarations.SafariExtensionsConfiguration{ManagedExtensions: managedExtensions}
+	cfg := blueprints.SafariExtensionsConfiguration{ManagedExtensions: managedExtensions}
 	return json.Marshal(cfg)
 }
 
 // FromRawConfiguration populates the typed component from raw JSON configuration.
 func (c *SafariExtensionsComponent) FromRawConfiguration(raw json.RawMessage) error {
-	var cfg declarations.SafariExtensionsConfiguration
+	var cfg blueprints.SafariExtensionsConfiguration
 	if err := json.Unmarshal(raw, &cfg); err != nil {
 		return err
 	}

--- a/internal/resources/blueprints/blueprint/components/safari_settings.go
+++ b/internal/resources/blueprints/blueprint/components/safari_settings.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 
 	"github.com/Jamf-Concepts/jamfplatform-go-sdk/jamfplatform/blueprints"
-	"github.com/Jamf-Concepts/jamfplatform-go-sdk/jamfplatform/bpcomponents/declarations"
 	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/common/helpers"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
@@ -84,48 +83,48 @@ func SafariSettingsComponentSchema() map[string]schema.Attribute {
 
 // ToRawConfiguration converts the typed component to raw JSON configuration.
 func (c *SafariSettingsComponent) ToRawConfiguration() (json.RawMessage, error) {
-	cfg := declarations.SafariSettingsConfiguration{}
+	cfg := blueprints.SafariSettingsConfiguration{}
 
 	if helpers.IsConfiguredValue(c.AcceptCookies) {
 		v := c.AcceptCookies.ValueString()
 		t := true
-		cfg.AcceptCookies = &declarations.AcceptCookies{Included: &t, Value: &v}
+		cfg.AcceptCookies = &blueprints.AcceptCookies{Included: &t, Value: &v}
 	}
 
 	if helpers.IsConfiguredValue(c.AllowDisablingFraudWarning) {
 		v := c.AllowDisablingFraudWarning.ValueBool()
 		t := true
-		cfg.AllowDisablingFraudWarning = &declarations.AllowDisablingFraudWarning{Included: &t, Value: &v}
+		cfg.AllowDisablingFraudWarning = &blueprints.AllowDisablingFraudWarning{Included: &t, Value: &v}
 	}
 
 	if helpers.IsConfiguredValue(c.AllowHistoryClearing) {
 		v := c.AllowHistoryClearing.ValueBool()
 		t := true
-		cfg.AllowHistoryClearing = &declarations.AllowHistoryClearing{Included: &t, Value: &v}
+		cfg.AllowHistoryClearing = &blueprints.AllowHistoryClearing{Included: &t, Value: &v}
 	}
 
 	if helpers.IsConfiguredValue(c.AllowJavaScript) {
 		v := c.AllowJavaScript.ValueBool()
 		t := true
-		cfg.AllowJavaScript = &declarations.AllowJavaScript{Included: &t, Value: &v}
+		cfg.AllowJavaScript = &blueprints.AllowJavaScript{Included: &t, Value: &v}
 	}
 
 	if helpers.IsConfiguredValue(c.AllowPrivateBrowsing) {
 		v := c.AllowPrivateBrowsing.ValueBool()
 		t := true
-		cfg.AllowPrivateBrowsing = &declarations.AllowPrivateBrowsing{Included: &t, Value: &v}
+		cfg.AllowPrivateBrowsing = &blueprints.AllowPrivateBrowsing{Included: &t, Value: &v}
 	}
 
 	if helpers.IsConfiguredValue(c.AllowPopups) {
 		v := c.AllowPopups.ValueBool()
 		t := true
-		cfg.AllowPopups = &declarations.AllowPopups{Included: &t, Value: &v}
+		cfg.AllowPopups = &blueprints.AllowPopups{Included: &t, Value: &v}
 	}
 
 	if helpers.IsConfiguredValue(c.AllowSummary) {
 		v := c.AllowSummary.ValueBool()
 		t := true
-		cfg.AllowSummary = &declarations.AllowSummary{Included: &t, Value: &v}
+		cfg.AllowSummary = &blueprints.AllowSummary{Included: &t, Value: &v}
 	}
 
 	if helpers.IsConfiguredValue(c.NewTabStartPageType) ||
@@ -133,11 +132,11 @@ func (c *SafariSettingsComponent) ToRawConfiguration() (json.RawMessage, error) 
 		helpers.IsConfiguredValue(c.NewTabStartPageExtensionID) {
 
 		trueVal := true
-		ntsp := &declarations.NewTabStartPage{
+		ntsp := &blueprints.NewTabStartPage{
 			Included: &trueVal,
 		}
 		if helpers.IsConfiguredValue(c.NewTabStartPageType) {
-			ntsp.PageType = c.NewTabStartPageType.ValueString()
+			ntsp.PageType = c.NewTabStartPageType.ValueStringPointer()
 		}
 		if helpers.IsConfiguredValue(c.NewTabStartPageHomepageURL) {
 			u := c.NewTabStartPageHomepageURL.ValueString()
@@ -155,7 +154,7 @@ func (c *SafariSettingsComponent) ToRawConfiguration() (json.RawMessage, error) 
 
 // FromRawConfiguration populates the typed component from raw JSON configuration.
 func (c *SafariSettingsComponent) FromRawConfiguration(raw json.RawMessage) error {
-	var cfg declarations.SafariSettingsConfiguration
+	var cfg blueprints.SafariSettingsConfiguration
 	if err := json.Unmarshal(raw, &cfg); err != nil {
 		return err
 	}
@@ -194,7 +193,7 @@ func (c *SafariSettingsComponent) FromRawConfiguration(raw json.RawMessage) erro
 	}
 
 	if ntsp := cfg.NewTabStartPage; ntsp != nil {
-		c.NewTabStartPageType = types.StringValue(ntsp.PageType)
+		c.NewTabStartPageType = types.StringPointerValue(ntsp.PageType)
 		if ntsp.HomepageURL != nil {
 			c.NewTabStartPageHomepageURL = types.StringValue(*ntsp.HomepageURL)
 		}

--- a/internal/resources/blueprints/blueprint/components/service_background_tasks.go
+++ b/internal/resources/blueprints/blueprint/components/service_background_tasks.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 
 	"github.com/Jamf-Concepts/jamfplatform-go-sdk/jamfplatform/blueprints"
-	"github.com/Jamf-Concepts/jamfplatform-go-sdk/jamfplatform/bpcomponents/declarations"
 	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/common/helpers"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
@@ -112,114 +111,120 @@ func ServiceBackgroundTasksComponentSchema() map[string]schema.Attribute {
 	}
 }
 
-// buildDataAssetReference converts a DataAssetRefModel to a declarations.DataAssetReference.
-func buildDataAssetReference(ref *DataAssetRefModel, defaultContentType string) declarations.DataAssetReference {
-	r := declarations.AssetDataReference{
-		DataURL:     ref.DataURL.ValueString(),
-		ContentType: &defaultContentType,
+// buildDataAssetReference converts a DataAssetRefModel to a map for API serialization.
+func buildDataAssetReference(ref *DataAssetRefModel, defaultContentType string) map[string]any {
+	inner := map[string]any{
+		"DataURL": ref.DataURL.ValueString(),
+	}
+	ct := defaultContentType
+	if helpers.IsConfiguredValue(ref.ContentType) {
+		ct = ref.ContentType.ValueString()
+	}
+	if ct != "" {
+		inner["ContentType"] = ct
 	}
 	if helpers.IsConfiguredValue(ref.HashSHA256) {
-		h := ref.HashSHA256.ValueString()
-		r.HashSHA256 = &h
+		inner["Hash-SHA-256"] = ref.HashSHA256.ValueString()
 	}
-	if helpers.IsConfiguredValue(ref.ContentType) {
-		ct := ref.ContentType.ValueString()
-		r.ContentType = &ct
+	return map[string]any{"Reference": inner}
+}
+
+// dataAssetRefFromMap converts a raw map to a DataAssetRefModel.
+func dataAssetRefFromMap(refMap map[string]any, defaultContentType string) *DataAssetRefModel {
+	innerMap, ok := refMap["Reference"].(map[string]any)
+	if !ok {
+		return nil
 	}
-	return declarations.DataAssetReference{Reference: r}
+	m := &DataAssetRefModel{}
+	if v, ok := innerMap["DataURL"].(string); ok {
+		m.DataURL = types.StringValue(v)
+	}
+	if v, ok := innerMap["Hash-SHA-256"].(string); ok {
+		m.HashSHA256 = types.StringValue(v)
+	}
+	ct := defaultContentType
+	if v, ok := innerMap["ContentType"].(string); ok {
+		ct = v
+	}
+	m.ContentType = types.StringValue(ct)
+	return m
 }
 
 // ToRawConfiguration converts the typed component to raw JSON configuration.
 func (c *ServiceBackgroundTasksComponent) ToRawConfiguration() (json.RawMessage, error) {
-	tasks := make([]declarations.ServiceBackgroundTasksConfiguration, 0, len(c.BackgroundTasks))
+	tasks := make([]map[string]any, 0, len(c.BackgroundTasks))
 
 	for _, task := range c.BackgroundTasks {
-		t := declarations.ServiceBackgroundTasksConfiguration{}
-
-		if helpers.IsConfiguredValue(task.TaskType) {
-			t.TaskType = task.TaskType.ValueString()
+		t := map[string]any{
+			"TaskType": task.TaskType.ValueString(),
 		}
 		if helpers.IsConfiguredValue(task.TaskDescription) {
-			desc := task.TaskDescription.ValueString()
-			t.TaskDescription = &desc
+			t["TaskDescription"] = task.TaskDescription.ValueString()
 		}
-
 		if task.ExecutableAssetReference != nil {
-			ref := buildDataAssetReference(task.ExecutableAssetReference, "application/zip")
-			t.ExecutableAssetReference = &ref
+			t["ExecutableAssetReference"] = buildDataAssetReference(task.ExecutableAssetReference, "application/zip")
 		}
-
 		if len(task.LaunchdConfigurations) > 0 {
-			launchdItems := make([]declarations.LaunchdItem, 0, len(task.LaunchdConfigurations))
+			launchdItems := make([]map[string]any, 0, len(task.LaunchdConfigurations))
 			for _, lc := range task.LaunchdConfigurations {
-				item := declarations.LaunchdItem{}
-				if helpers.IsConfiguredValue(lc.Context) {
-					item.Context = lc.Context.ValueString()
+				item := map[string]any{
+					"Context": lc.Context.ValueString(),
 				}
 				if lc.FileAssetReference != nil {
-					item.FileAssetReference = buildDataAssetReference(lc.FileAssetReference, "")
+					item["FileAssetReference"] = buildDataAssetReference(lc.FileAssetReference, "")
 				}
 				launchdItems = append(launchdItems, item)
 			}
-			t.LaunchdConfigurations = &launchdItems
+			t["LaunchdConfigurations"] = launchdItems
 		}
-
 		tasks = append(tasks, t)
 	}
 
-	cfg := declarations.ServicesBackgroundTasksConfiguration{BackgroundTasks: tasks}
-	return json.Marshal(cfg)
-}
-
-// dataAssetRefFromSDK converts a declarations.DataAssetReference to a DataAssetRefModel.
-func dataAssetRefFromSDK(ref declarations.DataAssetReference, defaultContentType string) *DataAssetRefModel {
-	m := &DataAssetRefModel{
-		DataURL: types.StringValue(ref.Reference.DataURL),
-	}
-	if ref.Reference.HashSHA256 != nil {
-		m.HashSHA256 = types.StringValue(*ref.Reference.HashSHA256)
-	}
-	if ref.Reference.ContentType != nil {
-		m.ContentType = types.StringValue(*ref.Reference.ContentType)
-	} else {
-		m.ContentType = types.StringValue(defaultContentType)
-	}
-	return m
+	return json.Marshal(map[string]any{"backgroundTasks": tasks})
 }
 
 // FromRawConfiguration populates the typed component from raw JSON configuration.
 func (c *ServiceBackgroundTasksComponent) FromRawConfiguration(raw json.RawMessage) error {
-	var cfg declarations.ServicesBackgroundTasksConfiguration
+	var cfg map[string]any
 	if err := json.Unmarshal(raw, &cfg); err != nil {
 		return err
 	}
 
-	tasks := make([]ServiceBackgroundTaskModel, 0, len(cfg.BackgroundTasks))
-	for _, t := range cfg.BackgroundTasks {
-		task := ServiceBackgroundTaskModel{
-			TaskType: types.StringValue(t.TaskType),
+	tasksRaw, _ := cfg["backgroundTasks"].([]any)
+	tasks := make([]ServiceBackgroundTaskModel, 0, len(tasksRaw))
+	for _, taskRaw := range tasksRaw {
+		taskMap, ok := taskRaw.(map[string]any)
+		if !ok {
+			continue
 		}
-
-		if t.TaskDescription != nil {
-			task.TaskDescription = types.StringValue(*t.TaskDescription)
+		task := ServiceBackgroundTaskModel{}
+		if v, ok := taskMap["TaskType"].(string); ok {
+			task.TaskType = types.StringValue(v)
 		}
-
-		if t.ExecutableAssetReference != nil {
-			task.ExecutableAssetReference = dataAssetRefFromSDK(*t.ExecutableAssetReference, "application/zip")
+		if v, ok := taskMap["TaskDescription"].(string); ok {
+			task.TaskDescription = types.StringValue(v)
 		}
-
-		if t.LaunchdConfigurations != nil {
-			launchdConfigs := make([]LaunchdItemModel, 0, len(*t.LaunchdConfigurations))
-			for _, lc := range *t.LaunchdConfigurations {
-				item := LaunchdItemModel{
-					Context:            types.StringValue(lc.Context),
-					FileAssetReference: dataAssetRefFromSDK(lc.FileAssetReference, ""),
+		if refMap, ok := taskMap["ExecutableAssetReference"].(map[string]any); ok {
+			task.ExecutableAssetReference = dataAssetRefFromMap(refMap, "application/zip")
+		}
+		if launchdRaw, ok := taskMap["LaunchdConfigurations"].([]any); ok {
+			launchdConfigs := make([]LaunchdItemModel, 0, len(launchdRaw))
+			for _, lcRaw := range launchdRaw {
+				lcMap, ok := lcRaw.(map[string]any)
+				if !ok {
+					continue
+				}
+				item := LaunchdItemModel{}
+				if v, ok := lcMap["Context"].(string); ok {
+					item.Context = types.StringValue(v)
+				}
+				if fileRefMap, ok := lcMap["FileAssetReference"].(map[string]any); ok {
+					item.FileAssetReference = dataAssetRefFromMap(fileRefMap, "")
 				}
 				launchdConfigs = append(launchdConfigs, item)
 			}
 			task.LaunchdConfigurations = launchdConfigs
 		}
-
 		tasks = append(tasks, task)
 	}
 

--- a/internal/resources/blueprints/blueprint/components/service_configuration_files.go
+++ b/internal/resources/blueprints/blueprint/components/service_configuration_files.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 
 	"github.com/Jamf-Concepts/jamfplatform-go-sdk/jamfplatform/blueprints"
-	"github.com/Jamf-Concepts/jamfplatform-go-sdk/jamfplatform/bpcomponents/declarations"
 	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/common/helpers"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -67,68 +66,71 @@ func ServiceConfigurationFilesComponentSchema() map[string]schema.Attribute {
 	}
 }
 
-// buildServiceConfigDataAssetRef converts a ServiceConfigDataAssetRefModel to a declarations.DataAssetReference.
-func buildServiceConfigDataAssetRef(ref *ServiceConfigDataAssetRefModel) declarations.DataAssetReference {
-	ct := "application/zip"
-	r := declarations.AssetDataReference{
-		DataURL:     ref.DataURL.ValueString(),
-		ContentType: &ct,
+// buildServiceConfigDataAssetRef converts a ServiceConfigDataAssetRefModel to a map for API serialization.
+func buildServiceConfigDataAssetRef(ref *ServiceConfigDataAssetRefModel) map[string]any {
+	inner := map[string]any{
+		"DataURL":     ref.DataURL.ValueString(),
+		"ContentType": "application/zip",
 	}
 	if helpers.IsConfiguredValue(ref.HashSHA256) {
-		h := ref.HashSHA256.ValueString()
-		r.HashSHA256 = &h
+		inner["Hash-SHA-256"] = ref.HashSHA256.ValueString()
 	}
-	return declarations.DataAssetReference{Reference: r}
+	return map[string]any{"Reference": inner}
 }
 
 // ToRawConfiguration converts the typed component to raw JSON configuration.
 func (c *ServiceConfigurationFilesComponent) ToRawConfiguration() (json.RawMessage, error) {
-	files := make([]declarations.ServiceConfigurationFilesConfiguration, 0, len(c.ServiceConfigFiles))
+	files := make([]map[string]any, 0, len(c.ServiceConfigFiles))
 
 	for _, cf := range c.ServiceConfigFiles {
-		f := declarations.ServiceConfigurationFilesConfiguration{}
-
-		if helpers.IsConfiguredValue(cf.ServiceType) {
-			f.ServiceType = cf.ServiceType.ValueString()
+		f := map[string]any{
+			"ServiceType": cf.ServiceType.ValueString(),
 		}
 		if cf.DataAssetReference != nil {
-			f.DataAssetReference = buildServiceConfigDataAssetRef(cf.DataAssetReference)
+			f["DataAssetReference"] = buildServiceConfigDataAssetRef(cf.DataAssetReference)
 		}
-
 		files = append(files, f)
 	}
 
-	cfg := declarations.ServicesConfigurationFilesConfiguration{ServiceConfigFiles: files}
-	return json.Marshal(cfg)
+	return json.Marshal(map[string]any{"serviceConfigFiles": files})
 }
 
 // FromRawConfiguration populates the typed component from raw JSON configuration.
 func (c *ServiceConfigurationFilesComponent) FromRawConfiguration(raw json.RawMessage) error {
-	var cfg declarations.ServicesConfigurationFilesConfiguration
+	var cfg map[string]any
 	if err := json.Unmarshal(raw, &cfg); err != nil {
 		return err
 	}
 
-	files := make([]ServiceConfigFileModel, 0, len(cfg.ServiceConfigFiles))
-	for _, f := range cfg.ServiceConfigFiles {
-		cf := ServiceConfigFileModel{
-			ServiceType: types.StringValue(f.ServiceType),
+	filesRaw, _ := cfg["serviceConfigFiles"].([]any)
+	files := make([]ServiceConfigFileModel, 0, len(filesRaw))
+	for _, fRaw := range filesRaw {
+		fMap, ok := fRaw.(map[string]any)
+		if !ok {
+			continue
 		}
-
-		ref := f.DataAssetReference
-		dataRef := &ServiceConfigDataAssetRefModel{
-			DataURL: types.StringValue(ref.Reference.DataURL),
+		cf := ServiceConfigFileModel{}
+		if v, ok := fMap["ServiceType"].(string); ok {
+			cf.ServiceType = types.StringValue(v)
 		}
-		if ref.Reference.HashSHA256 != nil {
-			dataRef.HashSHA256 = types.StringValue(*ref.Reference.HashSHA256)
+		if refMap, ok := fMap["DataAssetReference"].(map[string]any); ok {
+			innerMap, ok := refMap["Reference"].(map[string]any)
+			if ok {
+				dataRef := &ServiceConfigDataAssetRefModel{}
+				if v, ok := innerMap["DataURL"].(string); ok {
+					dataRef.DataURL = types.StringValue(v)
+				}
+				if v, ok := innerMap["Hash-SHA-256"].(string); ok {
+					dataRef.HashSHA256 = types.StringValue(v)
+				}
+				ct := "application/zip"
+				if v, ok := innerMap["ContentType"].(string); ok {
+					ct = v
+				}
+				dataRef.ContentType = types.StringValue(ct)
+				cf.DataAssetReference = dataRef
+			}
 		}
-		if ref.Reference.ContentType != nil {
-			dataRef.ContentType = types.StringValue(*ref.Reference.ContentType)
-		} else {
-			dataRef.ContentType = types.StringValue("application/zip")
-		}
-		cf.DataAssetReference = dataRef
-
 		files = append(files, cf)
 	}
 

--- a/internal/resources/blueprints/blueprint/components/software_update_settings.go
+++ b/internal/resources/blueprints/blueprint/components/software_update_settings.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 
 	"github.com/Jamf-Concepts/jamfplatform-go-sdk/jamfplatform/blueprints"
-	"github.com/Jamf-Concepts/jamfplatform-go-sdk/jamfplatform/bpcomponents/declarations"
 	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/common/helpers"
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
@@ -134,46 +133,45 @@ func SoftwareUpdateSettingsComponentSchema() map[string]schema.Attribute {
 }
 
 // buildOptionallyEnabled builds an OptionallyEnabled wrapper for a bool field.
-func buildOptionallyEnabled(field types.Bool, defaultValue bool) *declarations.OptionallyEnabled {
+func buildOptionallyEnabled(field types.Bool, defaultValue bool) *blueprints.OptionallyEnabled {
 	enabled := defaultValue
 	if helpers.IsConfiguredValue(field) {
 		enabled = field.ValueBool()
 	}
-	return &declarations.OptionallyEnabled{
+	return &blueprints.OptionallyEnabled{
 		Enabled:  enabled,
 		Included: new(helpers.IsConfiguredValue(field)),
 	}
 }
 
 // buildAutomaticAction builds an AutomaticAction wrapper for a string field.
-func buildAutomaticAction(field types.String, defaultValue string) *declarations.AutomaticAction {
+func buildAutomaticAction(field types.String, defaultValue string) *blueprints.AutomaticAction {
 	value := defaultValue
 	if helpers.IsConfiguredValue(field) {
 		value = field.ValueString()
 	}
-	return &declarations.AutomaticAction{
+	return &blueprints.AutomaticAction{
 		Included: new(helpers.IsConfiguredValue(field)),
 		Value:    value,
 	}
 }
 
 // buildOptionalPeriodInDays builds an OptionalPeriodInDays wrapper for an int64 field.
-func buildOptionalPeriodInDays(field types.Int64) *declarations.OptionalPeriodInDays {
+func buildOptionalPeriodInDays(field types.Int64) *blueprints.OptionalPeriodInDays {
 	if !helpers.IsConfiguredValue(field) {
-		v := 0
-		return &declarations.OptionalPeriodInDays{Included: new(false), Value: &v}
+		return &blueprints.OptionalPeriodInDays{Included: new(false)}
 	}
 	v := int(field.ValueInt64())
-	return &declarations.OptionalPeriodInDays{Included: new(true), Value: &v}
+	return &blueprints.OptionalPeriodInDays{Included: new(true), Value: &v}
 }
 
 // ToRawConfiguration converts the strongly-typed component to the OpenAPI nested format.
 func (c *SoftwareUpdateSettingsComponent) ToRawConfiguration() (json.RawMessage, error) {
-	cfg := declarations.SoftwareUpdateSettingsConfiguration{}
+	cfg := blueprints.SoftwareUpdateSettingsConfiguration{}
 
 	cfg.AllowStandardUserOSUpdates = buildOptionallyEnabled(c.AllowStandardUserOSUpdates, false)
 
-	cfg.AutomaticActions = &declarations.AutomaticActions{
+	cfg.AutomaticActions = &blueprints.AutomaticActions{
 		Download:              buildAutomaticAction(c.AutomaticDownload, "Allowed"),
 		InstallOSUpdates:      buildAutomaticAction(c.AutomaticInstallOSUpdates, "Allowed"),
 		InstallSecurityUpdate: buildAutomaticAction(c.AutomaticInstallSecurityUpdate, "Allowed"),
@@ -185,34 +183,34 @@ func (c *SoftwareUpdateSettingsComponent) ToRawConfiguration() (json.RawMessage,
 
 	if hasBetaSettings {
 		trueVal := true
-		betaValue := &declarations.BetaSettings{}
+		betaValue := &blueprints.BetaSettings{}
 
 		if helpers.IsConfiguredValue(c.BetaProgramEnrollment) {
 			betaValue.ProgramEnrollment = c.BetaProgramEnrollment.ValueString()
 		}
 
 		if len(c.BetaOfferPrograms) > 0 {
-			offerPrograms := make([]declarations.BetaProgram, len(c.BetaOfferPrograms))
+			offerPrograms := make([]blueprints.BetaProgram, len(c.BetaOfferPrograms))
 			for i, p := range c.BetaOfferPrograms {
-				offerPrograms[i] = declarations.BetaProgram{
-					Token:       p.Token.ValueString(),
-					Description: p.Description.ValueString(),
+				offerPrograms[i] = blueprints.BetaProgram{
+					Token:       p.Token.ValueStringPointer(),
+					Description: p.Description.ValueStringPointer(),
 				}
 			}
 			betaValue.OfferPrograms = &offerPrograms
 		}
 
 		if helpers.IsConfiguredValue(c.BetaRequireProgramToken) && helpers.IsConfiguredValue(c.BetaRequireProgramDescription) {
-			betaValue.RequireProgram = &declarations.BetaProgram{
-				Token:       c.BetaRequireProgramToken.ValueString(),
-				Description: c.BetaRequireProgramDescription.ValueString(),
+			betaValue.RequireProgram = &blueprints.BetaProgram{
+				Token:       c.BetaRequireProgramToken.ValueStringPointer(),
+				Description: c.BetaRequireProgramDescription.ValueStringPointer(),
 			}
 		}
 
-		cfg.Beta = &declarations.Beta{Included: &trueVal, Value: betaValue}
+		cfg.Beta = &blueprints.Beta{Included: &trueVal, Value: betaValue}
 	}
 
-	cfg.Deferrals = &declarations.Deferrals{
+	cfg.Deferrals = &blueprints.Deferrals{
 		CombinedPeriodInDays: buildOptionalPeriodInDays(c.DeferralCombinedPeriod),
 		MajorPeriodInDays:    buildOptionalPeriodInDays(c.DeferralMajorPeriod),
 		MinorPeriodInDays:    buildOptionalPeriodInDays(c.DeferralMinorPeriod),
@@ -221,7 +219,7 @@ func (c *SoftwareUpdateSettingsComponent) ToRawConfiguration() (json.RawMessage,
 
 	cfg.Notifications = buildOptionallyEnabled(c.NotificationsEnabled, false)
 
-	cfg.RapidSecurityResponse = &declarations.RapidSecurityResponse{
+	cfg.RapidSecurityResponse = &blueprints.RapidSecurityResponse{
 		Enable:         buildOptionallyEnabled(c.RapidSecurityResponseEnabled, false),
 		EnableRollback: buildOptionallyEnabled(c.RapidSecurityResponseRollbackEnabled, false),
 	}
@@ -230,7 +228,7 @@ func (c *SoftwareUpdateSettingsComponent) ToRawConfiguration() (json.RawMessage,
 	if helpers.IsConfiguredValue(c.RecommendedCadence) {
 		cadenceValue = c.RecommendedCadence.ValueString()
 	}
-	cfg.RecommendedCadence = &declarations.RecommendedCadence{
+	cfg.RecommendedCadence = &blueprints.RecommendedCadence{
 		Included: new(helpers.IsConfiguredValue(c.RecommendedCadence)),
 		Value:    cadenceValue,
 	}
@@ -240,7 +238,7 @@ func (c *SoftwareUpdateSettingsComponent) ToRawConfiguration() (json.RawMessage,
 
 // FromRawConfiguration populates the strongly-typed component from OpenAPI nested configuration.
 func (c *SoftwareUpdateSettingsComponent) FromRawConfiguration(raw json.RawMessage) error {
-	var cfg declarations.SoftwareUpdateSettingsConfiguration
+	var cfg blueprints.SoftwareUpdateSettingsConfiguration
 	if err := json.Unmarshal(raw, &cfg); err != nil {
 		return err
 	}
@@ -287,15 +285,15 @@ func (c *SoftwareUpdateSettingsComponent) FromRawConfiguration(raw json.RawMessa
 			programs := make([]BetaProgramModel, len(*bv.OfferPrograms))
 			for i, p := range *bv.OfferPrograms {
 				programs[i] = BetaProgramModel{
-					Token:       types.StringValue(p.Token),
-					Description: types.StringValue(p.Description),
+					Token:       types.StringPointerValue(p.Token),
+					Description: types.StringPointerValue(p.Description),
 				}
 			}
 			c.BetaOfferPrograms = programs
 		}
 		if bv.RequireProgram != nil {
-			c.BetaRequireProgramToken = types.StringValue(bv.RequireProgram.Token)
-			c.BetaRequireProgramDescription = types.StringValue(bv.RequireProgram.Description)
+			c.BetaRequireProgramToken = types.StringPointerValue(bv.RequireProgram.Token)
+			c.BetaRequireProgramDescription = types.StringPointerValue(bv.RequireProgram.Description)
 		}
 	}
 


### PR DESCRIPTION
## Summary

- Migrates all blueprint component packages from the removed `bpcomponents/declarations` sub-package to the consolidated `blueprints` package in SDK v0.7.0
- Renames versioned types to their canonical names (`V2` suffix dropped, `Configuration` → `TemporaryPairingConfig`)
- Removes V1 passcode backwards-compat path — SDK no longer returns V1 format
- Switches `safari_bookmarks` from `[]any` / map assertions to typed `BookmarkItem` / `URLBookmarkItem` / `FolderBookmarkItem` (SDK now ships a polymorphic unmarshaler)
- Replaces gone SDK types in `service_background_tasks` and `service_configuration_files` with `map[string]any` serialization
- Fixes `buildOptionalPeriodInDays` omitting `Value` when `Included: false` to prevent sending `value: 0`, which fails API minimum validation (`>= 1`) and previously surfaced as a misleading "context canceled" error (see SDK PR https://github.com/Jamf-Concepts/jamfplatform-go-sdk/pull/13)

## Test plan

- [x] `go test ./...` passes
- [x] Blueprint with software update settings (deferral days omitted) creates successfully
- [x] Blueprint with safari bookmarks (URL and folder types) round-trips correctly
- [x] Blueprint with passcode policy creates and reads back correctly