### PR TITLE
feat(filters): add ClassicFilterModel + ApplyClassicFilter generic

### DIFF
--- a/internal/common/filters/classic.go
+++ b/internal/common/filters/classic.go
@@ -1,0 +1,89 @@
+// Copyright Jamf Software LLC 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package filters
+
+import (
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	listschema "github.com/hashicorp/terraform-plugin-framework/list/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+// classicFilterBlockDescription is the user-facing markdown description for the
+// classic filter block. Classic APIs do not accept query parameters on their
+// List endpoints, so this filter is applied client-side after the full list is
+// fetched. It is intentionally narrow: a single case-insensitive substring match
+// against the resource's display name. For exact-name lookup, use the singular
+// "by name" data source instead.
+const classicFilterBlockDescription = "Optional client-side filter for classic-API list operations. Applied after the full list is fetched (classic endpoints do not accept query parameters). Use the singular `by name` data source for exact-name lookup."
+
+const classicNameSubstringDescription = "Case-insensitive substring matched against the resource's display name. Empty or omitted returns every item."
+
+// ClassicFilterModel is the parsed Terraform value for classic filter blocks.
+// All classic list resources and plural data sources share this one shape —
+// classic has no RSQL or query parameters, so a single substring is the only
+// dimension we filter on.
+type ClassicFilterModel struct {
+	NameSubstring types.String `tfsdk:"name_substring"`
+}
+
+// ClassicFilterAttribute returns the schema block for a plural data source's
+// optional client-side filter. By convention callers MUST mount the returned
+// value under attribute key `"filter"` so every classic data source presents
+// the same `filter { name_substring = "…" }` shape to users.
+func ClassicFilterAttribute() schema.SingleNestedAttribute {
+	return schema.SingleNestedAttribute{
+		MarkdownDescription: classicFilterBlockDescription,
+		Optional:            true,
+		Attributes: map[string]schema.Attribute{
+			"name_substring": schema.StringAttribute{
+				MarkdownDescription: classicNameSubstringDescription,
+				Optional:            true,
+			},
+		},
+	}
+}
+
+// ClassicListFilterAttribute is the list-resource counterpart to
+// ClassicFilterAttribute. Same shape, list-schema types, same mount-at-`filter`
+// convention.
+func ClassicListFilterAttribute() listschema.SingleNestedAttribute {
+	return listschema.SingleNestedAttribute{
+		MarkdownDescription: classicFilterBlockDescription,
+		Optional:            true,
+		Attributes: map[string]listschema.Attribute{
+			"name_substring": listschema.StringAttribute{
+				MarkdownDescription: classicNameSubstringDescription,
+				Optional:            true,
+			},
+		},
+	}
+}
+
+// ApplyClassicFilter applies a parsed ClassicFilterModel to a slice and returns
+// the filtered result. Null, unknown, or empty NameSubstring returns the input
+// slice **as-is** (same underlying array, `result == items` reference-equal).
+// Otherwise items survive the filter when the lowered name extracted by the
+// supplied accessor contains the lowered substring, and the return value is a
+// **fresh non-nil** slice (possibly length zero) backed by its own array.
+//
+// Generic over T so every classic list resource passes its own SDK item type
+// and a one-line name accessor — no per-resource filter logic duplication.
+//
+// The input slice is never mutated regardless of which branch is taken.
+func ApplyClassicFilter[T any](items []T, f ClassicFilterModel, name func(T) string) []T {
+	needle, ok := configuredFilterValue(f.NameSubstring)
+	if !ok {
+		return items
+	}
+	needleLower := strings.ToLower(needle)
+	out := make([]T, 0, len(items))
+	for _, item := range items {
+		if strings.Contains(strings.ToLower(name(item)), needleLower) {
+			out = append(out, item)
+		}
+	}
+	return out
+}

--- a/internal/common/filters/classic_test.go
+++ b/internal/common/filters/classic_test.go
@@ -1,0 +1,147 @@
+// Copyright Jamf Software LLC 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package filters
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	listschema "github.com/hashicorp/terraform-plugin-framework/list/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+type fakeItem struct {
+	Name string
+}
+
+func fakeName(i fakeItem) string { return i.Name }
+
+func items(names ...string) []fakeItem {
+	out := make([]fakeItem, len(names))
+	for i, n := range names {
+		out[i] = fakeItem{Name: n}
+	}
+	return out
+}
+
+func names(items []fakeItem) []string {
+	out := make([]string, len(items))
+	for i, it := range items {
+		out[i] = it.Name
+	}
+	return out
+}
+
+func TestApplyClassicFilter_PassThrough(t *testing.T) {
+	in := items("Primary", "HQ", "Branch")
+	tests := []struct {
+		name   string
+		filter ClassicFilterModel
+	}{
+		{"null", ClassicFilterModel{NameSubstring: types.StringNull()}},
+		{"unknown", ClassicFilterModel{NameSubstring: types.StringUnknown()}},
+		{"empty", ClassicFilterModel{NameSubstring: types.StringValue("")}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := ApplyClassicFilter(in, tc.filter, fakeName)
+			if !reflect.DeepEqual(got, in) {
+				t.Errorf("expected pass-through for %q, got %v", tc.name, names(got))
+			}
+		})
+	}
+}
+
+func TestApplyClassicFilter_SubstringMatch(t *testing.T) {
+	in := items("Primary HQ", "Primary Branch", "Remote", "primary basement")
+	got := ApplyClassicFilter(in, ClassicFilterModel{NameSubstring: types.StringValue("primary")}, fakeName)
+	want := []string{"Primary HQ", "Primary Branch", "primary basement"}
+	if !reflect.DeepEqual(names(got), want) {
+		t.Errorf("got %v, want %v", names(got), want)
+	}
+}
+
+func TestApplyClassicFilter_CaseInsensitive(t *testing.T) {
+	in := items("PRIMARY", "primary", "Primary", "secondary")
+	got := ApplyClassicFilter(in, ClassicFilterModel{NameSubstring: types.StringValue("PRIM")}, fakeName)
+	want := []string{"PRIMARY", "primary", "Primary"}
+	if !reflect.DeepEqual(names(got), want) {
+		t.Errorf("got %v, want %v", names(got), want)
+	}
+}
+
+func TestApplyClassicFilter_NoMatches(t *testing.T) {
+	in := items("alpha", "beta")
+	got := ApplyClassicFilter(in, ClassicFilterModel{NameSubstring: types.StringValue("zulu")}, fakeName)
+	if len(got) != 0 {
+		t.Errorf("expected empty slice, got %v", names(got))
+	}
+}
+
+func TestApplyClassicFilter_DoesNotMutateInput(t *testing.T) {
+	in := items("alpha", "beta", "ALPHA")
+	original := make([]fakeItem, len(in))
+	copy(original, in)
+
+	_ = ApplyClassicFilter(in, ClassicFilterModel{NameSubstring: types.StringValue("a")}, fakeName)
+
+	if !reflect.DeepEqual(in, original) {
+		t.Errorf("input slice was mutated: got %v, want %v", names(in), names(original))
+	}
+}
+
+func TestApplyClassicFilter_EmptyInput(t *testing.T) {
+	got := ApplyClassicFilter[fakeItem](nil, ClassicFilterModel{NameSubstring: types.StringValue("anything")}, fakeName)
+	if got == nil {
+		t.Fatalf("expected non-nil result when filter is active (even with nil input)")
+	}
+	if len(got) != 0 {
+		t.Errorf("expected empty result for nil input, got %v", names(got))
+	}
+}
+
+func TestClassicFilterAttribute_Shape(t *testing.T) {
+	a := ClassicFilterAttribute()
+	if !a.Optional {
+		t.Errorf("expected outer Optional true")
+	}
+	inner, ok := a.Attributes["name_substring"]
+	if !ok {
+		t.Fatalf("expected name_substring attribute, got keys %v", keys(a.Attributes))
+	}
+	str, ok := inner.(schema.StringAttribute)
+	if !ok {
+		t.Fatalf("name_substring expected to be schema.StringAttribute, got %T", inner)
+	}
+	if !str.Optional {
+		t.Errorf("name_substring should be Optional")
+	}
+}
+
+func TestClassicListFilterAttribute_Shape(t *testing.T) {
+	a := ClassicListFilterAttribute()
+	if !a.Optional {
+		t.Errorf("expected outer Optional true")
+	}
+	inner, ok := a.Attributes["name_substring"]
+	if !ok {
+		t.Fatalf("expected name_substring attribute")
+	}
+	str, ok := inner.(listschema.StringAttribute)
+	if !ok {
+		t.Fatalf("name_substring expected to be listschema.StringAttribute, got %T", inner)
+	}
+	if !str.Optional {
+		t.Errorf("name_substring should be Optional")
+	}
+}
+
+func keys[V any](m map[string]V) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}


