### PR TITLE
feat(sdk): bump jamfplatform-go-sdk to 11.28.0 spec drop

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/Jamf-Concepts/terraform-provider-jamfplatform
 go 1.26.3
 
 require (
-	github.com/Jamf-Concepts/jamfplatform-go-sdk v0.8.0
+	github.com/Jamf-Concepts/jamfplatform-go-sdk v0.8.1-0.20260520200656-08f6d8479cb0
 	github.com/hashicorp/terraform-plugin-framework v1.19.0
 	github.com/hashicorp/terraform-plugin-framework-timeouts v0.7.0
 	github.com/hashicorp/terraform-plugin-framework-validators v0.19.0

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 dario.cat/mergo v1.0.0 h1:AGCNq9Evsj31mOgNPcLyXc+4PNABt905YmuqPYYpBWk=
 dario.cat/mergo v1.0.0/go.mod h1:uNxQE+84aUszobStD9th8a29P2fMDhsBdgRYvZOxGmk=
-github.com/Jamf-Concepts/jamfplatform-go-sdk v0.8.0 h1:RX15Ybm5n9eN0liQwPJwkXHD6uKMiAkLhUJxOFOgQEU=
-github.com/Jamf-Concepts/jamfplatform-go-sdk v0.8.0/go.mod h1:0EB92TbSfGjVEEF9KB2x/uv9HK4kRIfTfjmFmUdWO38=
+github.com/Jamf-Concepts/jamfplatform-go-sdk v0.8.1-0.20260520200656-08f6d8479cb0 h1:mMCCLUmBZnW68Z9YF8m4qYaMajFO0lvzteEdH2yCdAw=
+github.com/Jamf-Concepts/jamfplatform-go-sdk v0.8.1-0.20260520200656-08f6d8479cb0/go.mod h1:0EB92TbSfGjVEEF9KB2x/uv9HK4kRIfTfjmFmUdWO38=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
 github.com/ProtonMail/go-crypto v1.4.1 h1:9RfcZHqEQUvP8RzecWEUafnZVtEvrBVL9BiF67IQOfM=

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -16,6 +16,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/provider/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 
 	"github.com/Jamf-Concepts/jamfplatform-go-sdk/jamfplatform"
 	deviceactions "github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/actions/device"
@@ -178,6 +179,12 @@ func (p *JamfPlatformProvider) Configure(ctx context.Context, req provider.Confi
 		)
 		return
 	}
+
+	tflog.Info(ctx, "Jamf Platform provider configured", map[string]any{
+		"provider_version":     p.version,
+		"jamf_pro_api_version": jamfplatform.JamfProAPIVersion,
+		"provider_pro_floor":   providerdata.ProviderMinJamfProVersion,
+	})
 
 	pd := providerdata.New(apiClient)
 	resp.DataSourceData = pd

--- a/internal/resources/blueprints/blueprint/components/custom_declarations.go
+++ b/internal/resources/blueprints/blueprint/components/custom_declarations.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 
 	"github.com/Jamf-Concepts/jamfplatform-go-sdk/jamfplatform/blueprints"
-	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/common/helpers"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -60,88 +59,54 @@ func CustomDeclarationsComponentSchema() map[string]schema.Attribute {
 }
 
 // ToRawConfiguration converts the typed component to raw JSON configuration.
