### PR TITLE
feat(pro/policy): Phase 2.6 section coverage + validators + scope wiring + account_maintenance

### DIFF
--- a/docs/resources/pro_policy.md
+++ b/docs/resources/pro_policy.md
@@ -3,12 +3,12 @@
 page_title: "jamfplatform_pro_policy Resource - terraform-provider-jamfplatform"
 subcategory: ""
 description: |-
-  Manages a Jamf Pro classic policy. Supports the full 13-section policy payload (general, scope, self_service, package_configuration, scripts, printers, dock_items, account_maintenance, reboot, maintenance, files_processes, user_interaction, disk_encryption). Scope targets are flat sets of numeric Jamf Pro classic IDs — interpolate jamfplatform_device_group.x.jamf_pro_id to bridge from Platform Services. The scope.limit_to_users block is intentionally omitted in v1 pending an upstream SDK fix.
+  Manages a Jamf Pro classic policy. Supports the full 13-section policy payload (general, scope, self_service, package_configuration, scripts, printers, dock_items, account_maintenance, reboot, maintenance, files_processes, user_interaction, disk_encryption). Scope targets are flat sets of numeric Jamf Pro classic IDs — interpolate jamfplatform_device_group.x.jamf_pro_id to bridge from Platform Services. The scope.limit_to_users block is intentionally omitted in v1 pending an upstream SDK fix. The classic <software_update> policy block is intentionally not modelled: software update via classic policy is an obsolete delivery path (superseded by MDM InstallApplication / ScheduleOSUpdate and the Jamf Pro patch-management surface). If you need to drive OS or app updates from Terraform, reach for the patch / DDM resources instead.
 ---
 
 # jamfplatform_pro_policy (Resource)
 
-Manages a Jamf Pro classic policy. Supports the full 13-section policy payload (general, scope, self_service, package_configuration, scripts, printers, dock_items, account_maintenance, reboot, maintenance, files_processes, user_interaction, disk_encryption). Scope targets are flat sets of numeric Jamf Pro classic IDs — interpolate `jamfplatform_device_group.x.jamf_pro_id` to bridge from Platform Services. The `scope.limit_to_users` block is intentionally omitted in v1 pending an upstream SDK fix.
+Manages a Jamf Pro classic policy. Supports the full 13-section policy payload (general, scope, self_service, package_configuration, scripts, printers, dock_items, account_maintenance, reboot, maintenance, files_processes, user_interaction, disk_encryption). Scope targets are flat sets of numeric Jamf Pro classic IDs — interpolate `jamfplatform_device_group.x.jamf_pro_id` to bridge from Platform Services. The `scope.limit_to_users` block is intentionally omitted in v1 pending an upstream SDK fix. The classic `<software_update>` policy block is **intentionally not modelled**: software update via classic policy is an obsolete delivery path (superseded by MDM `InstallApplication` / `ScheduleOSUpdate` and the Jamf Pro patch-management surface). If you need to drive OS or app updates from Terraform, reach for the patch / DDM resources instead.
 
 ## Example Usage
 
@@ -189,14 +189,14 @@ Optional:
 
 Optional:
 
-- `action` (String) Account action (`Create`, `Reset`, `Delete`, `DisableFileVault2`).
+- `action` (String) Account action. Wire-accepted values: `Create`, `Reset`, `Delete`, `DisableFileVault` (the classic UI labels the last action "Disable FileVault"; the wire string is `DisableFileVault` without a trailing `2` despite older documentation suggesting otherwise — confirmed against policy 6791 round-trip).
 - `admin` (Boolean) Whether the account is an admin.
-- `archive_home_directory` (Boolean) Archive the home directory on deletion.
-- `archive_home_directory_to` (String) Destination for the archived home directory.
+- `archive_home_directory_to` (String) Destination for the archived home directory. Only meaningful when `permanently_delete_home_directory = false`.
 - `filevault_enabled` (Boolean) Whether FileVault 2 is enabled for the account.
 - `hint` (String) Password hint.
 - `home` (String) Home directory path.
-- `password` (String, Sensitive) Plaintext password. Sensitive — surfaces in state until WriteOnly support lands.
+- `password` (String, Sensitive) Plaintext password used by `Create` and `Reset` actions. Sensitive — plaintext surfaces in state because the Jamf classic API does not echo it back; the provider preserves the user-supplied value to satisfy the framework's plan/state consistency check. The companion `password_sha256` attribute carries the server's sentinel hash.
+- `permanently_delete_home_directory` (Boolean) Permanently delete the home directory when `action = "Delete"`. When true, the home is removed; when false (or unset), the home is archived to `archive_home_directory_to`. The classic wire field is the inverse boolean `<archive_home_directory>` — the provider translates at the input/output boundary so the Terraform-facing semantic mirrors the Jamf Pro UI checkbox label "Permanently delete home directory".
 - `picture` (String) Account picture path.
 - `realname` (String) Account real (full) name.
 - `secure_token_allowed` (Boolean) Whether the account is allowed to hold a Secure Token.
@@ -225,7 +225,7 @@ Optional:
 Optional:
 
 - `action` (String) Management account action (e.g. `doNotChange`, `rotate`).
-- `managed_password` (String, Sensitive) Plaintext managed password (Sensitive).
+- `managed_password` (String, Sensitive) Plaintext managed password. Sensitive — plaintext surfaces in state because the classic API never echoes it back. Follow-up: migrate to `WriteOnly` once the broader policy resource adopts it.
 - `managed_password_length` (Number) Length used when randomly generating the managed password.
 
 
@@ -235,7 +235,7 @@ Optional:
 Optional:
 
 - `of_mode` (String) Open Firmware mode (`command` or `full`).
-- `of_password` (String, Sensitive) Plaintext OF/EFI password (Sensitive).
+- `of_password` (String, Sensitive) Plaintext Open Firmware / EFI password. Sensitive — plaintext surfaces in state because the classic API never echoes it back. Follow-up: migrate to `WriteOnly` once the broader policy resource adopts it.
 
 Read-Only:
 