### PR DESCRIPTION
## Summary
- Classic Jamf API List endpoints accept no query parameters, so the existing RSQL filter plumbing does not apply.
- Adds a uniform client-side filter — a single case-insensitive substring match on the resource's display name — shared across every classic plural data source and list resource.
- `ClassicFilterAttribute` / `ClassicListFilterAttribute` return the schema for data sources and list resources respectively. By convention both mount under attribute key `\"filter\"` so the user-facing shape is always `filter { name_substring = \"…\" }` regardless of which classic resource is being filtered.
- `ApplyClassicFilter` is generic over `T` — each classic list resource passes its own SDK item type plus a one-line name accessor, no per-resource filtering logic.
- Pass-through (null/unknown/empty filter) returns the input slice reference-equal; the filtering branch returns a fresh non-nil slice and never mutates the input.

Prep PR #2 of two for ProClassic resource enablement. Companion: `ConfigureProClassic` refactor PR. Both must land before the first canary `jamfplatform_pro_site`.

## Test plan
- [x] `make fix fmt lint test` — 0 lint issues, all unit tests pass
- [x] 9 new tests: pass-through (null/unknown/empty), substring match, case insensitive, no matches, no mutation of input, empty/nil input, schema shape (data source + list resource variants verify inner type is `StringAttribute` and Optional)
- [x] `internal/common/filters` coverage: 85.7%

🤖 Generated with [Claude Code](https://claude.com/claude-code)