### PR TITLE
feat(cbengine): allow scoping benchmarks to multiple device groups

### DIFF
--- a/docs/data-sources/cbengine_benchmark.md
+++ b/docs/data-sources/cbengine_benchmark.md
@@ -60,7 +60,8 @@ output "benchmark_by_title_rules" {
 - `last_updated_at` (String) Last updated at (RFC3339).
 - `rules` (Attributes List) Rules. (see [below for nested schema](#nestedatt--rules))
 - `sources` (Attributes List) Sources. (see [below for nested schema](#nestedatt--sources))
-- `target_device_group` (String) Device group for the target configuration.
+- `target_device_group` (String, Deprecated) **Deprecated** — use `target_device_groups`. First device group ID returned by the API, kept for backwards compatibility.
+- `target_device_groups` (Set of String) All device group Platform IDs targeted by this benchmark.
 - `tenant_id` (String) Tenant ID.
 - `update_available` (Boolean) Update available flag.
 

--- a/docs/resources/cbengine_benchmark.md
+++ b/docs/resources/cbengine_benchmark.md
@@ -14,6 +14,9 @@ Creates a Jamf Compliance Benchmark. Creation is asynchronous: the API accepts t
 
 ```terraform
 # Example: Create a Jamf Compliance Benchmark
+#
+# Targeting accepts either a set of device group Platform IDs (preferred) via
+# target_device_groups, or the deprecated single-value target_device_group.
 
 data "jamfplatform_cbengine_rules" "cis_lvl1" {
   baseline_id = "cis_lvl1"
@@ -38,8 +41,12 @@ resource "jamfplatform_cbengine_benchmark" "cis_lvl1" {
     }
   ]
 
-  target_device_group = "4a36a1fe-e45a-430d-a966-a4d3ac993577"
-  enforcement_mode    = "MONITOR_AND_ENFORCE"
+  # Multiple device groups can be targeted simultaneously.
+  target_device_groups = [
+    "4a36a1fe-e45a-430d-a966-a4d3ac993577",
+    "8b9b5fa0-66ed-43d9-9b9a-2b1f3f7d1e21",
+  ]
+  enforcement_mode = "MONITOR_AND_ENFORCE"
 }
 
 resource "jamfplatform_cbengine_benchmark" "custom_cis_lvl1" {
@@ -65,6 +72,9 @@ resource "jamfplatform_cbengine_benchmark" "custom_cis_lvl1" {
       enabled = true
     }
   ]
+
+  # target_device_group remains supported for backwards compatibility but is
+  # deprecated. Prefer target_device_groups (set form) for new configurations.
   target_device_group = "4a36a1fe-e45a-430d-a966-a4d3ac993577"
   enforcement_mode    = "MONITOR"
 }
@@ -78,13 +88,14 @@ resource "jamfplatform_cbengine_benchmark" "custom_cis_lvl1" {
 - `enforcement_mode` (String) Enforcement mode for the benchmark; allowed values: MONITOR or MONITOR_AND_ENFORCE. Required and immutable for this resource (replace on change).
 - `rules` (Attributes List) Set of rules to include in the benchmark. Each entry references a rule id and whether it is enabled; additional metadata (title, section, ODV hints) are computed from the API. Use the `jamfplatform_cbengine_rules` data source to look up available rules. (see [below for nested schema](#nestedatt--rules))
 - `sources` (Attributes List) Set of mSCP sources (branch + revision) to include in the benchmark. Required; changing sources requires replace. Use the `jamfplatform_cbengine_rules` data source to look up available sources. (see [below for nested schema](#nestedatt--sources))
-- `target_device_group` (String) Device group Platform ID targeted by this benchmark. Specified as a string in UUID format. The Platform ID can be sourced from the response body of the /api/v1/groups Jamf Pro API endpoint. Required and immutable for this resource (replace on change).
 - `title` (String) Benchmark title (max length 100). Required and replaces the resource when changed.
 
 ### Optional
 
 - `description` (String) Optional human-readable description of the benchmark (max length 1000). Replaces the resource when changed.
 - `source_baseline_id` (String) mSCP baseline identifier used as the source for rules. Required on creation, but computed for imports. Use the `jamfplatform_cbengine_baselines` data source to look up available baselines.
+- `target_device_group` (String, Deprecated) **Deprecated** — use `target_device_groups` instead. Single device group Platform ID targeted by this benchmark, in UUID format. Mutually exclusive with `target_device_groups`. Immutable (replace on change).
+- `target_device_groups` (Set of String) Device group Platform IDs targeted by this benchmark. Specified as a set of UUID strings; Platform IDs can be sourced from the response body of the `/api/v1/groups` Jamf Pro API endpoint. Mutually exclusive with the deprecated `target_device_group`. Immutable (replace on change).
 - `timeouts` (Attributes) (see [below for nested schema](#nestedatt--timeouts))
 
 ### Read-Only

--- a/examples/resources/jamfplatform_cbengine_benchmark/resource.tf
+++ b/examples/resources/jamfplatform_cbengine_benchmark/resource.tf
@@ -1,4 +1,7 @@
 # Example: Create a Jamf Compliance Benchmark
+#
+# Targeting accepts either a set of device group Platform IDs (preferred) via
+# target_device_groups, or the deprecated single-value target_device_group.
 
 data "jamfplatform_cbengine_rules" "cis_lvl1" {
   baseline_id = "cis_lvl1"
@@ -23,8 +26,12 @@ resource "jamfplatform_cbengine_benchmark" "cis_lvl1" {
     }
   ]
 
-  target_device_group = "4a36a1fe-e45a-430d-a966-a4d3ac993577"
-  enforcement_mode    = "MONITOR_AND_ENFORCE"
+  # Multiple device groups can be targeted simultaneously.
+  target_device_groups = [
+    "4a36a1fe-e45a-430d-a966-a4d3ac993577",
+    "8b9b5fa0-66ed-43d9-9b9a-2b1f3f7d1e21",
+  ]
+  enforcement_mode = "MONITOR_AND_ENFORCE"
 }
 
 resource "jamfplatform_cbengine_benchmark" "custom_cis_lvl1" {
@@ -50,6 +57,9 @@ resource "jamfplatform_cbengine_benchmark" "custom_cis_lvl1" {
       enabled = true
     }
   ]
+
+  # target_device_group remains supported for backwards compatibility but is
+  # deprecated. Prefer target_device_groups (set form) for new configurations.
   target_device_group = "4a36a1fe-e45a-430d-a966-a4d3ac993577"
   enforcement_mode    = "MONITOR"
 }

--- a/internal/resources/cbengine/benchmark/data_source.go
+++ b/internal/resources/cbengine/benchmark/data_source.go
@@ -199,7 +199,13 @@ func (d *BenchmarkDataSource) Schema(ctx context.Context, req datasource.SchemaR
 				},
 			},
 			"target_device_group": schema.StringAttribute{
-				MarkdownDescription: "Device group for the target configuration.",
+				MarkdownDescription: "**Deprecated** — use `target_device_groups`. First device group ID returned by the API, kept for backwards compatibility.",
+				DeprecationMessage:  "Use target_device_groups instead.",
+				Computed:            true,
+			},
+			"target_device_groups": schema.SetAttribute{
+				MarkdownDescription: "All device group Platform IDs targeted by this benchmark.",
+				ElementType:         types.StringType,
 				Computed:            true,
 			},
 			"enforcement_mode": schema.StringAttribute{

--- a/internal/resources/cbengine/benchmark/input_builders.go
+++ b/internal/resources/cbengine/benchmark/input_builders.go
@@ -5,9 +5,33 @@ package benchmark
 
 import (
 	"github.com/Jamf-Concepts/jamfplatform-go-sdk/jamfplatform/compliancebenchmarks"
+	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
+// buildDeviceGroupsRequest extracts the device group IDs the user supplied. Plural
+// target_device_groups takes precedence when configured; otherwise the deprecated
+// singular target_device_group is wrapped into a single-element slice. Schema
+// validation guarantees exactly one is supplied so this never observes both.
+func buildDeviceGroupsRequest(data *BenchmarkResourceModel) []string {
+	if !data.TargetDeviceGroups.IsNull() && !data.TargetDeviceGroups.IsUnknown() {
+		elements := data.TargetDeviceGroups.Elements()
+		out := make([]string, 0, len(elements))
+		for _, el := range elements {
+			s, ok := el.(types.String)
+			if !ok || s.IsNull() || s.IsUnknown() {
+				continue
+			}
+			out = append(out, s.ValueString())
+		}
+		return out
+	}
+	return []string{data.TargetDeviceGroup.ValueString()}
+}
+
 // buildBenchmarkRequest constructs the API request body from the Terraform plan model.
+// Device group targeting accepts either the deprecated singular target_device_group
+// or the preferred plural target_device_groups set; ConflictsWith + AtLeastOneOf on
+// the schema guarantee exactly one is configured.
 func buildBenchmarkRequest(data *BenchmarkResourceModel) *compliancebenchmarks.BenchmarkRequestV2 {
 	reqBody := &compliancebenchmarks.BenchmarkRequestV2{
 		Title:            data.Title.ValueString(),
@@ -16,7 +40,7 @@ func buildBenchmarkRequest(data *BenchmarkResourceModel) *compliancebenchmarks.B
 		Sources:          make([]compliancebenchmarks.Source, len(data.Sources)),
 		Rules:            make([]compliancebenchmarks.RuleRequest, len(data.Rules)),
 		Target: compliancebenchmarks.TargetV2{
-			DeviceGroups: []string{data.TargetDeviceGroup.ValueString()},
+			DeviceGroups: buildDeviceGroupsRequest(data),
 		},
 		EnforcementMode: data.EnforcementMode.ValueString(),
 	}

--- a/internal/resources/cbengine/benchmark/input_builders_test.go
+++ b/internal/resources/cbengine/benchmark/input_builders_test.go
@@ -6,8 +6,19 @@ package benchmark
 import (
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
+
+// setOfStrings constructs a non-null types.Set of string elements for test setup.
+func setOfStrings(ids ...string) types.Set {
+	vals := make([]attr.Value, len(ids))
+	for i, id := range ids {
+		vals[i] = types.StringValue(id)
+	}
+	out, _ := types.SetValue(types.StringType, vals)
+	return out
+}
 
 func TestBuildBenchmarkRequest_Full(t *testing.T) {
 	data := &BenchmarkResourceModel{
@@ -30,8 +41,9 @@ func TestBuildBenchmarkRequest_Full(t *testing.T) {
 				ODVValue: types.StringNull(),
 			},
 		},
-		TargetDeviceGroup: types.StringValue("group-1"),
-		EnforcementMode:   types.StringValue("audit"),
+		TargetDeviceGroup:  types.StringValue("group-1"),
+		TargetDeviceGroups: types.SetNull(types.StringType),
+		EnforcementMode:    types.StringValue("audit"),
 	}
 
 	req := buildBenchmarkRequest(data)
@@ -85,13 +97,14 @@ func TestBuildBenchmarkRequest_Full(t *testing.T) {
 
 func TestBuildBenchmarkRequest_EmptyRulesAndSources(t *testing.T) {
 	data := &BenchmarkResourceModel{
-		Title:             types.StringValue("Empty"),
-		Description:       types.StringValue(""),
-		SourceBaselineID:  types.StringValue("bl-1"),
-		Sources:           nil,
-		Rules:             nil,
-		TargetDeviceGroup: types.StringValue("dg-1"),
-		EnforcementMode:   types.StringValue("audit"),
+		Title:              types.StringValue("Empty"),
+		Description:        types.StringValue(""),
+		SourceBaselineID:   types.StringValue("bl-1"),
+		Sources:            nil,
+		Rules:              nil,
+		TargetDeviceGroup:  types.StringValue("dg-1"),
+		TargetDeviceGroups: types.SetNull(types.StringType),
+		EnforcementMode:    types.StringValue("audit"),
 	}
 
 	req := buildBenchmarkRequest(data)
@@ -115,8 +128,9 @@ func TestBuildBenchmarkRequest_ODVNull(t *testing.T) {
 				ODVValue: types.StringNull(),
 			},
 		},
-		TargetDeviceGroup: types.StringValue("dg-1"),
-		EnforcementMode:   types.StringValue("audit"),
+		TargetDeviceGroup:  types.StringValue("dg-1"),
+		TargetDeviceGroups: types.SetNull(types.StringType),
+		EnforcementMode:    types.StringValue("audit"),
 	}
 
 	req := buildBenchmarkRequest(data)
@@ -137,13 +151,60 @@ func TestBuildBenchmarkRequest_ODVEmpty(t *testing.T) {
 				ODVValue: types.StringValue(""),
 			},
 		},
-		TargetDeviceGroup: types.StringValue("dg-1"),
-		EnforcementMode:   types.StringValue("audit"),
+		TargetDeviceGroup:  types.StringValue("dg-1"),
+		TargetDeviceGroups: types.SetNull(types.StringType),
+		EnforcementMode:    types.StringValue("audit"),
 	}
 
 	req := buildBenchmarkRequest(data)
 
 	if req.Rules[0].ODV != nil {
 		t.Error("expected nil ODV for empty ODVValue — API rejects odv:{value:\"\"}")
+	}
+}
+
+func TestBuildBenchmarkRequest_PluralTargetDeviceGroups(t *testing.T) {
+	data := &BenchmarkResourceModel{
+		Title:              types.StringValue("Plural Scope"),
+		SourceBaselineID:   types.StringValue("bl-1"),
+		Rules:              nil,
+		Sources:            nil,
+		TargetDeviceGroup:  types.StringNull(),
+		TargetDeviceGroups: setOfStrings("group-a", "group-b", "group-c"),
+		EnforcementMode:    types.StringValue("audit"),
+	}
+
+	req := buildBenchmarkRequest(data)
+
+	if len(req.Target.DeviceGroups) != 3 {
+		t.Fatalf("expected 3 device groups, got %d (%v)", len(req.Target.DeviceGroups), req.Target.DeviceGroups)
+	}
+	seen := map[string]bool{}
+	for _, g := range req.Target.DeviceGroups {
+		seen[g] = true
+	}
+	for _, want := range []string{"group-a", "group-b", "group-c"} {
+		if !seen[want] {
+			t.Errorf("expected device group %q in payload, got %v", want, req.Target.DeviceGroups)
+		}
+	}
+}
+
+func TestBuildBenchmarkRequest_PluralWinsOverSingular(t *testing.T) {
+	// ConflictsWith makes this impossible in practice, but the builder must still
+	// prefer the plural path when both happen to be set — defensive behaviour for
+	// older imported state or programmatic callers.
+	data := &BenchmarkResourceModel{
+		Title:              types.StringValue("Both"),
+		SourceBaselineID:   types.StringValue("bl-1"),
+		TargetDeviceGroup:  types.StringValue("should-be-ignored"),
+		TargetDeviceGroups: setOfStrings("kept"),
+		EnforcementMode:    types.StringValue("audit"),
+	}
+
+	req := buildBenchmarkRequest(data)
+
+	if len(req.Target.DeviceGroups) != 1 || req.Target.DeviceGroups[0] != "kept" {
+		t.Errorf("expected plural to win with ['kept'], got %v", req.Target.DeviceGroups)
 	}
 }

--- a/internal/resources/cbengine/benchmark/model_types.go
+++ b/internal/resources/cbengine/benchmark/model_types.go
@@ -24,6 +24,7 @@ type BenchmarkResourceModel struct {
 	Sources            []SourceModel          `tfsdk:"sources"`
 	Rules              []RuleModel            `tfsdk:"rules"`
 	TargetDeviceGroup  types.String           `tfsdk:"target_device_group"`
+	TargetDeviceGroups types.Set              `tfsdk:"target_device_groups"`
 	EnforcementMode    types.String           `tfsdk:"enforcement_mode"`
 	TenantID           types.String           `tfsdk:"tenant_id"`
 	Deleted            types.Bool             `tfsdk:"deleted"`
@@ -43,6 +44,7 @@ type BenchmarkDataSourceModel struct {
 	Sources            []SourceModel            `tfsdk:"sources"`
 	Rules              []RuleModel              `tfsdk:"rules"`
 	TargetDeviceGroup  types.String             `tfsdk:"target_device_group"`
+	TargetDeviceGroups types.Set                `tfsdk:"target_device_groups"`
 	EnforcementMode    types.String             `tfsdk:"enforcement_mode"`
 	Deleted            types.Bool               `tfsdk:"deleted"`
 	UpdateAvailable    types.Bool               `tfsdk:"update_available"`

--- a/internal/resources/cbengine/benchmark/resource.go
+++ b/internal/resources/cbengine/benchmark/resource.go
@@ -12,6 +12,8 @@ import (
 	"github.com/Jamf-Concepts/jamfplatform-go-sdk/jamfplatform"
 	"github.com/Jamf-Concepts/jamfplatform-go-sdk/jamfplatform/compliancebenchmarks"
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
+	"github.com/hashicorp/terraform-plugin-framework-validators/resourcevalidator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/setvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -19,6 +21,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/listplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/setplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -33,6 +36,7 @@ type BenchmarkResource struct {
 var _ resource.Resource = &BenchmarkResource{}
 var _ resource.ResourceWithImportState = &BenchmarkResource{}
 var _ resource.ResourceWithIdentity = &BenchmarkResource{}
+var _ resource.ResourceWithConfigValidators = &BenchmarkResource{}
 
 const (
 	defaultCreateTimeout = 15 * time.Minute
@@ -250,12 +254,28 @@ func (r *BenchmarkResource) Schema(ctx context.Context, req resource.SchemaReque
 				},
 			},
 			"target_device_group": schema.StringAttribute{
-				MarkdownDescription: "Device group Platform ID targeted by this benchmark. Specified as a string in UUID format. The Platform ID can be sourced from the response body of the /api/v1/groups Jamf Pro API endpoint. Required and immutable for this resource (replace on change).",
-				Required:            true,
-				Validators: []validator.String{stringvalidator.RegexMatches(uuidRegex,
-					"Device group ID must be a valid UUID")},
+				MarkdownDescription: "**Deprecated** — use `target_device_groups` instead. Single device group Platform ID targeted by this benchmark, in UUID format. Mutually exclusive with `target_device_groups`. Immutable (replace on change).",
+				DeprecationMessage:  "Use target_device_groups (set of UUIDs) instead. The singular attribute is retained for backwards compatibility and will be removed in a future major release.",
+				Optional:            true,
+				Validators: []validator.String{
+					stringvalidator.RegexMatches(uuidRegex, "Device group ID must be a valid UUID"),
+					stringvalidator.ConflictsWith(path.MatchRoot("target_device_groups")),
+				},
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"target_device_groups": schema.SetAttribute{
+				MarkdownDescription: "Device group Platform IDs targeted by this benchmark. Specified as a set of UUID strings; Platform IDs can be sourced from the response body of the `/api/v1/groups` Jamf Pro API endpoint. Mutually exclusive with the deprecated `target_device_group`. Immutable (replace on change).",
+				ElementType:         types.StringType,
+				Optional:            true,
+				Validators: []validator.Set{
+					setvalidator.SizeAtLeast(1),
+					setvalidator.ValueStringsAre(stringvalidator.RegexMatches(uuidRegex, "Each device group ID must be a valid UUID")),
+					setvalidator.ConflictsWith(path.MatchRoot("target_device_group")),
+				},
+				PlanModifiers: []planmodifier.Set{
+					setplanmodifier.RequiresReplace(),
 				},
 			},
 			"enforcement_mode": schema.StringAttribute{
@@ -292,6 +312,18 @@ func (r *BenchmarkResource) Schema(ctx context.Context, req resource.SchemaReque
 				Delete: true,
 			}),
 		},
+	}
+}
+
+// ConfigValidators enforces that callers supply exactly one of the singular or
+// plural device-group attributes. ConflictsWith on each attribute already rejects
+// the both-set case; AtLeastOneOf adds the neither-set case.
+func (r *BenchmarkResource) ConfigValidators(ctx context.Context) []resource.ConfigValidator {
+	return []resource.ConfigValidator{
+		resourcevalidator.AtLeastOneOf(
+			path.MatchRoot("target_device_group"),
+			path.MatchRoot("target_device_groups"),
+		),
 	}
 }
 

--- a/internal/resources/cbengine/benchmark/resource_acceptance_test.go
+++ b/internal/resources/cbengine/benchmark/resource_acceptance_test.go
@@ -109,12 +109,24 @@ func TestAccResource_Benchmark_AllRules_Monitor(t *testing.T) {
 	}
 
 	benchmarkTitle := "tf-acc-benchmark-all-rules-" + suffix
-	scopeName := "tf-acc-benchmark-scope-" + suffix
+	scopeNameA := "tf-acc-benchmark-scope-a-" + suffix
+	scopeNameB := "tf-acc-benchmark-scope-b-" + suffix
 
 	ensureBenchmarkCleanup(t, benchmarkTitle)
 
 	config := fmt.Sprintf(`
-		resource "jamfplatform_device_group" "scope" {
+		resource "jamfplatform_device_group" "scope_a" {
+			name        = %q
+			group_type  = "smart"
+			device_type = "computer"
+			criteria = [{
+				criteria = "Serial Number"
+				operator = "like"
+				value    = ""
+			}]
+		}
+
+		resource "jamfplatform_device_group" "scope_b" {
 			name        = %q
 			group_type  = "smart"
 			device_type = "computer"
@@ -133,10 +145,13 @@ func TestAccResource_Benchmark_AllRules_Monitor(t *testing.T) {
 			sources = [%s]
 			rules   = [%s]
 
-			target_device_group = jamfplatform_device_group.scope.id
+			target_device_groups = [
+				jamfplatform_device_group.scope_a.id,
+				jamfplatform_device_group.scope_b.id,
+			]
 			enforcement_mode    = "MONITOR"
 		}
-	`, scopeName, benchmarkTitle, baselineID, strings.Join(sourceBlocks, ",\n"), strings.Join(ruleBlocks, ",\n"))
+	`, scopeNameA, scopeNameB, benchmarkTitle, baselineID, strings.Join(sourceBlocks, ",\n"), strings.Join(ruleBlocks, ",\n"))
 
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testhelpers.AccTestProtoV6ProviderFactories,
@@ -148,6 +163,8 @@ func TestAccResource_Benchmark_AllRules_Monitor(t *testing.T) {
 					resource.TestCheckResourceAttrSet("jamfplatform_cbengine_benchmark.test_all_rules", "id"),
 					resource.TestCheckResourceAttr("jamfplatform_cbengine_benchmark.test_all_rules", "title", benchmarkTitle),
 					resource.TestCheckResourceAttr("jamfplatform_cbengine_benchmark.test_all_rules", "enforcement_mode", "MONITOR"),
+					resource.TestCheckResourceAttr("jamfplatform_cbengine_benchmark.test_all_rules", "target_device_groups.#", "2"),
+					resource.TestCheckNoResourceAttr("jamfplatform_cbengine_benchmark.test_all_rules", "target_device_group"),
 				),
 			},
 		},
@@ -195,12 +212,24 @@ func TestAccResource_Benchmark_CustomRules_MonitorAndEnforce(t *testing.T) {
 	}
 
 	benchmarkTitle := "tf-acc-benchmark-custom-rules-" + suffix
-	scopeName := "tf-acc-benchmark-scope-custom-" + suffix
+	scopeNameA := "tf-acc-benchmark-scope-custom-a-" + suffix
+	scopeNameB := "tf-acc-benchmark-scope-custom-b-" + suffix
 
 	ensureBenchmarkCleanup(t, benchmarkTitle)
 
 	config := fmt.Sprintf(`
-		resource "jamfplatform_device_group" "scope" {
+		resource "jamfplatform_device_group" "scope_a" {
+			name        = %q
+			group_type  = "smart"
+			device_type = "computer"
+			criteria = [{
+				criteria = "Serial Number"
+				operator = "like"
+				value    = ""
+			}]
+		}
+
+		resource "jamfplatform_device_group" "scope_b" {
 			name        = %q
 			group_type  = "smart"
 			device_type = "computer"
@@ -219,10 +248,13 @@ func TestAccResource_Benchmark_CustomRules_MonitorAndEnforce(t *testing.T) {
 			sources = [%s]
 			rules   = [%s]
 
-			target_device_group = jamfplatform_device_group.scope.id
+			target_device_groups = [
+				jamfplatform_device_group.scope_a.id,
+				jamfplatform_device_group.scope_b.id,
+			]
 			enforcement_mode    = "MONITOR_AND_ENFORCE"
 		}
-	`, scopeName, benchmarkTitle, baselineID, strings.Join(sourceBlocks, ",\n"), strings.Join(ruleBlocks, ",\n"))
+	`, scopeNameA, scopeNameB, benchmarkTitle, baselineID, strings.Join(sourceBlocks, ",\n"), strings.Join(ruleBlocks, ",\n"))
 
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testhelpers.AccTestProtoV6ProviderFactories,
@@ -234,6 +266,96 @@ func TestAccResource_Benchmark_CustomRules_MonitorAndEnforce(t *testing.T) {
 					resource.TestCheckResourceAttrSet("jamfplatform_cbengine_benchmark.test_custom", "id"),
 					resource.TestCheckResourceAttr("jamfplatform_cbengine_benchmark.test_custom", "title", benchmarkTitle),
 					resource.TestCheckResourceAttr("jamfplatform_cbengine_benchmark.test_custom", "enforcement_mode", "MONITOR_AND_ENFORCE"),
+					resource.TestCheckResourceAttr("jamfplatform_cbengine_benchmark.test_custom", "target_device_groups.#", "2"),
+				),
+			},
+		},
+	})
+}
+
+// TestAccResource_Benchmark_DeprecatedSingularTarget verifies the deprecated
+// target_device_group attribute still functions end-to-end. Keep this until the
+// attribute is removed in a future major release.
+func TestAccResource_Benchmark_DeprecatedSingularTarget(t *testing.T) {
+	testhelpers.AccPreCheck(t)
+	suffix := testhelpers.RunSuffix()
+
+	ctx := context.Background()
+	c := testhelpers.NewAcceptanceClient(t)
+	cbClient := cbSDK.New(c)
+	baselines, err := cbClient.ListBaselines(ctx)
+	if err != nil {
+		t.Fatalf("Failed to check baselines: %v", err)
+	}
+	if len(baselines.Baselines) == 0 {
+		t.Skip("No baselines available — CB Engine may not be enabled")
+	}
+
+	baselineID := baselines.Baselines[0].BaselineID
+	rules, err := cbClient.GetBaselineRules(ctx, baselineID)
+	if err != nil {
+		t.Fatalf("Failed to get rules: %v", err)
+	}
+	if len(rules.Rules) == 0 {
+		t.Skip("No rules found for baseline")
+	}
+
+	var ruleBlocks []string
+	for i := 0; i < 1 && i < len(rules.Rules); i++ {
+		r := rules.Rules[i]
+		block := fmt.Sprintf(`{ id = %q, enabled = true`, r.ID)
+		if r.ODV != nil {
+			block += fmt.Sprintf(`, odv_value = %q`, r.ODV.Value)
+		}
+		block += " }"
+		ruleBlocks = append(ruleBlocks, block)
+	}
+
+	var sourceBlocks []string
+	for _, s := range rules.Sources {
+		sourceBlocks = append(sourceBlocks, fmt.Sprintf(`{ branch = %q, revision = %q }`, s.Branch, s.Revision))
+	}
+
+	benchmarkTitle := "tf-acc-benchmark-deprecated-singular-" + suffix
+	scopeName := "tf-acc-benchmark-scope-deprecated-" + suffix
+
+	ensureBenchmarkCleanup(t, benchmarkTitle)
+
+	config := fmt.Sprintf(`
+		resource "jamfplatform_device_group" "scope" {
+			name        = %q
+			group_type  = "smart"
+			device_type = "computer"
+			criteria = [{
+				criteria = "Serial Number"
+				operator = "like"
+				value    = ""
+			}]
+		}
+
+		resource "jamfplatform_cbengine_benchmark" "test_deprecated" {
+			title              = %q
+			description        = "Backwards-compatibility regression — uses deprecated singular target."
+			source_baseline_id = %q
+
+			sources = [%s]
+			rules   = [%s]
+
+			target_device_group = jamfplatform_device_group.scope.id
+			enforcement_mode    = "MONITOR"
+		}
+	`, scopeName, benchmarkTitle, baselineID, strings.Join(sourceBlocks, ",\n"), strings.Join(ruleBlocks, ",\n"))
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testhelpers.AccTestProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckBenchmarkResourcesDestroy(t),
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("jamfplatform_cbengine_benchmark.test_deprecated", "id"),
+					resource.TestCheckResourceAttrSet("jamfplatform_cbengine_benchmark.test_deprecated", "target_device_group"),
+					resource.TestCheckNoResourceAttr("jamfplatform_cbengine_benchmark.test_deprecated", "target_device_groups"),
 				),
 			},
 		},

--- a/internal/resources/cbengine/benchmark/schema_test.go
+++ b/internal/resources/cbengine/benchmark/schema_test.go
@@ -40,7 +40,7 @@ func TestBenchmarkResource_Schema(t *testing.T) {
 		t.Errorf("expected schema version 0, got %d", s.Version)
 	}
 
-	requiredAttrs := []string{"title", "sources", "rules", "target_device_group", "enforcement_mode"}
+	requiredAttrs := []string{"title", "sources", "rules", "enforcement_mode"}
 	for _, name := range requiredAttrs {
 		attr, ok := s.Attributes[name]
 		if !ok {
@@ -64,7 +64,7 @@ func TestBenchmarkResource_Schema(t *testing.T) {
 		}
 	}
 
-	optionalAttrs := []string{"description", "source_baseline_id", "timeouts"}
+	optionalAttrs := []string{"description", "source_baseline_id", "timeouts", "target_device_group", "target_device_groups"}
 	for _, name := range optionalAttrs {
 		attr, ok := s.Attributes[name]
 		if !ok {
@@ -74,6 +74,19 @@ func TestBenchmarkResource_Schema(t *testing.T) {
 		if !attr.IsOptional() {
 			t.Errorf("attribute %q should be optional", name)
 		}
+	}
+
+	singular, _ := s.Attributes["target_device_group"].(resourceschema.StringAttribute)
+	if singular.DeprecationMessage == "" {
+		t.Errorf("target_device_group should carry a DeprecationMessage")
+	}
+}
+
+func TestBenchmarkResource_ConfigValidators(t *testing.T) {
+	r := NewBenchmarkResource().(*BenchmarkResource)
+	got := r.ConfigValidators(context.Background())
+	if len(got) != 1 {
+		t.Fatalf("expected 1 resource-level config validator, got %d", len(got))
 	}
 }
 

--- a/internal/resources/cbengine/benchmark/state_builders.go
+++ b/internal/resources/cbengine/benchmark/state_builders.go
@@ -12,6 +12,8 @@ import (
 )
 
 // assignBenchmarkModelFromResponse maps the API response into the Terraform benchmark resource model.
+// For device-group targeting, the API always returns a slice; we preserve whichever attribute the
+// user originally configured (singular or plural) so post-apply state matches plan without drift.
 func assignBenchmarkModelFromResponse(model *BenchmarkResourceModel, bench *compliancebenchmarks.BenchmarkResponseV2) {
 	if model == nil || bench == nil {
 		return
@@ -27,15 +29,36 @@ func assignBenchmarkModelFromResponse(model *BenchmarkResourceModel, bench *comp
 	model.LastUpdatedAt = types.StringValue(bench.LastUpdatedAt.Format(time.RFC3339))
 	model.Sources = buildSourceModels(bench.Sources)
 	model.Rules = buildRuleModels(bench.Rules)
-	if bench.Target != nil {
-		model.TargetDeviceGroup = buildTargetDeviceGroup(bench.Target.DeviceGroups)
-	} else {
-		model.TargetDeviceGroup = types.StringNull()
-	}
+	assignTargetDeviceGroups(model, bench)
 	model.EnforcementMode = types.StringValue(bench.EnforcementMode)
 }
 
+// assignTargetDeviceGroups populates whichever of the two target-device-group attributes
+// the user configured. Singular path: keep TargetDeviceGroup populated, leave plural null.
+// Plural path: keep TargetDeviceGroups populated, leave singular null. If neither is
+// currently set (e.g. import), default to the plural representation.
+func assignTargetDeviceGroups(model *BenchmarkResourceModel, bench *compliancebenchmarks.BenchmarkResponseV2) {
+	var apiGroups []string
+	if bench.Target != nil {
+		apiGroups = bench.Target.DeviceGroups
+	}
+
+	usedSingular := !model.TargetDeviceGroup.IsNull() && !model.TargetDeviceGroup.IsUnknown()
+	usedPlural := !model.TargetDeviceGroups.IsNull() && !model.TargetDeviceGroups.IsUnknown()
+
+	switch {
+	case usedSingular && !usedPlural:
+		model.TargetDeviceGroup = buildTargetDeviceGroup(apiGroups)
+		model.TargetDeviceGroups = types.SetNull(types.StringType)
+	default:
+		// Plural path, neither configured (import / drift), or both (impossible per schema).
+		model.TargetDeviceGroups = buildTargetDeviceGroupsSet(apiGroups)
+		model.TargetDeviceGroup = types.StringNull()
+	}
+}
+
 // assignBenchmarkDataSourceFromResponse maps the API response into the Terraform benchmark data source model.
+// Data sources always populate both attributes — readers can use whichever shape they prefer.
 func assignBenchmarkDataSourceFromResponse(model *BenchmarkDataSourceModel, bench *compliancebenchmarks.BenchmarkResponseV2) {
 	if model == nil || bench == nil {
 		return
@@ -47,11 +70,12 @@ func assignBenchmarkDataSourceFromResponse(model *BenchmarkDataSourceModel, benc
 	model.Description = types.StringValue(bench.Description)
 	model.Sources = buildSourceModels(bench.Sources)
 	model.Rules = buildRuleModels(bench.Rules)
+	var apiGroups []string
 	if bench.Target != nil {
-		model.TargetDeviceGroup = buildTargetDeviceGroup(bench.Target.DeviceGroups)
-	} else {
-		model.TargetDeviceGroup = types.StringNull()
+		apiGroups = bench.Target.DeviceGroups
 	}
+	model.TargetDeviceGroup = buildTargetDeviceGroup(apiGroups)
+	model.TargetDeviceGroups = buildTargetDeviceGroupsSet(apiGroups)
 	model.EnforcementMode = types.StringValue(bench.EnforcementMode)
 	model.Deleted = types.BoolValue(bench.Deleted)
 	model.UpdateAvailable = types.BoolValue(bench.UpdateAvailable)
@@ -111,6 +135,20 @@ func buildTargetDeviceGroup(deviceGroups []string) types.String {
 		return types.StringValue(deviceGroups[0])
 	}
 	return types.StringNull()
+}
+
+// buildTargetDeviceGroupsSet converts the API slice into a Terraform set of strings,
+// returning a null set when the API responded with no groups.
+func buildTargetDeviceGroupsSet(deviceGroups []string) types.Set {
+	if len(deviceGroups) == 0 {
+		return types.SetNull(types.StringType)
+	}
+	vals := make([]attr.Value, len(deviceGroups))
+	for i, g := range deviceGroups {
+		vals[i] = types.StringValue(g)
+	}
+	result, _ := types.SetValue(types.StringType, vals)
+	return result
 }
 
 // buildStringList converts a string slice into a Terraform list of strings, returning null for empty.

--- a/internal/resources/cbengine/benchmark/state_builders_test.go
+++ b/internal/resources/cbengine/benchmark/state_builders_test.go
@@ -8,11 +8,18 @@ import (
 	"time"
 
 	"github.com/Jamf-Concepts/jamfplatform-go-sdk/jamfplatform/compliancebenchmarks"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
 func TestAssignBenchmarkModelFromResponse_Full(t *testing.T) {
-	model := &BenchmarkResourceModel{}
+	// Pre-populate the singular slot so assignTargetDeviceGroups takes the
+	// backwards-compat path and writes the API value into TargetDeviceGroup
+	// rather than the plural set.
+	model := &BenchmarkResourceModel{
+		TargetDeviceGroup:  types.StringValue("placeholder"),
+		TargetDeviceGroups: types.SetNull(types.StringType),
+	}
 	lastUpdated, _ := time.Parse(time.RFC3339, "2025-06-15T10:30:00Z")
 	bench := &compliancebenchmarks.BenchmarkResponseV2{
 		BenchmarkID:     "bench-1",
@@ -267,10 +274,76 @@ func TestBuildRuleModel_ODVWithoutValidation(t *testing.T) {
 	}
 }
 
+func TestAssignBenchmarkModelFromResponse_PluralPath(t *testing.T) {
+	// Model carries TargetDeviceGroups pre-set (the plural-path signal).
+	// State assignment must keep singular null and populate the plural set
+	// with every group the API returned.
+	preset, _ := types.SetValue(types.StringType, []attr.Value{types.StringValue("placeholder")})
+	model := &BenchmarkResourceModel{
+		TargetDeviceGroup:  types.StringNull(),
+		TargetDeviceGroups: preset,
+	}
+	bench := &compliancebenchmarks.BenchmarkResponseV2{
+		BenchmarkID: "bench-plural",
+		Target:      &compliancebenchmarks.TargetV2{DeviceGroups: []string{"g1", "g2", "g3"}},
+	}
+
+	assignBenchmarkModelFromResponse(model, bench)
+
+	if !model.TargetDeviceGroup.IsNull() {
+		t.Errorf("expected TargetDeviceGroup null when plural path active, got %q", model.TargetDeviceGroup.ValueString())
+	}
+	if model.TargetDeviceGroups.IsNull() {
+		t.Fatal("expected TargetDeviceGroups populated")
+	}
+	if len(model.TargetDeviceGroups.Elements()) != 3 {
+		t.Errorf("expected 3 elements in TargetDeviceGroups, got %d", len(model.TargetDeviceGroups.Elements()))
+	}
+}
+
+func TestAssignBenchmarkModelFromResponse_ImportDefaultsToPlural(t *testing.T) {
+	// Both attribute slots null/unknown (typical import). State builder should
+	// default to populating the plural set so imports surface every group.
+	model := &BenchmarkResourceModel{
+		TargetDeviceGroup:  types.StringNull(),
+		TargetDeviceGroups: types.SetNull(types.StringType),
+	}
+	bench := &compliancebenchmarks.BenchmarkResponseV2{
+		BenchmarkID: "bench-import",
+		Target:      &compliancebenchmarks.TargetV2{DeviceGroups: []string{"g1"}},
+	}
+
+	assignBenchmarkModelFromResponse(model, bench)
+
+	if !model.TargetDeviceGroup.IsNull() {
+		t.Errorf("expected singular null on import, got %q", model.TargetDeviceGroup.ValueString())
+	}
+	if model.TargetDeviceGroups.IsNull() || len(model.TargetDeviceGroups.Elements()) != 1 {
+		t.Errorf("expected plural populated on import")
+	}
+}
+
 func TestBuildTargetDeviceGroup(t *testing.T) {
 	result := buildTargetDeviceGroup([]string{"group-a", "group-b"})
 	if result.ValueString() != "group-a" {
 		t.Errorf("expected 'group-a', got %q", result.ValueString())
+	}
+}
+
+func TestBuildTargetDeviceGroupsSet(t *testing.T) {
+	result := buildTargetDeviceGroupsSet([]string{"a", "b", "c"})
+	if result.IsNull() {
+		t.Fatal("expected non-null set")
+	}
+	if len(result.Elements()) != 3 {
+		t.Errorf("expected 3 elements, got %d", len(result.Elements()))
+	}
+}
+
+func TestBuildTargetDeviceGroupsSet_Empty(t *testing.T) {
+	result := buildTargetDeviceGroupsSet(nil)
+	if !result.IsNull() {
+		t.Error("expected null set for empty input")
 	}
 }
 


### PR DESCRIPTION
## Summary

- Adds `target_device_groups` (Set of UUID strings) on the `jamfplatform_cbengine_benchmark` resource and data source. The SDK request body already accepted `[]string`; the provider was artificially narrowing scope to a single ID.
- Deprecates `target_device_group` (singular String). Both attributes remain `Optional` with mutual `ConflictsWith` plus a resource-level `AtLeastOneOf`, so existing configurations keep working unchanged; new configurations should use the set form. Both still `RequiresReplace` — the SDK exposes no `UpdateBenchmark`.
- State builder preserves whichever attribute the user configured: singular path keeps the plural set null, plural path keeps the singular string null. Imports default to the plural representation.

## Test plan

- [x] `go test ./...` — passes (`gofmt` ran on benchmark files directly; `make fmt` on `main` recurses into stale `.claude/worktrees/` and was skipped — fix lives on `feat/pro-expansion`).
- [x] `golangci-lint run` — zero issues.
- [x] `make generate` — docs regenerated for `cbengine_benchmark` resource + data source.
- [x] Acceptance, against tenant: `TF_ACC=1 go test -tags=acceptance -v -timeout 30m -run \"TestAcc.*Benchmark.*\" ./internal/resources/cbengine/benchmark/...` — all green. Coverage includes:
  - `TestAccResource_Benchmark_AllRules_Monitor` — two device-group fixtures targeted via the new set.
  - `TestAccResource_Benchmark_CustomRules_MonitorAndEnforce` — same, with `MONITOR_AND_ENFORCE`.
  - `TestAccResource_Benchmark_DeprecatedSingularTarget` — backwards-compatibility regression on the deprecated singular path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)