--- a/docs/resources/pro_policy.md
+++ b/docs/resources/pro_policy.md
@@ -96,7 +96,7 @@ resource "jamfplatform_pro_policy" "universal" {
 - `scripts` (Attributes) Scripts to run as part of the policy. (see [below for nested schema](#nestedatt--scripts))
 - `self_service` (Attributes) Self Service integration. The classic wire carries the notification bool as `<notification>` and the delivery method as the sibling `<notification_type>` element — the provider models them as `notification_enabled` (bool) and `notification_type` (string). (see [below for nested schema](#nestedatt--self_service))
 - `timeouts` (Attributes) (see [below for nested schema](#nestedatt--timeouts))
-- `user_interaction` (Attributes) User interaction prompts shown around policy execution. (see [below for nested schema](#nestedatt--user_interaction))
+- `user_interaction` (Attributes) User interaction prompts shown around policy execution. Cross-field rules: `allow_users_to_defer = false` forbids both deferral fields; `allow_deferral_until_utc` and `allow_deferral_minutes` are mutually exclusive (transitioning between forms requires destroy+recreate). (see [below for nested schema](#nestedatt--user_interaction))
 
 ### Read-Only
 
@@ -505,8 +505,8 @@ Optional:
 
 Optional:
 
-- `allow_deferral_minutes` (Number) Maximum deferral duration in minutes.
-- `allow_deferral_until_utc` (String) Maximum deferral cut-off in UTC ISO-8601.
+- `allow_deferral_minutes` (Number) Maximum deferral duration in minutes. Must be a positive multiple of 1440 (one day) — the classic API rejects any other value with HTTP 409. Mutually exclusive with `allow_deferral_until_utc`.
+- `allow_deferral_until_utc` (String) Maximum deferral cut-off in UTC ISO-8601. Mutually exclusive with `allow_deferral_minutes`.
 - `allow_users_to_defer` (Boolean) Allow the user to defer the policy.
 - `message_finish` (String) Message displayed after the policy completes.
 - `message_start` (String) Message displayed before the policy runs.

--- a/docs/resources/pro_policy.md
+++ b/docs/resources/pro_policy.md
@@ -92,7 +92,7 @@ resource "jamfplatform_pro_policy" "universal" {
 - `package_configuration` (Attributes) Packages to install / cache / remove. (see [below for nested schema](#nestedatt--package_configuration))
 - `printers` (Attributes) Printers to install or remove. The classic API returns a `size` field — Computed. (see [below for nested schema](#nestedatt--printers))
 - `reboot` (Attributes) Reboot configuration after the policy completes. (see [below for nested schema](#nestedatt--reboot))
-- `scope` (Attributes) Policy scope. Targets are flat sets of numeric Jamf Pro classic IDs; interpolate `jamfplatform_device_group.<x>.jamf_pro_id` to bridge from Platform Services UUIDs. Setting `all_computers = true` forbids `computer_ids`, `computer_group_ids`, `building_ids`, `department_ids`. An equivalent `all_jss_users` attribute is intentionally omitted in v1 — the underlying SDK does not expose the field, so a no-op would silently scope to zero users. (see [below for nested schema](#nestedatt--scope))
+- `scope` (Attributes) Policy scope. Targets are flat sets of numeric Jamf Pro classic IDs; interpolate `jamfplatform_device_group.<x>.jamf_pro_id` to bridge from Platform Services UUIDs. Setting `all_computers = true` forbids `computer_ids`, `computer_group_ids`, `building_ids`, `department_ids`. Setting `all_jss_users = true` forbids `jss_user_ids` and `jss_user_group_ids`. (see [below for nested schema](#nestedatt--scope))
 - `scripts` (Attributes) Scripts to run as part of the policy. (see [below for nested schema](#nestedatt--scripts))
 - `self_service` (Attributes) Self Service integration. The classic wire carries the notification bool as `<notification>` and the delivery method as the sibling `<notification_type>` element — the provider models them as `notification_enabled` (bool) and `notification_type` (string). (see [below for nested schema](#nestedatt--self_service))
 - `timeouts` (Attributes) (see [below for nested schema](#nestedatt--timeouts))
@@ -381,6 +381,7 @@ Optional:
 Optional:
 
 - `all_computers` (Boolean) Scope the policy to every computer in the tenant. Forbids per-computer / per-group / per-building / per-department targets when true.
+- `all_jss_users` (Boolean) Scope the policy to every JSS user in the tenant. Forbids per-user / per-user-group targets when true.
 - `building_ids` (Set of String) Set of Jamf Pro classic building IDs.
 - `computer_group_ids` (Set of String) Set of Jamf Pro classic computer group IDs.
 - `computer_ids` (Set of String) Set of Jamf Pro classic computer IDs.

--- a/docs/resources/pro_policy.md
+++ b/docs/resources/pro_policy.md
@@ -313,6 +313,7 @@ Optional:
 
 Optional:
 
+- `distribution_point` (String) Name of the file share distribution point to use for the policy. Wire field `<package_configuration><distribution_point>`. Server echoes the configured DP name (e.g. `Dummy DP`); omit to inherit the tenant default.
 - `packages` (Attributes Set) Set of package assignments. Each item identifies the package by classic ID; `name` is server-derived. `action` is one of `Install`, `Cache`, `Install Cached`, `Uninstall`. (see [below for nested schema](#nestedatt--package_configuration--packages))
 
 <a id="nestedatt--package_configuration--packages"></a>

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/Jamf-Concepts/terraform-provider-jamfplatform
 go 1.26.3
 
 require (
-	github.com/Jamf-Concepts/jamfplatform-go-sdk v0.8.1-0.20260524105800-d7d755d2a450
+	github.com/Jamf-Concepts/jamfplatform-go-sdk v0.8.1-0.20260524114538-46aec40edb28
 	github.com/hashicorp/terraform-plugin-framework v1.19.0
 	github.com/hashicorp/terraform-plugin-framework-timeouts v0.7.0
 	github.com/hashicorp/terraform-plugin-framework-validators v0.19.0

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,8 @@ github.com/Jamf-Concepts/jamfplatform-go-sdk v0.8.1-0.20260523154048-5df6cb9c8f2
 github.com/Jamf-Concepts/jamfplatform-go-sdk v0.8.1-0.20260523154048-5df6cb9c8f21/go.mod h1:0EB92TbSfGjVEEF9KB2x/uv9HK4kRIfTfjmFmUdWO38=
 github.com/Jamf-Concepts/jamfplatform-go-sdk v0.8.1-0.20260524105800-d7d755d2a450 h1:StDqAxqMIR/XEu0LLTgBIfqfkTbQzR3c7p0AePD+dHk=
 github.com/Jamf-Concepts/jamfplatform-go-sdk v0.8.1-0.20260524105800-d7d755d2a450/go.mod h1:0EB92TbSfGjVEEF9KB2x/uv9HK4kRIfTfjmFmUdWO38=
+github.com/Jamf-Concepts/jamfplatform-go-sdk v0.8.1-0.20260524114538-46aec40edb28 h1:GdfXLQ6TTaPQfoqWcRG2IyrHYSUBGbi0eq02l+HB80I=
+github.com/Jamf-Concepts/jamfplatform-go-sdk v0.8.1-0.20260524114538-46aec40edb28/go.mod h1:0EB92TbSfGjVEEF9KB2x/uv9HK4kRIfTfjmFmUdWO38=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
 github.com/ProtonMail/go-crypto v1.4.1 h1:9RfcZHqEQUvP8RzecWEUafnZVtEvrBVL9BiF67IQOfM=

--- a/internal/resources/pro/policies/policy/helpers.go
+++ b/internal/resources/pro/policies/policy/helpers.go
@@ -72,6 +72,25 @@ func preferCurrentStringPointer(api *string, current types.String) types.String 
 	return types.StringValue(*api)
 }
 
+// preferServerOrCurrentString returns the server value when present and
+// non-empty, otherwise the prior state value. Used for Computed string
+// attributes the server intermittently fails to echo on Update —
+// substituting the prior known state value avoids a Known → null (or
+// Known → "") transition that would otherwise trip the framework's
+// "produced inconsistent result after apply" check when the Computed
+// attribute is part of plan. The classic /policies endpoint has been
+// observed returning both `nil` and `""` for the same SHA field on
+// successive Update round-trips, so both cases collapse to "use prior".
+func preferServerOrCurrentString(api *string, current types.String) types.String {
+	if api != nil && *api != "" {
+		return types.StringValue(*api)
+	}
+	if !current.IsNull() && !current.IsUnknown() {
+		return current
+	}
+	return types.StringNull()
+}
+
 // preferCurrentBoolPointer is the bool sibling of preferCurrentStringPointer.
 func preferCurrentBoolPointer(api *bool, current types.Bool) types.Bool {
 	if helpers.IsConfiguredValue(current) {
@@ -102,6 +121,28 @@ func optionalBoolPointer(value types.Bool) *bool {
 	}
 	v := value.ValueBool()
 	return &v
+}
+
+// invertOptionalBoolPointer is optionalBoolPointer with the value negated.
+// Used to translate a user-facing boolean attribute into its inverse on the
+// wire (e.g. permanently_delete_home_directory ↔ archive_home_directory).
+// Null/unknown still collapses to nil so the wire emits no element.
+func invertOptionalBoolPointer(value types.Bool) *bool {
+	if value.IsNull() || value.IsUnknown() {
+		return nil
+	}
+	v := !value.ValueBool()
+	return &v
+}
+
+// invertBoolPointerValueOrNull is the state-side inverse of
+// invertOptionalBoolPointer. A nil server pointer becomes null state; a
+// non-nil pointer becomes its negated TF Bool value.
+func invertBoolPointerValueOrNull(b *bool) types.Bool {
+	if b == nil {
+		return types.BoolNull()
+	}
+	return types.BoolValue(!*b)
 }
 
 // optionalInt64ToInt projects a TF Int64 into a *int suitable for SDK

--- a/internal/resources/pro/policies/policy/input_builders.go
+++ b/internal/resources/pro/policies/policy/input_builders.go
@@ -180,6 +180,7 @@ func buildPolicyScope(ctx context.Context, m *PolicyScopeModel) (*proclassic.Pol
 	var diags diag.Diagnostics
 	s := &proclassic.PolicyPostScope{
 		AllComputers: optionalBoolPointer(m.AllComputers),
+		AllJssUsers:  optionalBoolPointer(m.AllJssUsers),
 	}
 
 	computers, d := scope.BuildIDSlice(ctx, m.ComputerIDs, func(id int) proclassic.PolicyScopeComputersComputerItem {
@@ -245,9 +246,10 @@ func buildPolicyScope(ctx context.Context, m *PolicyScopeModel) (*proclassic.Pol
 	// Omission semantics (SCOPE_SPIKE §6.5): collapse to nil when every child
 	// pointer is nil so the wire payload omits <scope> entirely rather than
 	// emitting an empty <scope></scope> element.
-	if s.AllComputers == nil && s.Computers == nil && s.ComputerGroups == nil &&
-		s.Buildings == nil && s.Departments == nil && s.JssUsers == nil &&
-		s.JssUserGroups == nil && s.Limitations == nil && s.Exclusions == nil {
+	if s.AllComputers == nil && s.AllJssUsers == nil && s.Computers == nil &&
+		s.ComputerGroups == nil && s.Buildings == nil && s.Departments == nil &&
+		s.JssUsers == nil && s.JssUserGroups == nil && s.Limitations == nil &&
+		s.Exclusions == nil {
 		return nil, diags
 	}
 	return s, diags

--- a/internal/resources/pro/policies/policy/input_builders.go
+++ b/internal/resources/pro/policies/policy/input_builders.go
@@ -435,23 +435,28 @@ func buildPolicySelfService(m *PolicySelfServiceModel) *proclassic.PolicyPostSel
 }
 
 func buildPolicyPackageConfiguration(m *PolicyPackageConfigurationModel) *proclassic.PolicyPostPackageConfiguration {
-	if len(m.Packages) == 0 {
+	dp := helpers.OptionalStringPointer(m.DistributionPoint)
+	if len(m.Packages) == 0 && dp == nil {
 		return nil
 	}
-	items := make([]proclassic.PolicyPackageConfigurationPackagesPackageItem, 0, len(m.Packages))
-	for _, p := range m.Packages {
-		items = append(items, proclassic.PolicyPackageConfigurationPackagesPackageItem{
-			ID:            stringIDPtr(p.ID),
-			Name:          helpers.OptionalStringPointer(p.Name),
-			Action:        helpers.OptionalStringPointer(p.Action),
-			Fut:           optionalBoolPointer(p.Fut),
-			Feu:           optionalBoolPointer(p.Feu),
-			UpdateAutorun: optionalBoolPointer(p.UpdateAutorun),
-		})
+	out := &proclassic.PolicyPostPackageConfiguration{
+		DistributionPoint: dp,
 	}
-	return &proclassic.PolicyPostPackageConfiguration{
-		Packages: &proclassic.PolicyPackageConfigurationPackages{Package: &items},
+	if len(m.Packages) > 0 {
+		items := make([]proclassic.PolicyPackageConfigurationPackagesPackageItem, 0, len(m.Packages))
+		for _, p := range m.Packages {
+			items = append(items, proclassic.PolicyPackageConfigurationPackagesPackageItem{
+				ID:            stringIDPtr(p.ID),
+				Name:          helpers.OptionalStringPointer(p.Name),
+				Action:        helpers.OptionalStringPointer(p.Action),
+				Fut:           optionalBoolPointer(p.Fut),
+				Feu:           optionalBoolPointer(p.Feu),
+				UpdateAutorun: optionalBoolPointer(p.UpdateAutorun),
+			})
+		}
+		out.Packages = &proclassic.PolicyPackageConfigurationPackages{Package: &items}
 	}
+	return out
 }
 
 func buildPolicyScripts(m *PolicyScriptsModel) *proclassic.PolicyPostScripts {

--- a/internal/resources/pro/policies/policy/input_builders.go
+++ b/internal/resources/pro/policies/policy/input_builders.go
@@ -532,7 +532,7 @@ func buildPolicyAccountMaintenance(m *PolicyAccountMaintenanceModel) *proclassic
 				Username:               helpers.OptionalStringPointer(a.Username),
 				Realname:               helpers.OptionalStringPointer(a.Realname),
 				Password:               helpers.OptionalStringPointer(a.Password),
-				ArchiveHomeDirectory:   optionalBoolPointer(a.ArchiveHomeDirectory),
+				ArchiveHomeDirectory:   invertOptionalBoolPointer(a.PermanentlyDeleteHomeDirectory),
 				ArchiveHomeDirectoryTo: helpers.OptionalStringPointer(a.ArchiveHomeDirectoryTo),
 				Home:                   helpers.OptionalStringPointer(a.Home),
 				Hint:                   helpers.OptionalStringPointer(a.Hint),

--- a/internal/resources/pro/policies/policy/input_builders_test.go
+++ b/internal/resources/pro/policies/policy/input_builders_test.go
@@ -155,6 +155,7 @@ func TestBuildPolicyInput_PackagesAndScripts(t *testing.T) {
 	plan := PolicyResourceModel{
 		General: &PolicyGeneralModel{Name: types.StringValue("tf-acc-pkg")},
 		PackageConfiguration: &PolicyPackageConfigurationModel{
+			DistributionPoint: types.StringValue("Dummy DP"),
 			Packages: []PolicyPackageItemModel{
 				{ID: types.StringValue("100"), Action: types.StringValue("Install")},
 			},
@@ -172,7 +173,35 @@ func TestBuildPolicyInput_PackagesAndScripts(t *testing.T) {
 	if got.PackageConfiguration == nil || got.PackageConfiguration.Packages == nil {
 		t.Fatalf("expected packages populated")
 	}
+	if got.PackageConfiguration.DistributionPoint == nil || *got.PackageConfiguration.DistributionPoint != "Dummy DP" {
+		t.Fatalf("expected distribution_point=Dummy DP, got %v", got.PackageConfiguration.DistributionPoint)
+	}
 	if got.Scripts == nil || got.Scripts.Script == nil {
 		t.Fatalf("expected scripts populated")
+	}
+}
+
+func TestBuildPolicyPackageConfiguration_DistributionPointOnly(t *testing.T) {
+	t.Parallel()
+	m := &PolicyPackageConfigurationModel{
+		DistributionPoint: types.StringValue("Dummy DP"),
+	}
+	got := buildPolicyPackageConfiguration(m)
+	if got == nil {
+		t.Fatalf("expected non-nil package_configuration when distribution_point is set")
+	}
+	if got.Packages != nil {
+		t.Fatalf("expected packages nil when no package items provided, got %+v", got.Packages)
+	}
+	if got.DistributionPoint == nil || *got.DistributionPoint != "Dummy DP" {
+		t.Fatalf("expected distribution_point=Dummy DP, got %v", got.DistributionPoint)
+	}
+}
+
+func TestBuildPolicyPackageConfiguration_EmptyReturnsNil(t *testing.T) {
+	t.Parallel()
+	m := &PolicyPackageConfigurationModel{}
+	if got := buildPolicyPackageConfiguration(m); got != nil {
+		t.Fatalf("expected nil for empty package_configuration, got %+v", got)
 	}
 }

--- a/internal/resources/pro/policies/policy/model_types.go
+++ b/internal/resources/pro/policies/policy/model_types.go
@@ -102,6 +102,7 @@ type PolicyGeneralOverrideDefaultsModel struct {
 // internal/common/scope helper. See SCOPE_SPIKE.md §5 for the canonical rules.
 type PolicyScopeModel struct {
 	AllComputers     types.Bool                   `tfsdk:"all_computers"`
+	AllJssUsers      types.Bool                   `tfsdk:"all_jss_users"`
 	ComputerIDs      types.Set                    `tfsdk:"computer_ids"`
 	ComputerGroupIDs types.Set                    `tfsdk:"computer_group_ids"`
 	BuildingIDs      types.Set                    `tfsdk:"building_ids"`

--- a/internal/resources/pro/policies/policy/model_types.go
+++ b/internal/resources/pro/policies/policy/model_types.go
@@ -171,7 +171,8 @@ type PolicySelfServiceCategoryModel struct {
 
 // PolicyPackageConfigurationModel models <policy><package_configuration>.
 type PolicyPackageConfigurationModel struct {
-	Packages []PolicyPackageItemModel `tfsdk:"packages"`
+	DistributionPoint types.String             `tfsdk:"distribution_point"`
+	Packages          []PolicyPackageItemModel `tfsdk:"packages"`
 }
 
 // PolicyPackageItemModel models a single <package>.

--- a/internal/resources/pro/policies/policy/model_types.go
+++ b/internal/resources/pro/policies/policy/model_types.go
@@ -245,19 +245,19 @@ type PolicyAccountMaintenanceModel struct {
 // Sensitive (no WriteOnly in v1; tracked as follow-up); password_sha256 is
 // Computed-only.
 type PolicyAccountItemModel struct {
-	Action                 types.String `tfsdk:"action"`
-	Username               types.String `tfsdk:"username"`
-	Realname               types.String `tfsdk:"realname"`
-	Password               types.String `tfsdk:"password"`
-	PasswordSha256         types.String `tfsdk:"password_sha256"`
-	ArchiveHomeDirectory   types.Bool   `tfsdk:"archive_home_directory"`
-	ArchiveHomeDirectoryTo types.String `tfsdk:"archive_home_directory_to"`
-	Home                   types.String `tfsdk:"home"`
-	Hint                   types.String `tfsdk:"hint"`
-	Picture                types.String `tfsdk:"picture"`
-	Admin                  types.Bool   `tfsdk:"admin"`
-	FilevaultEnabled       types.Bool   `tfsdk:"filevault_enabled"`
-	SecureTokenAllowed     types.Bool   `tfsdk:"secure_token_allowed"`
+	Action                         types.String `tfsdk:"action"`
+	Username                       types.String `tfsdk:"username"`
+	Realname                       types.String `tfsdk:"realname"`
+	Password                       types.String `tfsdk:"password"`
+	PasswordSha256                 types.String `tfsdk:"password_sha256"`
+	PermanentlyDeleteHomeDirectory types.Bool   `tfsdk:"permanently_delete_home_directory"`
+	ArchiveHomeDirectoryTo         types.String `tfsdk:"archive_home_directory_to"`
+	Home                           types.String `tfsdk:"home"`
+	Hint                           types.String `tfsdk:"hint"`
+	Picture                        types.String `tfsdk:"picture"`
+	Admin                          types.Bool   `tfsdk:"admin"`
+	FilevaultEnabled               types.Bool   `tfsdk:"filevault_enabled"`
+	SecureTokenAllowed             types.Bool   `tfsdk:"secure_token_allowed"`
 }
 
 // PolicyDirectoryBindingItemModel models a single <binding>.

--- a/internal/resources/pro/policies/policy/resource.go
+++ b/internal/resources/pro/policies/policy/resource.go
@@ -77,7 +77,7 @@ func (r *PolicyResource) IdentitySchema(ctx context.Context, req resource.Identi
 // schema is large by necessity — every section mirrors the SDK Policy type.
 func (r *PolicyResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = schema.Schema{
-		MarkdownDescription: "Manages a Jamf Pro classic policy. Supports the full 13-section policy payload (general, scope, self_service, package_configuration, scripts, printers, dock_items, account_maintenance, reboot, maintenance, files_processes, user_interaction, disk_encryption). Scope targets are flat sets of numeric Jamf Pro classic IDs — interpolate `jamfplatform_device_group.x.jamf_pro_id` to bridge from Platform Services. The `scope.limit_to_users` block is intentionally omitted in v1 pending an upstream SDK fix.",
+		MarkdownDescription: "Manages a Jamf Pro classic policy. Supports the full 13-section policy payload (general, scope, self_service, package_configuration, scripts, printers, dock_items, account_maintenance, reboot, maintenance, files_processes, user_interaction, disk_encryption). Scope targets are flat sets of numeric Jamf Pro classic IDs — interpolate `jamfplatform_device_group.x.jamf_pro_id` to bridge from Platform Services. The `scope.limit_to_users` block is intentionally omitted in v1 pending an upstream SDK fix. The classic `<software_update>` policy block is **intentionally not modelled**: software update via classic policy is an obsolete delivery path (superseded by MDM `InstallApplication` / `ScheduleOSUpdate` and the Jamf Pro patch-management surface). If you need to drive OS or app updates from Terraform, reach for the patch / DDM resources instead.",
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
 				MarkdownDescription: "Policy ID assigned by Jamf Pro.",
@@ -378,11 +378,19 @@ func (r *PolicyResource) Schema(ctx context.Context, req resource.SchemaRequest,
 						Optional:            true,
 						NestedObject: schema.NestedAttributeObject{
 							Attributes: map[string]schema.Attribute{
-								"action":   optComputedString("Account action (`Create`, `Reset`, `Delete`, `DisableFileVault2`)."),
+								"action": schema.StringAttribute{
+									MarkdownDescription: "Account action. Wire-accepted values: `Create`, `Reset`, `Delete`, `DisableFileVault` (the classic UI labels the last action \"Disable FileVault\"; the wire string is `DisableFileVault` without a trailing `2` despite older documentation suggesting otherwise — confirmed against policy 6791 round-trip).",
+									Optional:            true,
+									Computed:            true,
+									PlanModifiers:       []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
+									Validators: []validator.String{
+										stringvalidator.OneOf("Create", "Reset", "Delete", "DisableFileVault"),
+									},
+								},
 								"username": optComputedString("Account username."),
 								"realname": optComputedString("Account real (full) name."),
 								"password": schema.StringAttribute{
-									MarkdownDescription: "Plaintext password. Sensitive — surfaces in state until WriteOnly support lands.",
+									MarkdownDescription: "Plaintext password used by `Create` and `Reset` actions. Sensitive — plaintext surfaces in state because the Jamf classic API does not echo it back; the provider preserves the user-supplied value to satisfy the framework's plan/state consistency check. The companion `password_sha256` attribute carries the server's sentinel hash.",
 									Optional:            true,
 									Sensitive:           true,
 								},
@@ -391,14 +399,14 @@ func (r *PolicyResource) Schema(ctx context.Context, req resource.SchemaRequest,
 									Computed:            true,
 									PlanModifiers:       []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
 								},
-								"archive_home_directory":    optComputedBool("Archive the home directory on deletion."),
-								"archive_home_directory_to": optComputedString("Destination for the archived home directory."),
-								"home":                      optComputedString("Home directory path."),
-								"hint":                      optComputedString("Password hint."),
-								"picture":                   optComputedString("Account picture path."),
-								"admin":                     optComputedBool("Whether the account is an admin."),
-								"filevault_enabled":         optComputedBool("Whether FileVault 2 is enabled for the account."),
-								"secure_token_allowed":      optComputedBool("Whether the account is allowed to hold a Secure Token."),
+								"permanently_delete_home_directory": optComputedBool("Permanently delete the home directory when `action = \"Delete\"`. When true, the home is removed; when false (or unset), the home is archived to `archive_home_directory_to`. The classic wire field is the inverse boolean `<archive_home_directory>` — the provider translates at the input/output boundary so the Terraform-facing semantic mirrors the Jamf Pro UI checkbox label \"Permanently delete home directory\"."),
+								"archive_home_directory_to":         optComputedString("Destination for the archived home directory. Only meaningful when `permanently_delete_home_directory = false`."),
+								"home":                              optComputedString("Home directory path."),
+								"hint":                              optComputedString("Password hint."),
+								"picture":                           optComputedString("Account picture path."),
+								"admin":                             optComputedBool("Whether the account is an admin."),
+								"filevault_enabled":                 optComputedBool("Whether FileVault 2 is enabled for the account."),
+								"secure_token_allowed":              optComputedBool("Whether the account is allowed to hold a Secure Token."),
 							},
 						},
 					},
@@ -418,7 +426,7 @@ func (r *PolicyResource) Schema(ctx context.Context, req resource.SchemaRequest,
 						Attributes: map[string]schema.Attribute{
 							"action": optComputedString("Management account action (e.g. `doNotChange`, `rotate`)."),
 							"managed_password": schema.StringAttribute{
-								MarkdownDescription: "Plaintext managed password (Sensitive).",
+								MarkdownDescription: "Plaintext managed password. Sensitive — plaintext surfaces in state because the classic API never echoes it back. Follow-up: migrate to `WriteOnly` once the broader policy resource adopts it.",
 								Optional:            true,
 								Sensitive:           true,
 							},
@@ -431,7 +439,7 @@ func (r *PolicyResource) Schema(ctx context.Context, req resource.SchemaRequest,
 						Attributes: map[string]schema.Attribute{
 							"of_mode": optComputedString("Open Firmware mode (`command` or `full`)."),
 							"of_password": schema.StringAttribute{
-								MarkdownDescription: "Plaintext OF/EFI password (Sensitive).",
+								MarkdownDescription: "Plaintext Open Firmware / EFI password. Sensitive — plaintext surfaces in state because the classic API never echoes it back. Follow-up: migrate to `WriteOnly` once the broader policy resource adopts it.",
 								Optional:            true,
 								Sensitive:           true,
 							},

--- a/internal/resources/pro/policies/policy/resource.go
+++ b/internal/resources/pro/policies/policy/resource.go
@@ -41,6 +41,7 @@ type PolicyResource struct {
 var _ resource.Resource = &PolicyResource{}
 var _ resource.ResourceWithImportState = &PolicyResource{}
 var _ resource.ResourceWithIdentity = &PolicyResource{}
+var _ resource.ResourceWithConfigValidators = &PolicyResource{}
 
 const (
 	defaultCreateTimeout = 120 * time.Second
@@ -482,14 +483,22 @@ func (r *PolicyResource) Schema(ctx context.Context, req resource.SchemaRequest,
 				},
 			},
 			"user_interaction": schema.SingleNestedAttribute{
-				MarkdownDescription: "User interaction prompts shown around policy execution.",
+				MarkdownDescription: "User interaction prompts shown around policy execution. Cross-field rules: `allow_users_to_defer = false` forbids both deferral fields; `allow_deferral_until_utc` and `allow_deferral_minutes` are mutually exclusive (transitioning between forms requires destroy+recreate).",
 				Optional:            true,
 				Attributes: map[string]schema.Attribute{
 					"message_start":            optComputedString("Message displayed before the policy runs."),
 					"allow_users_to_defer":     optComputedBool("Allow the user to defer the policy."),
-					"allow_deferral_until_utc": optComputedString("Maximum deferral cut-off in UTC ISO-8601."),
-					"allow_deferral_minutes":   optComputedInt("Maximum deferral duration in minutes."),
-					"message_finish":           optComputedString("Message displayed after the policy completes."),
+					"allow_deferral_until_utc": optComputedString("Maximum deferral cut-off in UTC ISO-8601. Mutually exclusive with `allow_deferral_minutes`."),
+					"allow_deferral_minutes": schema.Int64Attribute{
+						MarkdownDescription: "Maximum deferral duration in minutes. Must be a positive multiple of 1440 (one day) — the classic API rejects any other value with HTTP 409. Mutually exclusive with `allow_deferral_until_utc`.",
+						Optional:            true,
+						Computed:            true,
+						PlanModifiers:       []planmodifier.Int64{int64planmodifier.UseStateForUnknown()},
+						Validators: []validator.Int64{
+							MultipleOfInt64(minutesPerDay),
+						},
+					},
+					"message_finish": optComputedString("Message displayed after the policy completes."),
 				},
 			},
 			"disk_encryption": schema.SingleNestedAttribute{
@@ -510,6 +519,16 @@ func (r *PolicyResource) Schema(ctx context.Context, req resource.SchemaRequest,
 				Delete: true,
 			}),
 		},
+	}
+}
+
+// ConfigValidators registers plan-time cross-field validators that mirror the
+// Jamf Pro classic /policies endpoint's server-side checks. Catching the
+// constraints at plan time gives users a clear error before apply rather than
+// the bare HTTP 409 the server surfaces.
+func (r *PolicyResource) ConfigValidators(ctx context.Context) []resource.ConfigValidator {
+	return []resource.ConfigValidator{
+		UserInteractionConfigValidator(),
 	}
 }
 

--- a/internal/resources/pro/policies/policy/resource.go
+++ b/internal/resources/pro/policies/policy/resource.go
@@ -268,6 +268,14 @@ func (r *PolicyResource) Schema(ctx context.Context, req resource.SchemaRequest,
 				MarkdownDescription: "Packages to install / cache / remove.",
 				Optional:            true,
 				Attributes: map[string]schema.Attribute{
+					"distribution_point": schema.StringAttribute{
+						MarkdownDescription: "Name of the file share distribution point to use for the policy. Wire field `<package_configuration><distribution_point>`. Server echoes the configured DP name (e.g. `Dummy DP`); omit to inherit the tenant default.",
+						Optional:            true,
+						Computed:            true,
+						PlanModifiers: []planmodifier.String{
+							stringplanmodifier.UseStateForUnknown(),
+						},
+					},
 					"packages": schema.SetNestedAttribute{
 						MarkdownDescription: "Set of package assignments. Each item identifies the package by classic ID; `name` is server-derived. `action` is one of `Install`, `Cache`, `Install Cached`, `Uninstall`.",
 						Optional:            true,

--- a/internal/resources/pro/policies/policy/resource.go
+++ b/internal/resources/pro/policies/policy/resource.go
@@ -172,18 +172,32 @@ func (r *PolicyResource) Schema(ctx context.Context, req resource.SchemaRequest,
 				},
 			},
 			"scope": schema.SingleNestedAttribute{
-				MarkdownDescription: "Policy scope. Targets are flat sets of numeric Jamf Pro classic IDs; interpolate `jamfplatform_device_group.<x>.jamf_pro_id` to bridge from Platform Services UUIDs. Setting `all_computers = true` forbids `computer_ids`, `computer_group_ids`, `building_ids`, `department_ids`. An equivalent `all_jss_users` attribute is intentionally omitted in v1 — the underlying SDK does not expose the field, so a no-op would silently scope to zero users.",
+				MarkdownDescription: "Policy scope. Targets are flat sets of numeric Jamf Pro classic IDs; interpolate `jamfplatform_device_group.<x>.jamf_pro_id` to bridge from Platform Services UUIDs. Setting `all_computers = true` forbids `computer_ids`, `computer_group_ids`, `building_ids`, `department_ids`. Setting `all_jss_users = true` forbids `jss_user_ids` and `jss_user_group_ids`.",
 				Optional:            true,
 				Attributes: map[string]schema.Attribute{
 					"all_computers": schema.BoolAttribute{
 						MarkdownDescription: "Scope the policy to every computer in the tenant. Forbids per-computer / per-group / per-building / per-department targets when true.",
 						Optional:            true,
+						Computed:            true,
+						PlanModifiers:       []planmodifier.Bool{boolplanmodifier.UseStateForUnknown()},
 						Validators: []validator.Bool{
 							scope.AllFlagConflictsWith(
 								path.MatchRelative().AtParent().AtName("computer_ids"),
 								path.MatchRelative().AtParent().AtName("computer_group_ids"),
 								path.MatchRelative().AtParent().AtName("building_ids"),
 								path.MatchRelative().AtParent().AtName("department_ids"),
+							),
+						},
+					},
+					"all_jss_users": schema.BoolAttribute{
+						MarkdownDescription: "Scope the policy to every JSS user in the tenant. Forbids per-user / per-user-group targets when true.",
+						Optional:            true,
+						Computed:            true,
+						PlanModifiers:       []planmodifier.Bool{boolplanmodifier.UseStateForUnknown()},
+						Validators: []validator.Bool{
+							scope.AllFlagConflictsWith(
+								path.MatchRelative().AtParent().AtName("jss_user_ids"),
+								path.MatchRelative().AtParent().AtName("jss_user_group_ids"),
 							),
 						},
 					},

--- a/internal/resources/pro/policies/policy/resource_acceptance_test.go
+++ b/internal/resources/pro/policies/policy/resource_acceptance_test.go
@@ -1619,3 +1619,257 @@ func TestAccPolicyResource_ScopeExclusionsFixtureCoverage(t *testing.T) {
 		},
 	})
 }
+
+func policyConfigAccountMaintenanceAccounts(name string) string {
+	return fmt.Sprintf(`
+resource "jamfplatform_pro_policy" "test" {
+  general = {
+    name = %q
+  }
+  account_maintenance = {
+    accounts = [
+      {
+        action               = "Create"
+        username             = "tf-acc-create"
+        realname             = "tf-acc create"
+        password             = "Sup3rS3cret!"
+        home                 = "/Users/tf-acc-create"
+        hint                 = "tf-acc hint"
+        admin                = true
+        filevault_enabled    = false
+        secure_token_allowed = true
+      },
+      {
+        action   = "Reset"
+        username = "tf-acc-reset"
+        password = "Resetting123!"
+      },
+      {
+        action                            = "Delete"
+        username                          = "tf-acc-delete"
+        permanently_delete_home_directory = true
+      },
+    ]
+  }
+}
+`, name)
+}
+
+// TestAccPolicyResource_AccountMaintenanceAccountsFullCoverage exercises
+// three of the four classic account-maintenance actions in a single policy:
+//
+//   - Create: full account-provisioning attribute set (username, realname,
+//     password, home, hint, admin, filevault_enabled, secure_token_allowed).
+//   - Reset:  password reset by username.
+//   - Delete: removal with `permanently_delete_home_directory = true`. This
+//     is the inverted-and-renamed form of the wire field
+//     `<archive_home_directory>` (Probe #8 in PHASE_2_6_SPIKE.md). Server
+//     receives the inverse on the wire; state stores the UI-canonical
+//     semantic.
+//
+// `DisableFileVault` is wired into the schema validator
+// (`stringvalidator.OneOf("Create", "Reset", "Delete", "DisableFileVault")`)
+// per Probe #9 — the wire string is `DisableFileVault` without a trailing
+// `2` despite older documentation. The action is NOT exercised in this
+// acceptance test because the classic /policies endpoint silently strips
+// `<account><action>DisableFileVault</action></account>` entries from new
+// policies (round-trip returns no account, framework then reports
+// "produced inconsistent result after apply"). The wire baseline in
+// PHASE_2_6_SPIKE.md §Appendix shows the action surviving on policy 6791,
+// which was created via the Jamf Pro UI — the rejection appears to be
+// API-only. Manually-probe the precise wire shape needed before adding
+// acceptance coverage.
+func TestAccPolicyResource_AccountMaintenanceAccountsFullCoverage(t *testing.T) {
+	testhelpers.AccPreCheck(t)
+	suffix := testhelpers.RunSuffix()
+	name := "tf-acc-policy-am-accounts-" + suffix
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testhelpers.AccTestProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckPolicyDestroy(t),
+		Steps: []resource.TestStep{
+			{
+				Config: policyConfigAccountMaintenanceAccounts(name),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"jamfplatform_pro_policy.test",
+						tfjsonpath.New("account_maintenance").AtMapKey("accounts"),
+						knownvalue.SetSizeExact(3),
+					),
+				},
+			},
+		},
+	})
+}
+
+func policyConfigAccountMaintenanceDirectoryBindings(policyName, dbName, dbUsername, dbPassword string) string {
+	return fmt.Sprintf(`
+resource "jamfplatform_pro_directory_binding" "fixture" {
+  name     = %q
+  priority = 1
+  type     = "Open Directory"
+  domain   = "ldap.tf-acc.example.com"
+  username = %q
+  password = %q
+
+  open_directory = {
+    encrypt_using_ssl     = false
+    perform_secure_bind   = false
+    use_for_authentication = true
+    use_for_contacts       = false
+  }
+}
+
+resource "jamfplatform_pro_policy" "test" {
+  general = {
+    name = %q
+  }
+  account_maintenance = {
+    directory_bindings = [
+      {
+        id = jamfplatform_pro_directory_binding.fixture.id
+      },
+    ]
+  }
+}
+`, dbName, dbUsername, dbPassword, policyName)
+}
+
+// TestAccPolicyResource_AccountMaintenanceDirectoryBindingsFullCoverage
+// creates a jamfplatform_pro_directory_binding fixture and references it
+// from policy.account_maintenance.directory_bindings, asserting the set
+// round-trips through the policy resource. The fixture uses the Open
+// Directory binding type which has the minimal required-field footprint.
+func TestAccPolicyResource_AccountMaintenanceDirectoryBindingsFullCoverage(t *testing.T) {
+	testhelpers.AccPreCheck(t)
+	suffix := testhelpers.RunSuffix()
+	policyName := "tf-acc-policy-am-db-" + suffix
+	dbName := "tf-acc-db-" + suffix
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testhelpers.AccTestProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckPolicyDestroy(t),
+		Steps: []resource.TestStep{
+			{
+				Config: policyConfigAccountMaintenanceDirectoryBindings(policyName, dbName, "cn=joiner,dc=tf-acc,dc=example,dc=com", "Sup3rS3cret!"),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"jamfplatform_pro_policy.test",
+						tfjsonpath.New("account_maintenance").AtMapKey("directory_bindings"),
+						knownvalue.SetSizeExact(1),
+					),
+				},
+			},
+		},
+	})
+}
+
+func policyConfigAccountMaintenanceManagementAccount(name, action, managedPassword string, length int64) string {
+	return fmt.Sprintf(`
+resource "jamfplatform_pro_policy" "test" {
+  general = {
+    name = %q
+  }
+  account_maintenance = {
+    management_account = {
+      action                  = %q
+      managed_password        = %q
+      managed_password_length = %d
+    }
+  }
+}
+`, name, action, managedPassword, length)
+}
+
+// TestAccPolicyResource_AccountMaintenanceManagementAccountFullCoverage
+// exercises the management_account block. Step 1 rotates the management
+// account using a literal managed_password; step 2 switches to the
+// rotate-with-length variant (no plaintext) to confirm the
+// managed_password_length attribute round-trips.
+func TestAccPolicyResource_AccountMaintenanceManagementAccountFullCoverage(t *testing.T) {
+	testhelpers.AccPreCheck(t)
+	suffix := testhelpers.RunSuffix()
+	name := "tf-acc-policy-am-ma-" + suffix
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testhelpers.AccTestProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckPolicyDestroy(t),
+		Steps: []resource.TestStep{
+			{
+				Config: policyConfigAccountMaintenanceManagementAccount(name, "rotate", "Sup3rS3cret!", 0),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"jamfplatform_pro_policy.test",
+						tfjsonpath.New("account_maintenance").AtMapKey("management_account").AtMapKey("action"),
+						knownvalue.StringExact("rotate"),
+					),
+				},
+			},
+			{
+				Config: policyConfigAccountMaintenanceManagementAccount(name, "rotate", "", 16),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"jamfplatform_pro_policy.test",
+						tfjsonpath.New("account_maintenance").AtMapKey("management_account").AtMapKey("managed_password_length"),
+						knownvalue.Int64Exact(16),
+					),
+				},
+			},
+		},
+	})
+}
+
+func policyConfigAccountMaintenanceOpenFirmwareEfiPassword(name, ofMode, ofPassword string) string {
+	return fmt.Sprintf(`
+resource "jamfplatform_pro_policy" "test" {
+  general = {
+    name = %q
+  }
+  account_maintenance = {
+    open_firmware_efi_password = {
+      of_mode     = %q
+      of_password = %q
+    }
+  }
+}
+`, name, ofMode, ofPassword)
+}
+
+// TestAccPolicyResource_AccountMaintenanceOpenFirmwareEfiPasswordFullCoverage
+// exercises the open_firmware_efi_password block. The plaintext of_password
+// is Sensitive and never echoed by the server; the SHA-256 sentinel
+// (literal `********************`) lands in `of_password_sha256` once a
+// password is set. Step 2 switches of_mode `command` → `full` to exercise
+// the Update path.
+func TestAccPolicyResource_AccountMaintenanceOpenFirmwareEfiPasswordFullCoverage(t *testing.T) {
+	testhelpers.AccPreCheck(t)
+	suffix := testhelpers.RunSuffix()
+	name := "tf-acc-policy-am-efi-" + suffix
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testhelpers.AccTestProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckPolicyDestroy(t),
+		Steps: []resource.TestStep{
+			{
+				Config: policyConfigAccountMaintenanceOpenFirmwareEfiPassword(name, "command", "OF-tf-acc-1!"),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"jamfplatform_pro_policy.test",
+						tfjsonpath.New("account_maintenance").AtMapKey("open_firmware_efi_password").AtMapKey("of_mode"),
+						knownvalue.StringExact("command"),
+					),
+				},
+			},
+			{
+				Config: policyConfigAccountMaintenanceOpenFirmwareEfiPassword(name, "full", "OF-tf-acc-2!"),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"jamfplatform_pro_policy.test",
+						tfjsonpath.New("account_maintenance").AtMapKey("open_firmware_efi_password").AtMapKey("of_mode"),
+						knownvalue.StringExact("full"),
+					),
+				},
+			},
+		},
+	})
+}

--- a/internal/resources/pro/policies/policy/resource_acceptance_test.go
+++ b/internal/resources/pro/policies/policy/resource_acceptance_test.go
@@ -12,6 +12,9 @@ package policy_test
 import (
 	"context"
 	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/Jamf-Concepts/jamfplatform-go-sdk/jamfplatform/proclassic"
@@ -24,6 +27,27 @@ import (
 	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/common/helpers"
 	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/testhelpers"
 )
+
+// packageFixturePath resolves the shared jamf-cli .pkg fixture committed under
+// internal/resources/pro/inventory/package/test_fixtures/. The path is computed
+// relative to this test file so the result is invariant to the working
+// directory `go test` was invoked from.
+func packageFixturePath(t *testing.T, name string) string {
+	t.Helper()
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatalf("could not resolve caller path for fixture lookup")
+	}
+	dir := filepath.Dir(file)
+	abs, err := filepath.Abs(filepath.Join(dir, "..", "..", "inventory", "package", "test_fixtures", name))
+	if err != nil {
+		t.Fatalf("resolving fixture path %q: %v", name, err)
+	}
+	if _, err := os.Stat(abs); err != nil {
+		t.Fatalf("fixture %q not present at %q: %v", name, abs, err)
+	}
+	return abs
+}
 
 // testAccCheckPolicyDestroy verifies policies created during the test were
 // destroyed.
@@ -422,6 +446,133 @@ resource "jamfplatform_pro_policy" "test" {
 // state_builders.assignPolicyResourceModel) the reboot section is only
 // populated on Read when the caller already manages it, so a freshly-imported
 // state will not contain the reboot block.
+func policyConfigPackageConfigurationDistributionPoint(name, dp string) string {
+	return fmt.Sprintf(`
+resource "jamfplatform_pro_policy" "test" {
+  general = {
+    name = %q
+  }
+  package_configuration = {
+    distribution_point = %q
+  }
+}
+`, name, dp)
+}
+
+// TestAccPolicyResource_PackageConfigurationDistributionPoint exercises the
+// top-level `<package_configuration><distribution_point>` wire field added in
+// SDK 0.8.1-…46aec40edb28. The wire returns this value as a peer of <packages>
+// (see PHASE_2_6_SPIKE.md §4 + Appendix). Test omits the `packages` set
+// entirely — there is no clean "NONE" value for packages[].id, so per-package
+// coverage is deferred to PR #5 with a real `jamfplatform_pro_package` fixture.
+// Import-state round-trip is not asserted (per
+// state_builders.assignPolicyResourceModel, optional sub-blocks are only
+// populated on Read when already managed by the caller).
+func TestAccPolicyResource_PackageConfigurationDistributionPoint(t *testing.T) {
+	testhelpers.AccPreCheck(t)
+	suffix := testhelpers.RunSuffix()
+	name := "tf-acc-policy-pkgcfg-dp-" + suffix
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testhelpers.AccTestProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckPolicyDestroy(t),
+		Steps: []resource.TestStep{
+			{
+				Config: policyConfigPackageConfigurationDistributionPoint(name, "Dummy DP"),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"jamfplatform_pro_policy.test",
+						tfjsonpath.New("package_configuration").AtMapKey("distribution_point"),
+						knownvalue.StringExact("Dummy DP"),
+					),
+				},
+			},
+		},
+	})
+}
+
+func policyConfigPackageConfigurationPackages(name, pkgName, pkgFileName, pkgSrc, action string) string {
+	return fmt.Sprintf(`
+resource "jamfplatform_pro_package" "fixture" {
+  display_name        = %q
+  file_name           = %q
+  package_file_source = %q
+  info                = "tf-acc package fixture for jamfplatform_pro_policy package_configuration coverage"
+}
+
+resource "jamfplatform_pro_policy" "test" {
+  general = {
+    name = %q
+  }
+  package_configuration = {
+    distribution_point = "Dummy DP"
+    packages = [
+      {
+        id     = jamfplatform_pro_package.fixture.id
+        action = %q
+      },
+    ]
+  }
+}
+`, pkgName, pkgFileName, pkgSrc, name, action)
+}
+
+// TestAccPolicyResource_PackageConfigurationPackages exercises the
+// `package_configuration.packages` set together with the top-level
+// distribution_point. A jamfplatform_pro_package resource uploads the
+// committed jamf-cli .pkg fixture (shared with the inventory/package acc
+// suite) so the policy can reference a real package ID. Step 2 swaps the
+// per-package action Install → Cache to exercise the Update path on the
+// policy's packages set without re-uploading the package.
+// Import-state round-trip is not asserted (per
+// state_builders.assignPolicyResourceModel, optional sub-blocks are only
+// populated on Read when already managed by the caller).
+func TestAccPolicyResource_PackageConfigurationPackages(t *testing.T) {
+	testhelpers.AccPreCheck(t)
+	suffix := testhelpers.RunSuffix()
+	policyName := "tf-acc-policy-pkgcfg-pkgs-" + suffix
+	pkgDisplay := "tf-acc-pkg-fixture-" + suffix
+	pkgFileName := "tf-acc-pkg-fixture-" + suffix + ".pkg"
+	pkgSrc := packageFixturePath(t, "jamf-cli-1.15.0.pkg")
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testhelpers.AccTestProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckPolicyDestroy(t),
+		Steps: []resource.TestStep{
+			{
+				Config: policyConfigPackageConfigurationPackages(policyName, pkgDisplay, pkgFileName, pkgSrc, "Install"),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"jamfplatform_pro_policy.test",
+						tfjsonpath.New("package_configuration").AtMapKey("distribution_point"),
+						knownvalue.StringExact("Dummy DP"),
+					),
+					statecheck.ExpectKnownValue(
+						"jamfplatform_pro_policy.test",
+						tfjsonpath.New("package_configuration").AtMapKey("packages"),
+						knownvalue.SetSizeExact(1),
+					),
+					statecheck.ExpectKnownValue(
+						"jamfplatform_pro_policy.test",
+						tfjsonpath.New("package_configuration").AtMapKey("packages").AtSliceIndex(0).AtMapKey("action"),
+						knownvalue.StringExact("Install"),
+					),
+				},
+			},
+			{
+				Config: policyConfigPackageConfigurationPackages(policyName, pkgDisplay, pkgFileName, pkgSrc, "Cache"),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"jamfplatform_pro_policy.test",
+						tfjsonpath.New("package_configuration").AtMapKey("packages").AtSliceIndex(0).AtMapKey("action"),
+						knownvalue.StringExact("Cache"),
+					),
+				},
+			},
+		},
+	})
+}
+
 func TestAccPolicyResource_RebootFullCoverage(t *testing.T) {
 	testhelpers.AccPreCheck(t)
 	suffix := testhelpers.RunSuffix()

--- a/internal/resources/pro/policies/policy/resource_acceptance_test.go
+++ b/internal/resources/pro/policies/policy/resource_acceptance_test.go
@@ -635,3 +635,561 @@ func TestAccPolicyResource_RebootFullCoverage(t *testing.T) {
 		},
 	})
 }
+
+func policyConfigScripts(policyName, scriptName, priority, scriptPolicyPriority, p4 string) string {
+	return fmt.Sprintf(`
+resource "jamfplatform_pro_script" "fixture" {
+  name            = %q
+  priority        = %q
+  info            = "tf-acc script fixture for jamfplatform_pro_policy scripts coverage"
+  script_contents = <<-EOT
+    #!/bin/sh
+    echo "tf-acc-script"
+  EOT
+}
+
+resource "jamfplatform_pro_policy" "test" {
+  general = {
+    name = %q
+  }
+  scripts = {
+    scripts = [
+      {
+        id         = jamfplatform_pro_script.fixture.id
+        priority   = %q
+        parameter4 = %q
+      },
+    ]
+  }
+}
+`, scriptName, priority, policyName, scriptPolicyPriority, p4)
+}
+
+// TestAccPolicyResource_ScriptsFullCoverage creates a jamfplatform_pro_script
+// fixture (the standalone script resource uses BEFORE/AFTER/AT_REBOOT) and
+// references its ID from policy.scripts.scripts. The policy's wire form for
+// `priority` is `Before`/`After`/`At Reboot` (per PHASE_2_6_SPIKE.md §5
+// + Appendix), distinct from the fixture's enum. Step 2 swaps priority and
+// parameter4 to exercise the Update path on the scripts set without
+// recreating the fixture.
+func TestAccPolicyResource_ScriptsFullCoverage(t *testing.T) {
+	testhelpers.AccPreCheck(t)
+	suffix := testhelpers.RunSuffix()
+	policyName := "tf-acc-policy-scripts-" + suffix
+	scriptName := "tf-acc-script-fixture-" + suffix
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testhelpers.AccTestProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckPolicyDestroy(t),
+		Steps: []resource.TestStep{
+			{
+				Config: policyConfigScripts(policyName, scriptName, "AFTER", "Before", "tf-acc-p4-initial"),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"jamfplatform_pro_policy.test",
+						tfjsonpath.New("scripts").AtMapKey("scripts"),
+						knownvalue.SetSizeExact(1),
+					),
+					statecheck.ExpectKnownValue(
+						"jamfplatform_pro_policy.test",
+						tfjsonpath.New("scripts").AtMapKey("scripts").AtSliceIndex(0).AtMapKey("priority"),
+						knownvalue.StringExact("Before"),
+					),
+					statecheck.ExpectKnownValue(
+						"jamfplatform_pro_policy.test",
+						tfjsonpath.New("scripts").AtMapKey("scripts").AtSliceIndex(0).AtMapKey("parameter4"),
+						knownvalue.StringExact("tf-acc-p4-initial"),
+					),
+				},
+			},
+			{
+				Config: policyConfigScripts(policyName, scriptName, "AFTER", "After", "tf-acc-p4-updated"),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"jamfplatform_pro_policy.test",
+						tfjsonpath.New("scripts").AtMapKey("scripts").AtSliceIndex(0).AtMapKey("priority"),
+						knownvalue.StringExact("After"),
+					),
+					statecheck.ExpectKnownValue(
+						"jamfplatform_pro_policy.test",
+						tfjsonpath.New("scripts").AtMapKey("scripts").AtSliceIndex(0).AtMapKey("parameter4"),
+						knownvalue.StringExact("tf-acc-p4-updated"),
+					),
+				},
+			},
+		},
+	})
+}
+
+func policyConfigPrinters(policyName, printerName, action string, makeDefault, leaveExistingDefault bool) string {
+	return fmt.Sprintf(`
+resource "jamfplatform_pro_printer" "fixture" {
+  name = %q
+  uri  = "ipp://10.1.20.120/"
+}
+
+resource "jamfplatform_pro_policy" "test" {
+  general = {
+    name = %q
+  }
+  printers = {
+    leave_existing_default = %t
+    printers = [
+      {
+        id           = jamfplatform_pro_printer.fixture.id
+        action       = %q
+        make_default = %t
+      },
+    ]
+  }
+}
+`, printerName, policyName, leaveExistingDefault, action, makeDefault)
+}
+
+// TestAccPolicyResource_PrintersFullCoverage creates a jamfplatform_pro_printer
+// fixture and references it from policy.printers.printers. Step 2 swaps action
+// `install` → `uninstall` and toggles make_default + leave_existing_default to
+// exercise the Update path. The classic API also returns a `size` field which
+// the schema exposes as Computed; not asserted explicitly because the framework
+// validates Computed values are non-Unknown after apply.
+func TestAccPolicyResource_PrintersFullCoverage(t *testing.T) {
+	testhelpers.AccPreCheck(t)
+	suffix := testhelpers.RunSuffix()
+	policyName := "tf-acc-policy-printers-" + suffix
+	printerName := "tf-acc-printer-fixture-" + suffix
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testhelpers.AccTestProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckPolicyDestroy(t),
+		Steps: []resource.TestStep{
+			{
+				Config: policyConfigPrinters(policyName, printerName, "install", true, false),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"jamfplatform_pro_policy.test",
+						tfjsonpath.New("printers").AtMapKey("printers"),
+						knownvalue.SetSizeExact(1),
+					),
+					statecheck.ExpectKnownValue(
+						"jamfplatform_pro_policy.test",
+						tfjsonpath.New("printers").AtMapKey("printers").AtSliceIndex(0).AtMapKey("action"),
+						knownvalue.StringExact("install"),
+					),
+					statecheck.ExpectKnownValue(
+						"jamfplatform_pro_policy.test",
+						tfjsonpath.New("printers").AtMapKey("printers").AtSliceIndex(0).AtMapKey("make_default"),
+						knownvalue.Bool(true),
+					),
+					statecheck.ExpectKnownValue(
+						"jamfplatform_pro_policy.test",
+						tfjsonpath.New("printers").AtMapKey("leave_existing_default"),
+						knownvalue.Bool(false),
+					),
+				},
+			},
+			{
+				Config: policyConfigPrinters(policyName, printerName, "uninstall", false, true),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"jamfplatform_pro_policy.test",
+						tfjsonpath.New("printers").AtMapKey("printers").AtSliceIndex(0).AtMapKey("action"),
+						knownvalue.StringExact("uninstall"),
+					),
+					statecheck.ExpectKnownValue(
+						"jamfplatform_pro_policy.test",
+						tfjsonpath.New("printers").AtMapKey("printers").AtSliceIndex(0).AtMapKey("make_default"),
+						knownvalue.Bool(false),
+					),
+					statecheck.ExpectKnownValue(
+						"jamfplatform_pro_policy.test",
+						tfjsonpath.New("printers").AtMapKey("leave_existing_default"),
+						knownvalue.Bool(true),
+					),
+				},
+			},
+		},
+	})
+}
+
+func policyConfigDockItems(policyName, dockItemName, action string) string {
+	return fmt.Sprintf(`
+resource "jamfplatform_pro_dock_item" "fixture" {
+  name = %q
+  type = "App"
+  path = "/Applications/Calculator.app"
+}
+
+resource "jamfplatform_pro_policy" "test" {
+  general = {
+    name = %q
+  }
+  dock_items = {
+    dock_items = [
+      {
+        id     = jamfplatform_pro_dock_item.fixture.id
+        action = %q
+      },
+    ]
+  }
+}
+`, dockItemName, policyName, action)
+}
+
+// TestAccPolicyResource_DockItemsFullCoverage creates a jamfplatform_pro_dock_item
+// fixture and references it from policy.dock_items.dock_items. Step 2 swaps action
+// `Add To End` → `Add To Beginning` to exercise the Update path.
+func TestAccPolicyResource_DockItemsFullCoverage(t *testing.T) {
+	testhelpers.AccPreCheck(t)
+	suffix := testhelpers.RunSuffix()
+	policyName := "tf-acc-policy-dockitems-" + suffix
+	dockItemName := "tf-acc-dock-item-fixture-" + suffix
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testhelpers.AccTestProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckPolicyDestroy(t),
+		Steps: []resource.TestStep{
+			{
+				Config: policyConfigDockItems(policyName, dockItemName, "Add To End"),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"jamfplatform_pro_policy.test",
+						tfjsonpath.New("dock_items").AtMapKey("dock_items"),
+						knownvalue.SetSizeExact(1),
+					),
+					statecheck.ExpectKnownValue(
+						"jamfplatform_pro_policy.test",
+						tfjsonpath.New("dock_items").AtMapKey("dock_items").AtSliceIndex(0).AtMapKey("action"),
+						knownvalue.StringExact("Add To End"),
+					),
+				},
+			},
+			{
+				Config: policyConfigDockItems(policyName, dockItemName, "Add To Beginning"),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"jamfplatform_pro_policy.test",
+						tfjsonpath.New("dock_items").AtMapKey("dock_items").AtSliceIndex(0).AtMapKey("action"),
+						knownvalue.StringExact("Add To Beginning"),
+					),
+				},
+			},
+		},
+	})
+}
+
+func policyConfigMaintenance(name string, recon bool) string {
+	return fmt.Sprintf(`
+resource "jamfplatform_pro_policy" "test" {
+  general = {
+    name = %q
+  }
+  maintenance = {
+    recon                       = %t
+    reset_name                  = true
+    install_all_cached_packages = true
+    heal                        = false
+    prebindings                 = false
+    permissions                 = true
+    byhost                      = true
+    system_cache                = true
+    user_cache                  = true
+    verify                      = true
+  }
+}
+`, name, recon)
+}
+
+// TestAccPolicyResource_MaintenanceFullCoverage exercises every maintenance
+// attribute. Per Probe #10 in PHASE_2_6_SPIKE.md, the wire silently rejects
+// heal=true (echo always returns false) so this test sets heal=false to match
+// what the server will return; the schema still surfaces the attribute for
+// users who want to declare the inert wire field. Step 2 toggles recon to
+// exercise the Update path.
+func TestAccPolicyResource_MaintenanceFullCoverage(t *testing.T) {
+	testhelpers.AccPreCheck(t)
+	suffix := testhelpers.RunSuffix()
+	name := "tf-acc-policy-maint-" + suffix
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testhelpers.AccTestProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckPolicyDestroy(t),
+		Steps: []resource.TestStep{
+			{
+				Config: policyConfigMaintenance(name, true),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"jamfplatform_pro_policy.test",
+						tfjsonpath.New("maintenance").AtMapKey("recon"),
+						knownvalue.Bool(true),
+					),
+					statecheck.ExpectKnownValue(
+						"jamfplatform_pro_policy.test",
+						tfjsonpath.New("maintenance").AtMapKey("heal"),
+						knownvalue.Bool(false),
+					),
+					statecheck.ExpectKnownValue(
+						"jamfplatform_pro_policy.test",
+						tfjsonpath.New("maintenance").AtMapKey("verify"),
+						knownvalue.Bool(true),
+					),
+				},
+			},
+			{
+				Config: policyConfigMaintenance(name, false),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"jamfplatform_pro_policy.test",
+						tfjsonpath.New("maintenance").AtMapKey("recon"),
+						knownvalue.Bool(false),
+					),
+				},
+			},
+		},
+	})
+}
+
+func policyConfigFilesProcesses(name, searchByPath, runCommand string) string {
+	return fmt.Sprintf(`
+resource "jamfplatform_pro_policy" "test" {
+  general = {
+    name = %q
+  }
+  files_processes = {
+    search_by_path         = %q
+    delete_file            = true
+    locate_file            = "tf-acc-locate-file"
+    update_locate_database = true
+    spotlight_search       = "tf-acc-spotlight"
+    search_for_process     = "tf-acc-process"
+    kill_process           = true
+    run_command            = %q
+  }
+}
+`, name, searchByPath, runCommand)
+}
+
+// TestAccPolicyResource_FilesProcessesFullCoverage exercises every
+// files_processes attribute. Step 2 perturbs two scalar string fields to
+// exercise the Update path.
+func TestAccPolicyResource_FilesProcessesFullCoverage(t *testing.T) {
+	testhelpers.AccPreCheck(t)
+	suffix := testhelpers.RunSuffix()
+	name := "tf-acc-policy-filesproc-" + suffix
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testhelpers.AccTestProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckPolicyDestroy(t),
+		Steps: []resource.TestStep{
+			{
+				Config: policyConfigFilesProcesses(name, "/tmp/tf-acc-search", "echo tf-acc-initial"),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"jamfplatform_pro_policy.test",
+						tfjsonpath.New("files_processes").AtMapKey("search_by_path"),
+						knownvalue.StringExact("/tmp/tf-acc-search"),
+					),
+					statecheck.ExpectKnownValue(
+						"jamfplatform_pro_policy.test",
+						tfjsonpath.New("files_processes").AtMapKey("delete_file"),
+						knownvalue.Bool(true),
+					),
+					statecheck.ExpectKnownValue(
+						"jamfplatform_pro_policy.test",
+						tfjsonpath.New("files_processes").AtMapKey("locate_file"),
+						knownvalue.StringExact("tf-acc-locate-file"),
+					),
+					statecheck.ExpectKnownValue(
+						"jamfplatform_pro_policy.test",
+						tfjsonpath.New("files_processes").AtMapKey("kill_process"),
+						knownvalue.Bool(true),
+					),
+					statecheck.ExpectKnownValue(
+						"jamfplatform_pro_policy.test",
+						tfjsonpath.New("files_processes").AtMapKey("run_command"),
+						knownvalue.StringExact("echo tf-acc-initial"),
+					),
+				},
+			},
+			{
+				Config: policyConfigFilesProcesses(name, "/tmp/tf-acc-search-updated", "echo tf-acc-updated"),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"jamfplatform_pro_policy.test",
+						tfjsonpath.New("files_processes").AtMapKey("search_by_path"),
+						knownvalue.StringExact("/tmp/tf-acc-search-updated"),
+					),
+					statecheck.ExpectKnownValue(
+						"jamfplatform_pro_policy.test",
+						tfjsonpath.New("files_processes").AtMapKey("run_command"),
+						knownvalue.StringExact("echo tf-acc-updated"),
+					),
+				},
+			},
+		},
+	})
+}
+
+func policyConfigUserInteractionUntilUTC(name, messageStart, untilUTC string) string {
+	return fmt.Sprintf(`
+resource "jamfplatform_pro_policy" "test" {
+  general = {
+    name = %q
+  }
+  user_interaction = {
+    message_start            = %q
+    allow_users_to_defer     = true
+    allow_deferral_until_utc = %q
+    message_finish           = "tf-acc message_finish"
+  }
+}
+`, name, messageStart, untilUTC)
+}
+
+// TestAccPolicyResource_UserInteractionFullCoverage exercises every
+// user_interaction attribute. Both steps use the cut-off form
+// (allow_deferral_until_utc); step 2 perturbs message_start and the cut-off
+// date to exercise the Update path. The duration form
+// (allow_deferral_minutes) is documented but not toggled in the same test
+// because the classic API cannot transition between the two forms without an
+// intermediate clear (see constraint notes below) and step coverage of the
+// minutes form belongs in a separate, dedicated test.
+//
+// Three server-side cross-field constraints surfaced during this test and
+// are noted here for follow-up plan-time validators:
+//   - allow_deferral_minutes must be a multiple of 1440 (one day): the server
+//     returns 409 with `Error: allow_deferral_minutes must be a multiple of
+//     1440 (minutes in day), currently the UI displays only number of days`.
+//   - When allow_users_to_defer=false, allow_deferral_until_utc and
+//     allow_deferral_minutes cannot be configured: the server returns 409
+//     with `Error: When 'allow_users_to_defer' is false,
+//     'allow_deferral_until_utc' and 'allow_deferral_minutes' cannot be
+//     configured`.
+//   - allow_deferral_until_utc and allow_deferral_minutes are mutually
+//     exclusive: the server returns 409 with `Error: You cannot use both
+//     'allow_deferral_until_utc' and 'allow_deferral_minutes'`. Omitting one
+//     field on an Update does not clear it (Optional+Computed semantics keep
+//     prior state); transitioning between forms requires destroy+recreate.
+func TestAccPolicyResource_UserInteractionFullCoverage(t *testing.T) {
+	testhelpers.AccPreCheck(t)
+	suffix := testhelpers.RunSuffix()
+	name := "tf-acc-policy-userint-" + suffix
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testhelpers.AccTestProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckPolicyDestroy(t),
+		Steps: []resource.TestStep{
+			{
+				Config: policyConfigUserInteractionUntilUTC(name, "tf-acc message_start initial", "2030-01-01T01:00:00.000+0000"),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"jamfplatform_pro_policy.test",
+						tfjsonpath.New("user_interaction").AtMapKey("message_start"),
+						knownvalue.StringExact("tf-acc message_start initial"),
+					),
+					statecheck.ExpectKnownValue(
+						"jamfplatform_pro_policy.test",
+						tfjsonpath.New("user_interaction").AtMapKey("allow_users_to_defer"),
+						knownvalue.Bool(true),
+					),
+					statecheck.ExpectKnownValue(
+						"jamfplatform_pro_policy.test",
+						tfjsonpath.New("user_interaction").AtMapKey("allow_deferral_until_utc"),
+						knownvalue.StringExact("2030-01-01T01:00:00.000+0000"),
+					),
+					statecheck.ExpectKnownValue(
+						"jamfplatform_pro_policy.test",
+						tfjsonpath.New("user_interaction").AtMapKey("message_finish"),
+						knownvalue.StringExact("tf-acc message_finish"),
+					),
+				},
+			},
+			{
+				Config: policyConfigUserInteractionUntilUTC(name, "tf-acc message_start updated", "2031-06-15T12:00:00.000+0000"),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"jamfplatform_pro_policy.test",
+						tfjsonpath.New("user_interaction").AtMapKey("message_start"),
+						knownvalue.StringExact("tf-acc message_start updated"),
+					),
+					statecheck.ExpectKnownValue(
+						"jamfplatform_pro_policy.test",
+						tfjsonpath.New("user_interaction").AtMapKey("allow_users_to_defer"),
+						knownvalue.Bool(true),
+					),
+					statecheck.ExpectKnownValue(
+						"jamfplatform_pro_policy.test",
+						tfjsonpath.New("user_interaction").AtMapKey("allow_deferral_until_utc"),
+						knownvalue.StringExact("2031-06-15T12:00:00.000+0000"),
+					),
+				},
+			},
+		},
+	})
+}
+
+func policyConfigDiskEncryption(policyName, decName, action string, authRestart bool) string {
+	return fmt.Sprintf(`
+resource "jamfplatform_pro_disk_encryption_configuration" "fixture" {
+  name                     = %q
+  key_type                 = "Individual"
+  file_vault_enabled_users = "Current or Next User"
+}
+
+resource "jamfplatform_pro_policy" "test" {
+  general = {
+    name = %q
+  }
+  disk_encryption = {
+    action                           = %q
+    disk_encryption_configuration_id = tonumber(jamfplatform_pro_disk_encryption_configuration.fixture.id)
+    auth_restart                     = %t
+  }
+}
+`, decName, policyName, action, authRestart)
+}
+
+// TestAccPolicyResource_DiskEncryptionFullCoverage creates a
+// jamfplatform_pro_disk_encryption_configuration fixture (key_type=Individual
+// is the minimal config — no IRK certificate required) and references its ID
+// from policy.disk_encryption. Step 2 toggles auth_restart to exercise the
+// Update path. Probe #12 in PHASE_2_6_SPIKE.md found that action=remediate
+// silently reverts to apply on the server, so this test sticks with
+// action=apply throughout.
+func TestAccPolicyResource_DiskEncryptionFullCoverage(t *testing.T) {
+	testhelpers.AccPreCheck(t)
+	suffix := testhelpers.RunSuffix()
+	policyName := "tf-acc-policy-de-" + suffix
+	decName := "tf-acc-dec-fixture-" + suffix
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testhelpers.AccTestProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckPolicyDestroy(t),
+		Steps: []resource.TestStep{
+			{
+				Config: policyConfigDiskEncryption(policyName, decName, "apply", false),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"jamfplatform_pro_policy.test",
+						tfjsonpath.New("disk_encryption").AtMapKey("action"),
+						knownvalue.StringExact("apply"),
+					),
+					statecheck.ExpectKnownValue(
+						"jamfplatform_pro_policy.test",
+						tfjsonpath.New("disk_encryption").AtMapKey("auth_restart"),
+						knownvalue.Bool(false),
+					),
+				},
+			},
+			{
+				Config: policyConfigDiskEncryption(policyName, decName, "apply", true),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"jamfplatform_pro_policy.test",
+						tfjsonpath.New("disk_encryption").AtMapKey("auth_restart"),
+						knownvalue.Bool(true),
+					),
+				},
+			},
+		},
+	})
+}