+// Empty Declarations marshals to `{}` to preserve the canonical no-op shape;
+// otherwise builds blueprints.CustomDeclarationsConfiguration so the on-wire
+// payload is driven by the SDK schema rather than ad-hoc maps.
 func (c *CustomDeclarationsComponent) ToRawConfiguration() (json.RawMessage, error) {
-	config := make(map[string]any)
-
-	if len(c.Declarations) > 0 {
-		declarations := make([]any, 0, len(c.Declarations))
-
-		for idx, declaration := range c.Declarations {
-			declarationMap := make(map[string]any)
-
-			if helpers.IsConfiguredValue(declaration.ChannelType) {
-				declarationMap["channelType"] = declaration.ChannelType.ValueString()
-			}
-			if helpers.IsConfiguredValue(declaration.Kind) {
-				declarationMap["kind"] = declaration.Kind.ValueString()
-			}
-			if helpers.IsConfiguredValue(declaration.Payload) {
-				var payloadObj any
-				if err := json.Unmarshal([]byte(declaration.Payload.ValueString()), &payloadObj); err != nil {
-					return nil, err
-				}
-				declarationMap["payload"] = payloadObj
-			}
-			declarationMap["payloadKey"] = idx + 1
-			if helpers.IsConfiguredValue(declaration.Type) {
-				declarationMap["type"] = declaration.Type.ValueString()
-			}
-
-			declarations = append(declarations, declarationMap)
-		}
-
-		config["declarations"] = declarations
+	if len(c.Declarations) == 0 {
+		return json.RawMessage(`{}`), nil
 	}
 
-	return json.Marshal(config)
+	declarations := make([]blueprints.CustomDeclaration, 0, len(c.Declarations))
+	for idx, declaration := range c.Declarations {
+		var payload map[string]any
+		if err := json.Unmarshal([]byte(declaration.Payload.ValueString()), &payload); err != nil {
+			return nil, err
+		}
+		declarations = append(declarations, blueprints.CustomDeclaration{
+			ChannelType: declaration.ChannelType.ValueString(),
+			Kind:        declaration.Kind.ValueString(),
+			Payload:     payload,
+			PayloadKey:  idx + 1,
+			Type:        declaration.Type.ValueString(),
+		})
+	}
+
+	return json.Marshal(blueprints.CustomDeclarationsConfiguration{Declarations: declarations})
 }
 
 // FromRawConfiguration populates the typed component from raw JSON configuration.
 func (c *CustomDeclarationsComponent) FromRawConfiguration(raw json.RawMessage) error {
-	var config map[string]any
+	var config blueprints.CustomDeclarationsConfiguration
 	if err := json.Unmarshal(raw, &config); err != nil {
 		return err
 	}
 
-	if declarationsRaw, exists := config["declarations"]; exists {
-		if declarationsSlice, ok := declarationsRaw.([]any); ok {
-			declarations := make([]CustomDeclarationModel, 0, len(declarationsSlice))
-
-			for _, declarationRaw := range declarationsSlice {
-				if declarationMap, ok := declarationRaw.(map[string]any); ok {
-					declaration := CustomDeclarationModel{}
-
-					if channelType, exists := declarationMap["channelType"]; exists {
-						if channelStr, ok := channelType.(string); ok {
-							declaration.ChannelType = types.StringValue(channelStr)
-						}
-					}
-					if kind, exists := declarationMap["kind"]; exists {
-						if kindStr, ok := kind.(string); ok {
-							declaration.Kind = types.StringValue(kindStr)
-						}
-					}
-					if payload, exists := declarationMap["payload"]; exists {
-						payloadJSON, err := json.Marshal(payload)
-						if err != nil {
-							return err
-						}
-						declaration.Payload = types.StringValue(string(payloadJSON))
-					}
-					if declType, exists := declarationMap["type"]; exists {
-						if typeStr, ok := declType.(string); ok {
-							declaration.Type = types.StringValue(typeStr)
-						}
-					}
-
-					declarations = append(declarations, declaration)
-				}
-			}
-
-			c.Declarations = declarations
+	declarations := make([]CustomDeclarationModel, 0, len(config.Declarations))
+	for _, declaration := range config.Declarations {
+		payloadJSON, err := json.Marshal(declaration.Payload)
+		if err != nil {
+			return err
 		}
+		declarations = append(declarations, CustomDeclarationModel{
+			ChannelType: types.StringValue(declaration.ChannelType),
+			Kind:        types.StringValue(declaration.Kind),
+			Payload:     types.StringValue(string(payloadJSON)),
+			Type:        types.StringValue(declaration.Type),
+		})
 	}
 
+	c.Declarations = declarations
 	return nil
 }
 


### PR DESCRIPTION
## Summary

- Bumps `jamfplatform-go-sdk` to `v0.8.1-0.20260520200656-08f6d8479cb0` — head of [PR #21 (`nm-jamf-pro-11-28-0`)](https://github.com/Jamf-Concepts/jamfplatform-go-sdk/pull/21), the full Jamf 11.28.0 API spec refresh.
- Migrates `internal/resources/blueprints/blueprint/components/custom_declarations.go` from ad-hoc `map[string]any` marshal to the new strongly-typed `blueprints.CustomDeclaration` + `blueprints.CustomDeclarationsConfiguration` structs. Schema and on-wire JSON unchanged.
- Emits a one-line `tflog.Info` at provider `Configure` carrying `jamfplatform.JamfProAPIVersion` + provider/Pro-floor versions for support telemetry.

## Breaking-change exposure (from upstream PR #21)

Six PR-flagged downstream-breaking type changes:

| SDK change | Provider impact |
|---|---|
| `ComputerInventory.Plugins` → `[]map[string]any` | Not referenced |
| Computer/MobileDevice `Site` embed → `*V1SiteBase` | Not referenced |
| `MDMCommand` gains `CommandError`/`DateCompleted`/`ProfileID` | Not referenced |
| Declaration Reporting `Status` enum rename | Not referenced |
| `ErrorDto.ID` → `*string` | Not referenced |
| `StatusReportDeclarationDto.DateUpdated` lost omitempty | Not referenced |

Greps run on both type names and field accesses — zero hits across `internal/`. Existing resources are recompile-only.

## Deferred (follow-up PRs)

- `blueprints.ManagedAppComponent` — new SDK type for VPP-via-DDM, no provider equivalent yet.
- 10 new Pro endpoints (account groups, last login, m2m tenant id, user sessions, dss declaration, jamf-pro-server-url history, etc.).
- V3 computer-groups / V2 mobile-device-groups / V2 platform groups resolver + Apply lifecycle.
- DDM filtered declaration-report endpoints.

## Pin caveat

SDK pin is a pseudo-version against an **open** upstream PR branch. Re-pin to a tag once `jamfplatform-go-sdk#21` merges.

## Test plan

- [x] `go build ./...` clean
- [x] `make lint` — 0 issues
- [x] `make test` — all unit tests pass (incl. `custom_declarations` roundtrip / indexed-payload-key / invalid-payload / empty cases)
- [x] `make generate` — no doc/header drift
- [x] `TF_ACC=1 go test -tags acceptance -v -count=1 -timeout=15m -run '^TestAccResource_Blueprint_CustomDeclarations$' ./internal/resources/blueprints/blueprint/` against a 11.28.0 tenant

🤖 Generated with [Claude Code](https://claude.com/claude-code)