### PR TITLE
refactor(providerdata): extract configureSub + add ConfigureProClassic

### DIFF
--- a/internal/common/helpers/ids.go
+++ b/internal/common/helpers/ids.go
@@ -26,3 +26,14 @@ func StringToIntID(s types.String) (int64, error) {
 	}
 	return v, nil
 }
+
+// StringValueFromIntPtr converts a nil-safe *int (the shape returned by every
+// Jamf classic XML SDK type) into a Terraform string attribute. A nil pointer
+// becomes a null string so callers can detect a missing server-side ID rather
+// than silently substituting an empty value.
+func StringValueFromIntPtr(p *int) types.String {
+	if p == nil {
+		return types.StringNull()
+	}
+	return types.StringValue(strconv.Itoa(*p))
+}

--- a/internal/common/helpers/ids_test.go
+++ b/internal/common/helpers/ids_test.go
@@ -27,6 +27,41 @@ func TestIntIDToString(t *testing.T) {
 	}
 }
 
+func TestStringValueFromIntPtr(t *testing.T) {
+	zero := 0
+	pos := 12345
+	neg := -1
+
+	tests := []struct {
+		name     string
+		in       *int
+		wantNull bool
+		want     string
+	}{
+		{"nil", nil, true, ""},
+		{"zero", &zero, false, "0"},
+		{"positive", &pos, false, "12345"},
+		{"negative", &neg, false, "-1"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := StringValueFromIntPtr(tc.in)
+			if tc.wantNull {
+				if !got.IsNull() {
+					t.Fatalf("expected null types.String, got %#v", got)
+				}
+				return
+			}
+			if got.IsNull() {
+				t.Fatalf("expected non-null types.String for %v, got null", tc.in)
+			}
+			if got.ValueString() != tc.want {
+				t.Errorf("got %q, want %q", got.ValueString(), tc.want)
+			}
+		})
+	}
+}
+
 func TestStringToIntID(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/internal/providerdata/providerdata.go
+++ b/internal/providerdata/providerdata.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/Jamf-Concepts/jamfplatform-go-sdk/jamfplatform"
 	"github.com/Jamf-Concepts/jamfplatform-go-sdk/jamfplatform/pro"
+	"github.com/Jamf-Concepts/jamfplatform-go-sdk/jamfplatform/proclassic"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 
 	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/common/helpers"
@@ -120,24 +121,27 @@ func (d *Data) floorAlreadyHandled() bool {
 	return d.floorHandled
 }
 
-// ConfigurePro is the shared Configure boilerplate for every Pro resource, data source,
-// list resource, and action. It type-asserts providerData into *Data, fetches the Jamf
-// Pro tenant version (lazily, cached on the Data value), runs the per-resource minimum
-// version gate when minVer is non-empty, and surfaces the provider-floor advisory
-// warning when the tenant is below the provider build target.
+// configureSub is the shared core for every SDK sub-client Configure helper. It
+// type-asserts providerData into *Data, fetches the Jamf Pro tenant version
+// (lazily, cached on the Data value), runs the per-resource minimum version gate
+// when minVer is non-empty, surfaces the provider-floor advisory warning when
+// the tenant is below the provider build target, and constructs the sub-client
+// via the supplied factory.
 //
-// Once the floor warning has been considered for the Data value, subsequent Configure
-// calls with empty minVer skip the version fetch entirely — there is nothing left to
-// evaluate on those code paths, so the network round-trip is avoided.
+// Once the floor warning has been considered for the Data value, subsequent
+// Configure calls with empty minVer skip the version fetch entirely — there is
+// nothing left to evaluate on those code paths, so the network round-trip is
+// avoided.
 //
-// resourceType is the fully-qualified Terraform type name used in diagnostic messages
-// (e.g. "jamfplatform_pro_category"). Returns a *pro.Client ready for use; callers
-// should check resp.Diagnostics.HasError() before using it.
-//
-// Returns (nil, nil) when providerData is nil (the framework calls Configure with a
-// nil ProviderData during early lifecycle — that is not an error, the resource simply
-// remains unconfigured until a later Configure call provides the data).
-func ConfigurePro(ctx context.Context, providerData any, minVer, resourceType string) (*pro.Client, diag.Diagnostics) {
+// Returns (nil, nil) when providerData is nil (the framework calls Configure with
+// a nil ProviderData during early lifecycle — that is not an error, the resource
+// simply remains unconfigured until a later Configure call provides the data).
+func configureSub[T any](
+	ctx context.Context,
+	providerData any,
+	minVer, resourceType string,
+	factory func(*jamfplatform.Client) *T,
+) (*T, diag.Diagnostics) {
 	var diags diag.Diagnostics
 	if providerData == nil {
 		return nil, diags
@@ -150,7 +154,7 @@ func ConfigurePro(ctx context.Context, providerData any, minVer, resourceType st
 		)
 		return nil, diags
 	}
-	client := pro.New(pd.Client)
+	client := factory(pd.Client)
 
 	// Fast path: empty per-resource minVer and the provider-floor advisory has already
 	// been considered for this Data value → nothing left to fetch.
@@ -176,4 +180,35 @@ func ConfigurePro(ctx context.Context, providerData any, minVer, resourceType st
 		diags.Append(warn)
 	}
 	return client, diags
+}
+
+// ConfigurePro is the shared Configure boilerplate for every Pro resource, data
+// source, list resource, and action. It type-asserts providerData into *Data,
+// fetches the Jamf Pro tenant version (lazily, cached on the Data value), runs
+// the per-resource minimum version gate when minVer is non-empty, and surfaces
+// the provider-floor advisory warning when the tenant is below the provider
+// build target.
+//
+// resourceType is the fully-qualified Terraform type name used in diagnostic
+// messages (e.g. "jamfplatform_pro_category"). Returns a *pro.Client ready for
+// use; callers should check resp.Diagnostics.HasError() before using it.
+//
+// Returns (nil, nil) when providerData is nil — the framework calls Configure
+// with a nil ProviderData during early lifecycle and that is not an error; the
+// resource simply remains unconfigured until a later Configure call provides
+// the data.
+//
+// Once the floor warning has been considered for a Data value, subsequent
+// Configure calls with empty minVer skip the version fetch entirely.
+func ConfigurePro(ctx context.Context, providerData any, minVer, resourceType string) (*pro.Client, diag.Diagnostics) {
+	return configureSub(ctx, providerData, minVer, resourceType, pro.New)
+}
+
+// ConfigureProClassic is the shared Configure boilerplate for every ProClassic
+// resource, data source, list resource, and action. Semantics are identical to
+// ConfigurePro — same Data value, same version cache, same one-shot floor
+// warning, same nil-providerData and minVer contracts — but the returned client
+// speaks XML against the classic API surface.
+func ConfigureProClassic(ctx context.Context, providerData any, minVer, resourceType string) (*proclassic.Client, diag.Diagnostics) {
+	return configureSub(ctx, providerData, minVer, resourceType, proclassic.New)
 }

--- a/internal/providerdata/providerdata_test.go
+++ b/internal/providerdata/providerdata_test.go
@@ -210,6 +210,83 @@ func TestConfigurePro_ShortCircuit_EmptyMinVerAfterFloorHandled(t *testing.T) {
 	}
 }
 
+// ProClassic Configure tests are intentionally narrower than the Pro suite:
+// ConfigureProClassic and ConfigurePro share the configureSub core, so the
+// version-cache, fetch-retry, fast-path-short-circuit, and gate-satisfied paths
+// are already exercised through the Pro tests above. The tests below cover the
+// proclassic-specific wiring (factory choice, returned type) and the
+// cross-client invariants we need to keep (shared one-shot floor warning).
+
+func TestConfigureProClassic_NilProviderData(t *testing.T) {
+	client, diags := ConfigureProClassic(context.Background(), nil, "", "jamfplatform_pro_test")
+	if client != nil {
+		t.Errorf("expected nil client for nil providerData, got %v", client)
+	}
+	if diags.HasError() {
+		t.Errorf("expected no diagnostics for nil providerData, got %v", diags)
+	}
+}
+
+func TestConfigureProClassic_WrongType(t *testing.T) {
+	client, diags := ConfigureProClassic(context.Background(), "not a Data value", "", "jamfplatform_pro_test")
+	if client != nil {
+		t.Errorf("expected nil client for wrong providerData type, got %v", client)
+	}
+	if !diags.HasError() {
+		t.Fatalf("expected error diagnostic for wrong providerData type, got %v", diags)
+	}
+	if !strings.Contains(diags[0].Summary(), "Unexpected Configure Type") {
+		t.Errorf("expected 'Unexpected Configure Type' summary, got %q", diags[0].Summary())
+	}
+}
+
+func TestConfigureProClassic_HappyPath_NoMinVer(t *testing.T) {
+	pd := &Data{Client: newFakeClient(),
+		versionFetcher: func(_ context.Context) (string, error) {
+			return "11.27.0", nil
+		},
+	}
+	client, diags := ConfigureProClassic(context.Background(), pd, "", "jamfplatform_pro_test")
+	if client == nil {
+		t.Fatal("expected non-nil proclassic client on happy path")
+	}
+	if diags.HasError() {
+		t.Errorf("expected no errors, got %v", diags)
+	}
+}
+
+func TestConfigureProClassic_MinVerGate_Failed(t *testing.T) {
+	pd := &Data{Client: newFakeClient(),
+		versionFetcher: func(_ context.Context) (string, error) {
+			return "10.0.0", nil
+		},
+	}
+	_, diags := ConfigureProClassic(context.Background(), pd, "11.5.0", "jamfplatform_pro_test")
+	if !diags.HasError() {
+		t.Fatalf("expected error when tenant < minVer, got %v", diags)
+	}
+}
+
+// TestConfigureProClassic_SharesFloorStateWithPro verifies that ConfigurePro and
+// ConfigureProClassic share the one-shot floor-warning machinery on the same
+// Data value. A config that mixes both kinds of resources must only see one
+// warning regardless of order.
+func TestConfigureProClassic_SharesFloorStateWithPro(t *testing.T) {
+	pd := &Data{Client: newFakeClient(),
+		versionFetcher: func(_ context.Context) (string, error) {
+			return "10.0.0", nil
+		},
+	}
+	_, diags1 := ConfigurePro(context.Background(), pd, "", "jamfplatform_pro_a")
+	if got := countSeverity(diags1, diag.SeverityWarning); got != 1 {
+		t.Fatalf("first (Pro) Configure: expected 1 warning, got %d (%v)", got, diags1)
+	}
+	_, diags2 := ConfigureProClassic(context.Background(), pd, "", "jamfplatform_pro_b")
+	if got := countSeverity(diags2, diag.SeverityWarning); got != 0 {
+		t.Errorf("subsequent (ProClassic) Configure: expected 0 warnings, got %d (%v)", got, diags2)
+	}
+}
+
 // TestGetJamfProVersion_CachesSuccess verifies successful fetches are not re-issued.
 func TestGetJamfProVersion_CachesSuccess(t *testing.T) {
 	calls := 0


### PR DESCRIPTION
## Summary
- Hoists version-fetch / floor-warning / type-assertion machinery out of `ConfigurePro` into an unexported generic `configureSub[T]` so a second SDK sub-client (proclassic) can reuse it.
- `ConfigurePro` becomes a one-line wrapper binding `pro.New`; new `ConfigureProClassic` is the symmetric wrapper binding `proclassic.New`.
- Both wrappers share the same `Data` value, the same cached tenant version, and the same one-shot provider-floor advisory — configs mixing Pro and ProClassic resources emit only a single floor warning.
- Adds `helpers.StringValueFromIntPtr` for converting `*int` IDs (the shape classic XML SDK types return) into Terraform string attributes with explicit null-on-nil semantics — a missing server-side ID must surface, not silently collapse to `""`.

Prep PR #1 of two for ProClassic resource enablement. Companion: ProClassic client-side filter helper PR. Both must land before the first canary `jamfplatform_pro_site`.

## Test plan
- [x] `make fix fmt lint test` — 0 lint issues, all unit tests pass
- [x] All 9 existing `ConfigurePro_*` tests still pass byte-for-byte (semantic preservation through `configureSub`)
- [x] 5 new `ConfigureProClassic` tests: nil providerData, wrong type, happy path returns `*proclassic.Client`, gate failed, cross-client one-shot floor warning
- [x] 4 new `StringValueFromIntPtr` cases: nil, zero, positive, negative
- [x] `internal/providerdata` coverage: 83.0% · `internal/common/helpers` coverage: 77.9%

🤖 Generated with [Claude Code](https://claude.com/claude-code)