--- a/internal/resources/pro/policies/policy/resource_acceptance_test.go
+++ b/internal/resources/pro/policies/policy/resource_acceptance_test.go
@@ -28,6 +28,65 @@ import (
 	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/testhelpers"
 )
 
+// newSDKClient returns a real ProClassic SDK client wired to the same
+// acceptance-test credentials the provider factory uses. Used for setup +
+// teardown of fixture records (computer, user) that the project does not yet
+// expose as Terraform resources but the policy resource's scope sub-blocks
+// reference by classic ID.
+func newSDKClient(t *testing.T) *proclassic.Client {
+	t.Helper()
+	return proclassic.New(testhelpers.NewAcceptanceClient(t))
+}
+
+// createDummyComputer creates a minimal classic computer record via the SDK
+// and returns its server-assigned ID as a string. Cleanup runs at test end
+// via t.Cleanup.
+//
+// The classic POST endpoint at /computers/id/0 ignores the supplied id of 0
+// and assigns a fresh ID; the SDK signature returns only error, so we re-read
+// by name to discover the assigned ID.
+func createDummyComputer(t *testing.T, name string) string {
+	t.Helper()
+	c := newSDKClient(t)
+	ctx := context.Background()
+	if err := c.CreateComputerByID(ctx, "0", &proclassic.ComputerPost{
+		General: &proclassic.ComputerPostGeneral{Name: &name},
+	}); err != nil {
+		t.Fatalf("CreateComputerByID(%q): %v", name, err)
+	}
+	got, err := c.GetComputerByName(ctx, name)
+	if err != nil || got == nil || got.General == nil || got.General.ID == nil {
+		t.Fatalf("GetComputerByName(%q) after create: %v", name, err)
+	}
+	id := fmt.Sprintf("%d", *got.General.ID)
+	t.Cleanup(func() {
+		if err := c.DeleteComputerByID(context.Background(), id); err != nil && !helpers.IsNotFoundError(err) {
+			t.Logf("cleanup DeleteComputerByID(%s): %v", id, err)
+		}
+	})
+	return id
+}
+
+// createDummyUser creates a minimal classic user record via the SDK and
+// returns its server-assigned ID as a string. Cleanup runs at test end via
+// t.Cleanup.
+func createDummyUser(t *testing.T, name string) string {
+	t.Helper()
+	c := newSDKClient(t)
+	ctx := context.Background()
+	got, err := c.CreateUserByID(ctx, "0", &proclassic.UserPost{Name: &name})
+	if err != nil || got == nil || got.ID == nil {
+		t.Fatalf("CreateUserByID(%q): %v", name, err)
+	}
+	id := fmt.Sprintf("%d", *got.ID)
+	t.Cleanup(func() {
+		if err := c.DeleteUserByID(context.Background(), id); err != nil && !helpers.IsNotFoundError(err) {
+			t.Logf("cleanup DeleteUserByID(%s): %v", id, err)
+		}
+	})
+	return id
+}
+
 // packageFixturePath resolves the shared jamf-cli .pkg fixture committed under
 // internal/resources/pro/inventory/package/test_fixtures/. The path is computed
 // relative to this test file so the result is invariant to the working
@@ -1187,6 +1246,373 @@ func TestAccPolicyResource_DiskEncryptionFullCoverage(t *testing.T) {
 						"jamfplatform_pro_policy.test",
 						tfjsonpath.New("disk_encryption").AtMapKey("auth_restart"),
 						knownvalue.Bool(true),
+					),
+				},
+			},
+		},
+	})
+}
+
+func policyConfigScopeAllJssUsers(name string, allJssUsers bool) string {
+	return fmt.Sprintf(`
+resource "jamfplatform_pro_policy" "test" {
+  general = {
+    name = %q
+  }
+  scope = {
+    all_computers = true
+    all_jss_users = %t
+  }
+}
+`, name, allJssUsers)
+}
+
+// TestAccPolicyResource_ScopeAllJssUsersFullCoverage exercises the
+// scope.all_jss_users Bool attribute newly wired into the schema after SDK
+// commit d7d755d added the proclassic.PolicyScope.AllJssUsers field. Both
+// steps keep all_computers=true so the policy is otherwise valid; step 2
+// flips all_jss_users to exercise the Update path.
+func TestAccPolicyResource_ScopeAllJssUsersFullCoverage(t *testing.T) {
+	testhelpers.AccPreCheck(t)
+	suffix := testhelpers.RunSuffix()
+	name := "tf-acc-policy-scope-alljss-" + suffix
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testhelpers.AccTestProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckPolicyDestroy(t),
+		Steps: []resource.TestStep{
+			{
+				Config: policyConfigScopeAllJssUsers(name, true),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"jamfplatform_pro_policy.test",
+						tfjsonpath.New("scope").AtMapKey("all_jss_users"),
+						knownvalue.Bool(true),
+					),
+					statecheck.ExpectKnownValue(
+						"jamfplatform_pro_policy.test",
+						tfjsonpath.New("scope").AtMapKey("all_computers"),
+						knownvalue.Bool(true),
+					),
+				},
+			},
+			{
+				Config: policyConfigScopeAllJssUsers(name, false),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"jamfplatform_pro_policy.test",
+						tfjsonpath.New("scope").AtMapKey("all_jss_users"),
+						knownvalue.Bool(false),
+					),
+				},
+			},
+		},
+	})
+}
+
+func policyConfigScopeTargetsAllFixtures(policyName, buildingName, departmentName, deviceGroupName, userGroupName string, computerID, userID string) string {
+	return fmt.Sprintf(`
+resource "jamfplatform_pro_building" "fixture" {
+  name = %q
+}
+
+resource "jamfplatform_pro_department" "fixture" {
+  name = %q
+}
+
+resource "jamfplatform_device_group" "fixture" {
+  name        = %q
+  description = "tf-acc scope fixture"
+  group_type  = "static"
+  device_type = "computer"
+}
+
+resource "jamfplatform_pro_user_group" "fixture" {
+  name       = %q
+  group_type = "static"
+}
+
+resource "jamfplatform_pro_policy" "test" {
+  general = {
+    name = %q
+  }
+  scope = {
+    computer_ids       = [%q]
+    computer_group_ids = [jamfplatform_device_group.fixture.jamf_pro_id]
+    building_ids       = [jamfplatform_pro_building.fixture.id]
+    department_ids     = [jamfplatform_pro_department.fixture.id]
+    jss_user_ids       = [%q]
+    jss_user_group_ids = [jamfplatform_pro_user_group.fixture.id]
+  }
+}
+`, buildingName, departmentName, deviceGroupName, userGroupName, policyName, computerID, userID)
+}
+
+// TestAccPolicyResource_ScopeTargetsFixtureCoverage exercises every scope
+// target sub-block by creating one fixture per category and asserting the
+// resulting set membership round-trips through the policy resource. Fixtures
+// that have a matching Terraform Pro resource are declared inline in the HCL;
+// fixtures the project does not yet expose as resources (classic computer,
+// classic user) are created out-of-band via direct SDK calls and cleaned up
+// at test end via t.Cleanup.
+//
+// The static computer group is created via the Platform Services
+// jamfplatform_device_group resource and its server-derived `jamf_pro_id`
+// attribute bridges into the classic policy's computer_group_ids set per the
+// resource description.
+func TestAccPolicyResource_ScopeTargetsFixtureCoverage(t *testing.T) {
+	testhelpers.AccPreCheck(t)
+	suffix := testhelpers.RunSuffix()
+	policyName := "tf-acc-policy-scope-targets-" + suffix
+	buildingName := "tf-acc-building-" + suffix
+	departmentName := "tf-acc-department-" + suffix
+	deviceGroupName := "tf-acc-device-group-" + suffix
+	userGroupName := "tf-acc-user-group-" + suffix
+	computerName := "tf-acc-computer-" + suffix
+	userName := "tf-acc-user-" + suffix
+
+	computerID := createDummyComputer(t, computerName)
+	userID := createDummyUser(t, userName)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testhelpers.AccTestProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckPolicyDestroy(t),
+		Steps: []resource.TestStep{
+			{
+				Config: policyConfigScopeTargetsAllFixtures(policyName, buildingName, departmentName, deviceGroupName, userGroupName, computerID, userID),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"jamfplatform_pro_policy.test",
+						tfjsonpath.New("scope").AtMapKey("computer_ids"),
+						knownvalue.SetSizeExact(1),
+					),
+					statecheck.ExpectKnownValue(
+						"jamfplatform_pro_policy.test",
+						tfjsonpath.New("scope").AtMapKey("computer_group_ids"),
+						knownvalue.SetSizeExact(1),
+					),
+					statecheck.ExpectKnownValue(
+						"jamfplatform_pro_policy.test",
+						tfjsonpath.New("scope").AtMapKey("building_ids"),
+						knownvalue.SetSizeExact(1),
+					),
+					statecheck.ExpectKnownValue(
+						"jamfplatform_pro_policy.test",
+						tfjsonpath.New("scope").AtMapKey("department_ids"),
+						knownvalue.SetSizeExact(1),
+					),
+					statecheck.ExpectKnownValue(
+						"jamfplatform_pro_policy.test",
+						tfjsonpath.New("scope").AtMapKey("jss_user_ids"),
+						knownvalue.SetSizeExact(1),
+					),
+					statecheck.ExpectKnownValue(
+						"jamfplatform_pro_policy.test",
+						tfjsonpath.New("scope").AtMapKey("jss_user_group_ids"),
+						knownvalue.SetSizeExact(1),
+					),
+				},
+			},
+		},
+	})
+}
+
+func policyConfigScopeLimitations(policyName, networkSegmentName, ibeaconName string) string {
+	return fmt.Sprintf(`
+resource "jamfplatform_pro_network_segment" "fixture" {
+  name             = %q
+  starting_address = "10.99.0.0"
+  ending_address   = "10.99.0.255"
+}
+
+resource "jamfplatform_pro_ibeacon" "fixture" {
+  name                    = %q
+  uuid                    = "759b0599-64e0-416a-8d31-d8e93482a4d7"
+  include_any_major_value = true
+  include_any_minor_value = true
+}
+
+resource "jamfplatform_pro_policy" "test" {
+  general = {
+    name = %q
+  }
+  scope = {
+    all_computers = true
+    limitations = {
+      network_segment_ids = [jamfplatform_pro_network_segment.fixture.id]
+      ibeacon_ids         = [jamfplatform_pro_ibeacon.fixture.id]
+    }
+  }
+}
+`, networkSegmentName, ibeaconName, policyName)
+}
+
+// TestAccPolicyResource_ScopeLimitationsFixtureCoverage exercises the
+// fixture-backed `scope.limitations` sub-attributes — network segment IDs and
+// iBeacon IDs. The `directory_service_or_local_user_names` and
+// `directory_service_user_group_names` attributes are NOT exercised here: the
+// classic API rejects names that do not resolve against the tenant's LDAP
+// integration (`Error: Problem matching limitation user group`), so testing
+// them requires fixture LDAP entries the tenant does not generally provide.
+// Their wire round-trip is covered indirectly via the policy 6791 baseline
+// captured in PHASE_2_6_SPIKE.md §Appendix.
+func TestAccPolicyResource_ScopeLimitationsFixtureCoverage(t *testing.T) {
+	testhelpers.AccPreCheck(t)
+	suffix := testhelpers.RunSuffix()
+	policyName := "tf-acc-policy-scope-lim-" + suffix
+	networkSegmentName := "tf-acc-netseg-" + suffix
+	ibeaconName := "tf-acc-ibeacon-" + suffix
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testhelpers.AccTestProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckPolicyDestroy(t),
+		Steps: []resource.TestStep{
+			{
+				Config: policyConfigScopeLimitations(policyName, networkSegmentName, ibeaconName),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"jamfplatform_pro_policy.test",
+						tfjsonpath.New("scope").AtMapKey("limitations").AtMapKey("network_segment_ids"),
+						knownvalue.SetSizeExact(1),
+					),
+					statecheck.ExpectKnownValue(
+						"jamfplatform_pro_policy.test",
+						tfjsonpath.New("scope").AtMapKey("limitations").AtMapKey("ibeacon_ids"),
+						knownvalue.SetSizeExact(1),
+					),
+				},
+			},
+		},
+	})
+}
+
+func policyConfigScopeExclusions(policyName, buildingName, departmentName, deviceGroupName, userGroupName, networkSegmentName, ibeaconName string, computerID, userID string) string {
+	return fmt.Sprintf(`
+resource "jamfplatform_pro_building" "fixture" {
+  name = %q
+}
+
+resource "jamfplatform_pro_department" "fixture" {
+  name = %q
+}
+
+resource "jamfplatform_device_group" "fixture" {
+  name        = %q
+  description = "tf-acc scope exclusions fixture"
+  group_type  = "static"
+  device_type = "computer"
+}
+
+resource "jamfplatform_pro_user_group" "fixture" {
+  name       = %q
+  group_type = "static"
+}
+
+resource "jamfplatform_pro_network_segment" "fixture" {
+  name             = %q
+  starting_address = "10.88.0.0"
+  ending_address   = "10.88.0.255"
+}
+
+resource "jamfplatform_pro_ibeacon" "fixture" {
+  name                    = %q
+  uuid                    = "759b0599-64e0-416a-8d31-d8e93482a4d7"
+  include_any_major_value = true
+  include_any_minor_value = true
+}
+
+resource "jamfplatform_pro_policy" "test" {
+  general = {
+    name = %q
+  }
+  scope = {
+    all_computers = true
+    exclusions = {
+      computer_ids                          = [%q]
+      computer_group_ids                    = [jamfplatform_device_group.fixture.jamf_pro_id]
+      building_ids                          = [jamfplatform_pro_building.fixture.id]
+      department_ids                        = [jamfplatform_pro_department.fixture.id]
+      jss_user_ids        = [%q]
+      jss_user_group_ids  = [jamfplatform_pro_user_group.fixture.id]
+      network_segment_ids = [jamfplatform_pro_network_segment.fixture.id]
+      ibeacon_ids         = [jamfplatform_pro_ibeacon.fixture.id]
+    }
+  }
+}
+`, buildingName, departmentName, deviceGroupName, userGroupName, networkSegmentName, ibeaconName, policyName, computerID, userID)
+}
+
+// TestAccPolicyResource_ScopeExclusionsFixtureCoverage mirrors the targets
+// + limitations coverage but routes every fixture ID through
+// scope.exclusions. Verifies that the exclusion-side schema parallels the
+// target schema and that the SDK builders emit the right wire shape under
+// `<scope><exclusions>`. Free-form directory-service name fields are
+// omitted for the same reason as in
+// TestAccPolicyResource_ScopeLimitationsFixtureCoverage: the classic API
+// validates names against the tenant's LDAP integration and rejects names
+// that do not resolve.
+func TestAccPolicyResource_ScopeExclusionsFixtureCoverage(t *testing.T) {
+	testhelpers.AccPreCheck(t)
+	suffix := testhelpers.RunSuffix()
+	policyName := "tf-acc-policy-scope-excl-" + suffix
+	buildingName := "tf-acc-building-excl-" + suffix
+	departmentName := "tf-acc-department-excl-" + suffix
+	deviceGroupName := "tf-acc-device-group-excl-" + suffix
+	userGroupName := "tf-acc-user-group-excl-" + suffix
+	networkSegmentName := "tf-acc-netseg-excl-" + suffix
+	ibeaconName := "tf-acc-ibeacon-excl-" + suffix
+	computerName := "tf-acc-computer-excl-" + suffix
+	userName := "tf-acc-user-excl-" + suffix
+
+	computerID := createDummyComputer(t, computerName)
+	userID := createDummyUser(t, userName)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testhelpers.AccTestProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckPolicyDestroy(t),
+		Steps: []resource.TestStep{
+			{
+				Config: policyConfigScopeExclusions(policyName, buildingName, departmentName, deviceGroupName, userGroupName, networkSegmentName, ibeaconName, computerID, userID),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"jamfplatform_pro_policy.test",
+						tfjsonpath.New("scope").AtMapKey("exclusions").AtMapKey("computer_ids"),
+						knownvalue.SetSizeExact(1),
+					),
+					statecheck.ExpectKnownValue(
+						"jamfplatform_pro_policy.test",
+						tfjsonpath.New("scope").AtMapKey("exclusions").AtMapKey("computer_group_ids"),
+						knownvalue.SetSizeExact(1),
+					),
+					statecheck.ExpectKnownValue(
+						"jamfplatform_pro_policy.test",
+						tfjsonpath.New("scope").AtMapKey("exclusions").AtMapKey("building_ids"),
+						knownvalue.SetSizeExact(1),
+					),
+					statecheck.ExpectKnownValue(
+						"jamfplatform_pro_policy.test",
+						tfjsonpath.New("scope").AtMapKey("exclusions").AtMapKey("department_ids"),
+						knownvalue.SetSizeExact(1),
+					),
+					statecheck.ExpectKnownValue(
+						"jamfplatform_pro_policy.test",
+						tfjsonpath.New("scope").AtMapKey("exclusions").AtMapKey("jss_user_ids"),
+						knownvalue.SetSizeExact(1),
+					),
+					statecheck.ExpectKnownValue(
+						"jamfplatform_pro_policy.test",
+						tfjsonpath.New("scope").AtMapKey("exclusions").AtMapKey("jss_user_group_ids"),
+						knownvalue.SetSizeExact(1),
+					),
+					statecheck.ExpectKnownValue(
+						"jamfplatform_pro_policy.test",
+						tfjsonpath.New("scope").AtMapKey("exclusions").AtMapKey("network_segment_ids"),
+						knownvalue.SetSizeExact(1),
+					),
+					statecheck.ExpectKnownValue(
+						"jamfplatform_pro_policy.test",
+						tfjsonpath.New("scope").AtMapKey("exclusions").AtMapKey("ibeacon_ids"),
+						knownvalue.SetSizeExact(1),
 					),
 				},
 			},

--- a/internal/resources/pro/policies/policy/state_builders.go
+++ b/internal/resources/pro/policies/policy/state_builders.go
@@ -483,27 +483,64 @@ func flattenPolicyDockItems(d *proclassic.PolicyDockItems, state *PolicyDockItem
 
 func flattenPolicyAccountMaintenance(am *proclassic.PolicyAccountMaintenance, state *PolicyAccountMaintenanceModel) {
 	if am.Accounts != nil && am.Accounts.Account != nil {
+		// Build a username → planned-plaintext-password lookup so the Set's
+		// unordered round-trip preserves the per-account Sensitive plaintext.
+		// The server never echoes the plaintext, so an index-based pairing is
+		// wrong: Set hashing reorders items and the i-th flattened entry will
+		// not correspond to the i-th state entry. Username is the natural key
+		// for Create/Reset/Delete/DisableFileVault — Probe 9 confirmed the
+		// classic API accepts duplicate usernames across actions, so this
+		// preserves plaintext correctly even in the multi-action policy
+		// pattern (policy 6791 baseline).
+		// passwordByUsername + shaByUsername lookup is LOAD-BEARING for any
+		// policy where the Set may reorder between plan and apply. Do NOT
+		// "simplify" to index-based pairing — Sets are inherently unordered,
+		// and the classic API has been observed reordering account entries on
+		// round-trip, so the i-th flattened entry is not guaranteed to match
+		// the i-th state entry. The username-keyed pair lets us:
+		//   - Preserve the Sensitive plaintext `password` across the Sets's
+		//     unordered round-trip (server never echoes plaintext).
+		//   - Carry the prior `password_sha256` forward via
+		//     preferServerOrCurrentString when the server omits the SHA echo
+		//     on Update (same `""` / `nil` regression that hits
+		//     open_firmware_efi_password.of_password_sha256 — applied
+		//     prophylactically here so an Update-step acc test won't regress).
+		passwordByUsername := make(map[string]types.String, len(state.Accounts))
+		shaByUsername := make(map[string]types.String, len(state.Accounts))
+		for _, prev := range state.Accounts {
+			if !prev.Username.IsNull() && !prev.Username.IsUnknown() {
+				passwordByUsername[prev.Username.ValueString()] = prev.Password
+				shaByUsername[prev.Username.ValueString()] = prev.PasswordSha256
+			}
+		}
+
 		items := *am.Accounts.Account
 		out := make([]PolicyAccountItemModel, 0, len(items))
-		for i, a := range items {
-			var currentPassword types.String
-			if i < len(state.Accounts) {
-				currentPassword = state.Accounts[i].Password
+		for _, a := range items {
+			currentPassword := types.StringNull()
+			currentSha := types.StringNull()
+			if a.Username != nil {
+				if p, ok := passwordByUsername[*a.Username]; ok {
+					currentPassword = p
+				}
+				if s, ok := shaByUsername[*a.Username]; ok {
+					currentSha = s
+				}
 			}
 			out = append(out, PolicyAccountItemModel{
-				Action:                 helpers.StringPointerValueOrNull(a.Action),
-				Username:               helpers.StringPointerValueOrNull(a.Username),
-				Realname:               helpers.StringPointerValueOrNull(a.Realname),
-				Password:               currentPassword, // server doesn't echo plaintext — preserve plan/state value
-				PasswordSha256:         helpers.StringPointerValueOrNull(a.PasswordSha256),
-				ArchiveHomeDirectory:   helpers.BoolPointerValueOrNull(a.ArchiveHomeDirectory),
-				ArchiveHomeDirectoryTo: helpers.StringPointerValueOrNull(a.ArchiveHomeDirectoryTo),
-				Home:                   helpers.StringPointerValueOrNull(a.Home),
-				Hint:                   helpers.StringPointerValueOrNull(a.Hint),
-				Picture:                helpers.StringPointerValueOrNull(a.Picture),
-				Admin:                  helpers.BoolPointerValueOrNull(a.Admin),
-				FilevaultEnabled:       helpers.BoolPointerValueOrNull(a.FilevaultEnabled),
-				SecureTokenAllowed:     helpers.BoolPointerValueOrNull(a.SecureTokenAllowed),
+				Action:                         helpers.StringPointerValueOrNull(a.Action),
+				Username:                       helpers.StringPointerValueOrNull(a.Username),
+				Realname:                       helpers.StringPointerValueOrNull(a.Realname),
+				Password:                       currentPassword, // server doesn't echo plaintext — preserve plan/state value
+				PasswordSha256:                 preferServerOrCurrentString(a.PasswordSha256, currentSha),
+				PermanentlyDeleteHomeDirectory: invertBoolPointerValueOrNull(a.ArchiveHomeDirectory),
+				ArchiveHomeDirectoryTo:         helpers.StringPointerValueOrNull(a.ArchiveHomeDirectoryTo),
+				Home:                           helpers.StringPointerValueOrNull(a.Home),
+				Hint:                           helpers.StringPointerValueOrNull(a.Hint),
+				Picture:                        helpers.StringPointerValueOrNull(a.Picture),
+				Admin:                          helpers.BoolPointerValueOrNull(a.Admin),
+				FilevaultEnabled:               helpers.BoolPointerValueOrNull(a.FilevaultEnabled),
+				SecureTokenAllowed:             helpers.BoolPointerValueOrNull(a.SecureTokenAllowed),
 			})
 		}
 		state.Accounts = out
@@ -525,22 +562,31 @@ func flattenPolicyAccountMaintenance(am *proclassic.PolicyAccountMaintenance, st
 		state.DirectoryBindings = nil
 	}
 
-	if am.ManagementAccount != nil {
-		if state.ManagementAccount == nil {
-			state.ManagementAccount = &PolicyManagementAccountModel{}
-		}
+	// management_account + open_firmware_efi_password are Optional sibling
+	// blocks. The classic API returns default-shaped objects for both even
+	// when the caller did not set them, so unconditionally populating state
+	// would violate the framework's "produced inconsistent result after
+	// apply" check: plan said null, we would return a populated object.
+	// Mirror the assignPolicyResourceModel section-level gate — only refresh
+	// when the caller already manages the sub-block.
+	if state.ManagementAccount != nil && am.ManagementAccount != nil {
 		state.ManagementAccount.Action = preferCurrentStringPointer(am.ManagementAccount.Action, state.ManagementAccount.Action)
 		// managed_password not echoed — preserve user-supplied
 		state.ManagementAccount.ManagedPasswordLength = preferCurrentInt(am.ManagementAccount.ManagedPasswordLength, state.ManagementAccount.ManagedPasswordLength)
 	}
 
-	if am.OpenFirmwareEfiPassword != nil {
-		if state.OpenFirmwareEfiPassword == nil {
-			state.OpenFirmwareEfiPassword = &PolicyOpenFirmwareEfiPasswordModel{}
-		}
+	if state.OpenFirmwareEfiPassword != nil && am.OpenFirmwareEfiPassword != nil {
 		state.OpenFirmwareEfiPassword.OfMode = preferCurrentStringPointer(am.OpenFirmwareEfiPassword.OfMode, state.OpenFirmwareEfiPassword.OfMode)
-		// of_password not echoed — preserve user-supplied
-		state.OpenFirmwareEfiPassword.OfPasswordSha256 = helpers.StringPointerValueOrNull(am.OpenFirmwareEfiPassword.OfPasswordSha256)
+		// of_password not echoed — preserve user-supplied. of_password_sha256
+		// is the Jamf-returned sentinel `********************` once a password
+		// is set, but the server intermittently omits the echo on Update
+		// round-trips (observed: of_mode `command` → `full` clears the SHA
+		// from the response even though the password is still stored).
+		// Preserve the prior state SHA when the server returns nil so the
+		// Computed attribute does not flip back to null — Update-time
+		// inconsistency would otherwise trip the framework's
+		// "produced inconsistent result after apply" check.
+		state.OpenFirmwareEfiPassword.OfPasswordSha256 = preferServerOrCurrentString(am.OpenFirmwareEfiPassword.OfPasswordSha256, state.OpenFirmwareEfiPassword.OfPasswordSha256)
 	}
 }
 

--- a/internal/resources/pro/policies/policy/state_builders.go
+++ b/internal/resources/pro/policies/policy/state_builders.go
@@ -392,6 +392,8 @@ func flattenPolicySelfService(ss *proclassic.PolicySelfService, state *PolicySel
 }
 
 func flattenPolicyPackageConfiguration(pc *proclassic.PolicyPackageConfiguration, state *PolicyPackageConfigurationModel) {
+	state.DistributionPoint = preferCurrentStringPointer(pc.DistributionPoint, state.DistributionPoint)
+
 	if pc.Packages == nil || pc.Packages.Package == nil {
 		state.Packages = nil
 		return

--- a/internal/resources/pro/policies/policy/state_builders.go
+++ b/internal/resources/pro/policies/policy/state_builders.go
@@ -170,6 +170,7 @@ func flattenPolicyNetworkLimitations(ctx context.Context, nl *proclassic.PolicyG
 func flattenPolicyScope(ctx context.Context, s *proclassic.PolicyScope, state *PolicyScopeModel) diag.Diagnostics {
 	var diags diag.Diagnostics
 	state.AllComputers = preferCurrentBoolPointer(s.AllComputers, state.AllComputers)
+	state.AllJssUsers = preferCurrentBoolPointer(s.AllJssUsers, state.AllJssUsers)
 
 	state.ComputerIDs = flattenComputerItemSet(ctx, s.Computers)
 	state.ComputerGroupIDs = flattenIDNameSet(ctx, idNameSliceFromGroups(s.ComputerGroups))

--- a/internal/resources/pro/policies/policy/state_builders_test.go
+++ b/internal/resources/pro/policies/policy/state_builders_test.go
@@ -108,3 +108,50 @@ func TestAssignPolicyResourceModel_RoundTripNotification(t *testing.T) {
 		t.Fatalf("expected notification_type=Self Service, got %q", state.SelfService.NotificationType.ValueString())
 	}
 }
+
+func TestAssignPolicyResourceModel_PackageConfigurationDistributionPoint(t *testing.T) {
+	t.Parallel()
+	state := &PolicyResourceModel{
+		General:              &PolicyGeneralModel{Name: types.StringValue("tf-acc")},
+		PackageConfiguration: &PolicyPackageConfigurationModel{},
+	}
+	src := &proclassic.Policy{
+		General: &proclassic.PolicyGeneral{Name: new("tf-acc")},
+		PackageConfiguration: &proclassic.PolicyPackageConfiguration{
+			DistributionPoint: new("Dummy DP"),
+		},
+	}
+	diags := assignPolicyResourceModel(context.Background(), state, src)
+	if diags.HasError() {
+		t.Fatalf("unexpected diagnostics: %v", diags)
+	}
+	if state.PackageConfiguration.DistributionPoint.ValueString() != "Dummy DP" {
+		t.Fatalf("expected distribution_point=Dummy DP, got %q", state.PackageConfiguration.DistributionPoint.ValueString())
+	}
+	if state.PackageConfiguration.Packages != nil {
+		t.Fatalf("expected packages nil when server returned none, got %+v", state.PackageConfiguration.Packages)
+	}
+}
+
+func TestAssignPolicyResourceModel_PackageConfigurationConfiguredWins(t *testing.T) {
+	t.Parallel()
+	state := &PolicyResourceModel{
+		General: &PolicyGeneralModel{Name: types.StringValue("tf-acc")},
+		PackageConfiguration: &PolicyPackageConfigurationModel{
+			DistributionPoint: types.StringValue("Configured DP"),
+		},
+	}
+	src := &proclassic.Policy{
+		General: &proclassic.PolicyGeneral{Name: new("tf-acc")},
+		PackageConfiguration: &proclassic.PolicyPackageConfiguration{
+			DistributionPoint: new("Server DP"),
+		},
+	}
+	diags := assignPolicyResourceModel(context.Background(), state, src)
+	if diags.HasError() {
+		t.Fatalf("unexpected diagnostics: %v", diags)
+	}
+	if got := state.PackageConfiguration.DistributionPoint.ValueString(); got != "Configured DP" {
+		t.Fatalf("preferCurrentStringPointer should keep configured value, got %q", got)
+	}
+}

--- a/internal/resources/pro/policies/policy/validators.go
+++ b/internal/resources/pro/policies/policy/validators.go
@@ -1,0 +1,135 @@
+// Copyright Jamf Software LLC 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package policy
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+)
+
+// minutesPerDay is the wire-required granularity for
+// user_interaction.allow_deferral_minutes. The classic API enforces
+// "allow_deferral_minutes must be a multiple of 1440 (minutes in day)" and
+// returns HTTP 409 on any non-multiple.
+const minutesPerDay = 1440
+
+// multipleOfInt64Validator enforces that an Int64 attribute is a positive
+// multiple of a fixed divisor. The classic /policies endpoint applies this to
+// user_interaction.allow_deferral_minutes (divisor 1440 — one day). A
+// dedicated validator is needed because terraform-plugin-framework-validators
+// only ships int64validator.OneOf (enumerable) and int64validator.Between
+// (range) — neither expresses "any multiple of N".
+type multipleOfInt64Validator struct {
+	divisor int64
+}
+
+// MultipleOfInt64 returns a validator.Int64 enforcing multiple-of-divisor.
+func MultipleOfInt64(divisor int64) validator.Int64 {
+	return multipleOfInt64Validator{divisor: divisor}
+}
+
+// Description returns a plain-text description of the validator.
+func (v multipleOfInt64Validator) Description(context.Context) string {
+	return fmt.Sprintf("value must be a multiple of %d", v.divisor)
+}
+
+// MarkdownDescription returns the markdown description.
+func (v multipleOfInt64Validator) MarkdownDescription(ctx context.Context) string {
+	return v.Description(ctx)
+}
+
+// ValidateInt64 implements validator.Int64.
+func (v multipleOfInt64Validator) ValidateInt64(ctx context.Context, req validator.Int64Request, resp *validator.Int64Response) {
+	if req.ConfigValue.IsNull() || req.ConfigValue.IsUnknown() {
+		return
+	}
+	value := req.ConfigValue.ValueInt64()
+	if v.divisor == 0 || value%v.divisor != 0 {
+		resp.Diagnostics.AddAttributeError(
+			req.Path,
+			"Invalid value",
+			fmt.Sprintf("Expected a multiple of %d, got %d.", v.divisor, value),
+		)
+	}
+}
+
+// userInteractionConfigValidator enforces the two cross-field constraints the
+// classic /policies endpoint applies to <user_interaction>:
+//
+//  1. When allow_users_to_defer = false, neither allow_deferral_until_utc nor
+//     allow_deferral_minutes may be set. The server returns 409 with `Error:
+//     When 'allow_users_to_defer' is false, 'allow_deferral_until_utc' and
+//     'allow_deferral_minutes' cannot be configured`.
+//  2. allow_deferral_until_utc and allow_deferral_minutes are mutually
+//     exclusive. The server returns 409 with `Error: You cannot use both
+//     'allow_deferral_until_utc' and 'allow_deferral_minutes'`. Note that
+//     omitting one field on an Update does not clear a previously-stored
+//     value (Optional+Computed semantics keep prior state); transitioning
+//     between the two deferral forms therefore requires destroy+recreate.
+//
+// The third documented wire constraint (allow_deferral_minutes must be a
+// multiple of 1440) is enforced inline on the attribute via MultipleOfInt64.
+type userInteractionConfigValidator struct{}
+
+// UserInteractionConfigValidator returns the resource.ConfigValidator wiring
+// the user_interaction cross-field rules into plan-time validation.
+func UserInteractionConfigValidator() resource.ConfigValidator {
+	return userInteractionConfigValidator{}
+}
+
+// Description returns a plain-text description of the validator.
+func (userInteractionConfigValidator) Description(context.Context) string {
+	return "user_interaction: allow_users_to_defer=false forbids deferral fields; allow_deferral_until_utc and allow_deferral_minutes are mutually exclusive"
+}
+
+// MarkdownDescription returns the markdown description.
+func (v userInteractionConfigValidator) MarkdownDescription(ctx context.Context) string {
+	return v.Description(ctx)
+}
+
+// ValidateResource implements the plan-time cross-field check.
+func (userInteractionConfigValidator) ValidateResource(ctx context.Context, req resource.ValidateConfigRequest, resp *resource.ValidateConfigResponse) {
+	var data PolicyResourceModel
+	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() || data.UserInteraction == nil {
+		return
+	}
+	ui := data.UserInteraction
+
+	untilSet := !ui.AllowDeferralUntilUtc.IsNull() && !ui.AllowDeferralUntilUtc.IsUnknown()
+	minutesSet := !ui.AllowDeferralMinutes.IsNull() && !ui.AllowDeferralMinutes.IsUnknown()
+
+	// Rule 1: when allow_users_to_defer is explicitly false, deferral fields
+	// are forbidden. A null/Unknown allow_users_to_defer is treated as
+	// "unset", which the server accepts.
+	if !ui.AllowUsersToDefer.IsNull() && !ui.AllowUsersToDefer.IsUnknown() && !ui.AllowUsersToDefer.ValueBool() {
+		if untilSet {
+			resp.Diagnostics.AddAttributeError(
+				path.Root("user_interaction").AtName("allow_deferral_until_utc"),
+				"allow_deferral_until_utc forbidden when allow_users_to_defer = false",
+				"Set `allow_users_to_defer = true` to use a deferral cut-off, or remove `allow_deferral_until_utc`. The classic API rejects this combination with HTTP 409 (`Error: When 'allow_users_to_defer' is false, 'allow_deferral_until_utc' and 'allow_deferral_minutes' cannot be configured`).",
+			)
+		}
+		if minutesSet {
+			resp.Diagnostics.AddAttributeError(
+				path.Root("user_interaction").AtName("allow_deferral_minutes"),
+				"allow_deferral_minutes forbidden when allow_users_to_defer = false",
+				"Set `allow_users_to_defer = true` to use a deferral duration, or remove `allow_deferral_minutes`. The classic API rejects this combination with HTTP 409 (`Error: When 'allow_users_to_defer' is false, 'allow_deferral_until_utc' and 'allow_deferral_minutes' cannot be configured`).",
+			)
+		}
+	}
+
+	// Rule 2: until_utc and minutes are mutually exclusive.
+	if untilSet && minutesSet {
+		resp.Diagnostics.AddAttributeError(
+			path.Root("user_interaction").AtName("allow_deferral_minutes"),
+			"allow_deferral_until_utc and allow_deferral_minutes are mutually exclusive",
+			"Set exactly one of `allow_deferral_until_utc` (a cut-off date) or `allow_deferral_minutes` (a duration). The classic API rejects both being set with HTTP 409 (`Error: You cannot use both 'allow_deferral_until_utc' and 'allow_deferral_minutes'`). Note: omitting one on an Update does not clear a previously-set value — transitioning between forms requires destroy+recreate.",
+		)
+	}
+}

--- a/internal/resources/pro/policies/policy/validators_test.go
+++ b/internal/resources/pro/policies/policy/validators_test.go
@@ -1,0 +1,64 @@
+// Copyright Jamf Software LLC 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package policy
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func TestMultipleOfInt64_AcceptsMultiples(t *testing.T) {
+	t.Parallel()
+	v := MultipleOfInt64(1440)
+	for _, val := range []int64{0, 1440, 2880, 14400} {
+		req := validator.Int64Request{
+			Path:        path.Root("allow_deferral_minutes"),
+			ConfigValue: types.Int64Value(val),
+		}
+		resp := &validator.Int64Response{}
+		v.ValidateInt64(context.Background(), req, resp)
+		if resp.Diagnostics.HasError() {
+			t.Fatalf("expected %d to be accepted, got diagnostics %v", val, resp.Diagnostics)
+		}
+	}
+}
+
+func TestMultipleOfInt64_RejectsNonMultiples(t *testing.T) {
+	t.Parallel()
+	v := MultipleOfInt64(1440)
+	for _, val := range []int64{1, 60, 1441, 2881} {
+		req := validator.Int64Request{
+			Path:        path.Root("allow_deferral_minutes"),
+			ConfigValue: types.Int64Value(val),
+		}
+		resp := &validator.Int64Response{}
+		v.ValidateInt64(context.Background(), req, resp)
+		if !resp.Diagnostics.HasError() {
+			t.Fatalf("expected %d to be rejected, got no error", val)
+		}
+	}
+}
+
+func TestMultipleOfInt64_SkipsNullAndUnknown(t *testing.T) {
+	t.Parallel()
+	v := MultipleOfInt64(1440)
+	for name, value := range map[string]types.Int64{
+		"null":    types.Int64Null(),
+		"unknown": types.Int64Unknown(),
+	} {
+		req := validator.Int64Request{
+			Path:        path.Root("allow_deferral_minutes"),
+			ConfigValue: value,
+		}
+		resp := &validator.Int64Response{}
+		v.ValidateInt64(context.Background(), req, resp)
+		if resp.Diagnostics.HasError() {
+			t.Fatalf("expected %s to be skipped, got diagnostics %v", name, resp.Diagnostics)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Lands Phase 2.6 of the Jamf Pro classic policy resource: every section in the 13-section policy payload now has additive acceptance coverage, a handful of probe-driven schema corrections, plan-time validators for the cross-field rules surfaced during the acc runs, and the Probe #8 / Probe #9 renames + bugfixes for account_maintenance.

Commits land in five logical chunks against \`feat/pro-expansion\`:

1. **\`chore(deps): bump jamfplatform-go-sdk\`** — pulls in [jamfplatform-go-sdk PR #21](https://github.com/Jamf-Concepts/jamfplatform-go-sdk/pull/21) which adds \`PolicyPackageConfiguration.DistributionPoint\` to both Get and Post types. Wire returns \`<distribution_point>\` peer of \`<packages>\`; SDK previously omitted it entirely (Go \`encoding/xml\` silently drops unknown elements). Spike audit miss.

2. **\`feat(pro/policy): package_configuration top-level distribution_point\`** — adds the new attribute. Two acc tests: one for the DP alone, one alongside a \`jamfplatform_pro_package\` fixture exercising the \`packages\` set.

3. **\`feat(pro/policy): remaining sections acceptance coverage + user_interaction validators\`** — per-section acc tests for scripts, printers, dock_items, maintenance, files_processes, user_interaction, disk_encryption. Three new \`user_interaction\` plan-time validators: \`MultipleOfInt64(1440)\` on \`allow_deferral_minutes\`, plus a cross-field validator enforcing the \`allow_users_to_defer=false\` block and the \`until_utc\` ⊕ \`minutes\` mutual exclusion.

4. **\`feat(pro/policy): wire scope.all_jss_users + full scope sub-block acceptance coverage\`** — wires the d7d755d SDK fix into the provider schema, plus fixture-backed coverage for every scope sub-block (targets + limitations + exclusions). Uses inline Pro resources where available (building, department, device_group, user_group, network_segment, ibeacon) and direct SDK calls in test setup for fixture-less classes (classic computers + users, cleaned up via \`t.Cleanup\`). \`scope.all_computers\` / \`scope.all_jss_users\` switched to Optional+Computed (UseStateForUnknown) — the prior Optional-only declaration tripped the framework's apply-time consistency check whenever the server echoed a default of \`false\`.

5. **\`feat(pro/policy)!: account_maintenance section coverage + breaking renames\`** — BREAKING:
   - \`accounts[].action\`: proper \`OneOf(\"Create\", \"Reset\", \"Delete\", \"DisableFileVault\")\` validator (Probe #9 — wire is \`DisableFileVault\`, no trailing \`2\`).
   - \`accounts[].archive_home_directory\` renamed to \`permanently_delete_home_directory\` AND inverted in semantics (Probe #8). Mirrors the Jamf Pro UI checkbox label.
   - \`flattenPolicyAccountMaintenance\` now gates \`management_account\` / \`open_firmware_efi_password\` sub-block flattening on \`state.X != nil\`, plus uses username-keyed lookups to preserve Sensitive plaintext + SHA across the Sets unordered round-trip.
   - New \`preferServerOrCurrentString\` helper for Computed Strings the classic server intermittently fails to echo on Update (observed: \`of_password_sha256\` flips \`\"********************\"\` → \`\"\"\`).
   - Resource MarkdownDescription documents the classic \`<software_update>\` block as intentionally not modelled (obsolete delivery path).

No state upgraders — provider has not shipped publicly (maintainer-confirmed) so breaking renames are free.

## Probe / discovery notes worth carrying forward

- **SDK audit miss**: \`PolicyPackageConfiguration.DistributionPoint\` was wire-present but missing from SDK types AND the OpenAPI spec. Fixed upstream in PR #21 before the provider work landed. Spike audit had marked the field \"add\" without flagging it as sdk-blocked.
- **user_interaction cross-field constraints** documented from acc-test failures: \`allow_deferral_minutes\` must be a multiple of 1440 (one day); \`allow_users_to_defer=false\` forbids both deferral fields; the two deferral forms are mutually exclusive and the classic API cannot clear one on Update (Optional+Computed keeps state) so transitioning between forms requires destroy+recreate.
- **\`of_password_sha256\` echo regression**: classic /policies returns the SHA sentinel as \`\"\"\` (or nil) on certain Update round-trips; \`preferServerOrCurrentString\` substitutes the prior state value to keep Computed values consistent.
- **DisableFileVault account creation is API-only-rejected**: schema accepts the validator value but the classic /policies CREATE silently strips \`<account><action>DisableFileVault</action>\` entries. Spike baseline policy 6791 has the action surviving — created via the UI. Acceptance coverage deferred; documented in the AM tests.

## Acceptance coverage

22 acceptance tests for \`jamfplatform_pro_policy\` exercising every section in the schema. Approximate wall-clock for the full \`TestAccPolicyResource\` sweep on the test tenant: ~3 minutes.

## Out of scope

- \`scope.limit_to_users\` provider wiring (SDK exposes it; awaiting maintainer decision).
- Multi-category \`self_service.self_service_categories\` migration (SDK fix landed in d7d755d; provider follow-up tracked).
- WriteOnly migration for plaintext password attrs across the provider — tracked as a dedicated follow-up PR with companion \`_wo_version\` rotation triggers and removal of the \`*_sha256\` Computed siblings (Jamf returns a sentinel \`********************\`, not a real hash).

## Test plan

- [x] \`make fix fmt lint test\` clean.
- [x] \`make generate\` regenerates docs cleanly (\`docs/resources/pro_policy.md\` reflects the new attrs + descriptions).
- [x] \`TF_ACC=1 go test -tags acceptance -run 'TestAccPolicyResource' -v -timeout 30m ./internal/resources/pro/policies/policy/\` against the \`nmartin.jamfcloud.com\` tenant — all 22 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)