### PR TITLE
fix(pro/configuration_profiles): harden payload diff suppression

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/Jamf-Concepts/terraform-provider-jamfplatform
 go 1.26.3
 
 require (
-	github.com/Jamf-Concepts/jamfplatform-go-sdk v0.8.1-0.20260525095051-c5a02815f1cb
+	github.com/Jamf-Concepts/jamfplatform-go-sdk v0.8.1-0.20260526130210-70b4cd6c5522
 	github.com/hashicorp/terraform-plugin-framework v1.19.0
 	github.com/hashicorp/terraform-plugin-framework-timeouts v0.7.0
 	github.com/hashicorp/terraform-plugin-framework-validators v0.19.0

--- a/go.sum
+++ b/go.sum
@@ -10,6 +10,8 @@ github.com/Jamf-Concepts/jamfplatform-go-sdk v0.8.1-0.20260525093747-35ba621c66a
 github.com/Jamf-Concepts/jamfplatform-go-sdk v0.8.1-0.20260525093747-35ba621c66a9/go.mod h1:0EB92TbSfGjVEEF9KB2x/uv9HK4kRIfTfjmFmUdWO38=
 github.com/Jamf-Concepts/jamfplatform-go-sdk v0.8.1-0.20260525095051-c5a02815f1cb h1:trFywCEYr+Ac3IRM+iYmXIDyknq3lI2AGS2AOE3D+PM=
 github.com/Jamf-Concepts/jamfplatform-go-sdk v0.8.1-0.20260525095051-c5a02815f1cb/go.mod h1:0EB92TbSfGjVEEF9KB2x/uv9HK4kRIfTfjmFmUdWO38=
+github.com/Jamf-Concepts/jamfplatform-go-sdk v0.8.1-0.20260526130210-70b4cd6c5522 h1:is4ckk7IJDk9Vq+lTZ0M9m2so9Vht1G9es2FnuOtE/8=
+github.com/Jamf-Concepts/jamfplatform-go-sdk v0.8.1-0.20260526130210-70b4cd6c5522/go.mod h1:0EB92TbSfGjVEEF9KB2x/uv9HK4kRIfTfjmFmUdWO38=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
 github.com/ProtonMail/go-crypto v1.4.1 h1:9RfcZHqEQUvP8RzecWEUafnZVtEvrBVL9BiF67IQOfM=

--- a/internal/resources/pro/configuration_profiles/macos_configuration_profile/input_builders.go
+++ b/internal/resources/pro/configuration_profiles/macos_configuration_profile/input_builders.go
@@ -99,7 +99,7 @@ func buildGeneral(m *GeneralModel, existingUUID string) (*proclassic.OsXConfigur
 			diags.AddError("Failed to inject server-canonical PayloadUUID/PayloadIdentifier into update payload", err.Error())
 			return nil, nil, diags
 		}
-		s := string(prepared)
+		s := proclassic.PayloadsXMLText(prepared)
 		g.Payloads = &s
 		return g, prepared, diags
 	}

--- a/internal/resources/pro/configuration_profiles/macos_configuration_profile/input_builders_test.go
+++ b/internal/resources/pro/configuration_profiles/macos_configuration_profile/input_builders_test.go
@@ -88,11 +88,11 @@ func TestBuildGeneral_PayloadIdentifierInjectionOnUpdate(t *testing.T) {
 	if g.Payloads == nil {
 		t.Fatal("expected Payloads to be set")
 	}
-	if !strings.Contains(*g.Payloads, existingUUID) {
-		t.Fatalf("expected server-canonical UUID substituted into both top-level fields; got %s", *g.Payloads)
+	if !strings.Contains(string(*g.Payloads), existingUUID) {
+		t.Fatalf("expected server-canonical UUID substituted into both top-level fields; got %s", string(*g.Payloads))
 	}
-	if strings.Contains(*g.Payloads, "NEW-identifier") || strings.Contains(*g.Payloads, "NEW-UUID") {
-		t.Fatalf("expected user-supplied identifiers replaced; got %s", *g.Payloads)
+	if strings.Contains(string(*g.Payloads), "NEW-identifier") || strings.Contains(string(*g.Payloads), "NEW-UUID") {
+		t.Fatalf("expected user-supplied identifiers replaced; got %s", string(*g.Payloads))
 	}
 	if len(prepared) == 0 {
 		t.Fatal("expected prepared bytes returned")
@@ -111,7 +111,7 @@ func TestBuildGeneral_PayloadIdentifierInjection_CreatePathNoOp(t *testing.T) {
 		Name:     types.StringValue("x"),
 		Payloads: types.StringValue(newPayload),
 	}, "")
-	if g.Payloads == nil || !strings.Contains(*g.Payloads, "CREATE-id") {
+	if g.Payloads == nil || !strings.Contains(string(*g.Payloads), "CREATE-id") {
 		t.Fatal("expected create-path payload untouched")
 	}
 }

--- a/internal/resources/pro/configuration_profiles/macos_configuration_profile/state_builders.go
+++ b/internal/resources/pro/configuration_profiles/macos_configuration_profile/state_builders.go
@@ -80,7 +80,7 @@ func flattenGeneral(g *proclassic.OsXConfigurationProfileGeneral, state *General
 	// semantically equivalent; only overwrite with the server form when
 	// genuine out-of-band drift is detected.
 	if g.Payloads != nil {
-		server := *g.Payloads
+		server := string(*g.Payloads)
 		keep := false
 		if !state.Payloads.IsNull() && !state.Payloads.IsUnknown() {
 			if eq, err := payloadhelpers.PayloadsSemanticallyEqual([]byte(state.Payloads.ValueString()), []byte(server)); err == nil && eq {
@@ -88,7 +88,7 @@ func flattenGeneral(g *proclassic.OsXConfigurationProfileGeneral, state *General
 			}
 		}
 		if !keep {
-			state.Payloads = types.StringValue(server)
+			state.Payloads = types.StringValue(string(payloadhelpers.CanonicalisePlistXML([]byte(server))))
 		}
 	}
 	state.DistributionMethod = helpers.ReconcileOptionalStringPointer(g.DistributionMethod, state.DistributionMethod)

--- a/internal/resources/pro/configuration_profiles/macos_configuration_profile/state_builders_test.go
+++ b/internal/resources/pro/configuration_profiles/macos_configuration_profile/state_builders_test.go
@@ -6,6 +6,7 @@ package macos_configuration_profile
 import (
 	"context"
 	"slices"
+	"strings"
 	"testing"
 
 	"github.com/Jamf-Concepts/jamfplatform-go-sdk/jamfplatform/proclassic"
@@ -60,13 +61,13 @@ func TestFlattenGeneral_UUIDAndPayloadsExposed(t *testing.T) {
 	state := &GeneralModel{}
 	flattenGeneral(&proclassic.OsXConfigurationProfileGeneral{
 		UUID:     new("abc-uuid"),
-		Payloads: new("<plist/>"),
+		Payloads: new(proclassic.PayloadsXMLText("<plist/>")),
 	}, state)
 	if state.UUID.ValueString() != "abc-uuid" {
 		t.Fatalf("UUID: got %v", state.UUID)
 	}
-	if state.Payloads.ValueString() != "<plist/>" {
-		t.Fatalf("Payloads: got %v", state.Payloads)
+	if got := state.Payloads.ValueString(); !strings.Contains(got, "<plist") {
+		t.Fatalf("Payloads: got %v", got)
 	}
 }
 

--- a/internal/resources/pro/configuration_profiles/mobile_device_configuration_profile/input_builders.go
+++ b/internal/resources/pro/configuration_profiles/mobile_device_configuration_profile/input_builders.go
@@ -73,7 +73,7 @@ func buildGeneral(m *GeneralModel, existingUUID string) (*proclassic.MobileDevic
 			diags.AddError("Failed to inject server-canonical PayloadUUID/PayloadIdentifier into update payload", err.Error())
 			return nil, nil, diags
 		}
-		s := string(prepared)
+		s := proclassic.PayloadsXMLText(prepared)
 		g.Payloads = &s
 		return g, prepared, diags
 	}

--- a/internal/resources/pro/configuration_profiles/mobile_device_configuration_profile/input_builders_test.go
+++ b/internal/resources/pro/configuration_profiles/mobile_device_configuration_profile/input_builders_test.go
@@ -110,11 +110,11 @@ func TestBuildGeneral_PayloadIdentifierInjectionOnUpdate(t *testing.T) {
 	if g.Payloads == nil {
 		t.Fatal("expected Payloads to be set")
 	}
-	if !strings.Contains(*g.Payloads, existingUUID) {
-		t.Fatalf("expected server-canonical UUID substituted; got %s", *g.Payloads)
+	if !strings.Contains(string(*g.Payloads), existingUUID) {
+		t.Fatalf("expected server-canonical UUID substituted; got %s", string(*g.Payloads))
 	}
-	if strings.Contains(*g.Payloads, "NEW-identifier") || strings.Contains(*g.Payloads, "NEW-UUID") {
-		t.Fatalf("expected user-supplied identifiers replaced; got %s", *g.Payloads)
+	if strings.Contains(string(*g.Payloads), "NEW-identifier") || strings.Contains(string(*g.Payloads), "NEW-UUID") {
+		t.Fatalf("expected user-supplied identifiers replaced; got %s", string(*g.Payloads))
 	}
 	if len(prepared) == 0 {
 		t.Fatal("expected prepared bytes returned")
@@ -133,7 +133,7 @@ func TestBuildGeneral_PayloadIdentifierInjection_CreatePathNoOp(t *testing.T) {
 		Name:     types.StringValue("x"),
 		Payloads: types.StringValue(newPayload),
 	}, "")
-	if g.Payloads == nil || !strings.Contains(*g.Payloads, "CREATE-id") {
+	if g.Payloads == nil || !strings.Contains(string(*g.Payloads), "CREATE-id") {
 		t.Fatal("expected create-path payload untouched")
 	}
 }

--- a/internal/resources/pro/configuration_profiles/mobile_device_configuration_profile/state_builders.go
+++ b/internal/resources/pro/configuration_profiles/mobile_device_configuration_profile/state_builders.go
@@ -66,7 +66,7 @@ func flattenGeneral(g *proclassic.MobileDeviceConfigurationProfileGeneral, state
 	// canonical form is semantically equivalent; only overwrite when genuine
 	// out-of-band drift is detected.
 	if g.Payloads != nil {
-		server := *g.Payloads
+		server := string(*g.Payloads)
 		keep := false
 		if !state.Payloads.IsNull() && !state.Payloads.IsUnknown() {
 			if eq, err := payloadhelpers.PayloadsSemanticallyEqual([]byte(state.Payloads.ValueString()), []byte(server)); err == nil && eq {
@@ -74,7 +74,7 @@ func flattenGeneral(g *proclassic.MobileDeviceConfigurationProfileGeneral, state
 			}
 		}
 		if !keep {
-			state.Payloads = types.StringValue(server)
+			state.Payloads = types.StringValue(string(payloadhelpers.CanonicalisePlistXML([]byte(server))))
 		}
 	}
 	// Wire element is <deployment_method>; TF attribute is distribution_method (UI-canonical).

--- a/internal/resources/pro/configuration_profiles/mobile_device_configuration_profile/state_builders_test.go
+++ b/internal/resources/pro/configuration_profiles/mobile_device_configuration_profile/state_builders_test.go
@@ -5,6 +5,7 @@ package mobile_device_configuration_profile
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/Jamf-Concepts/jamfplatform-go-sdk/jamfplatform/proclassic"
@@ -81,13 +82,13 @@ func TestFlattenGeneral_UUIDAndPayloadsExposed(t *testing.T) {
 	state := &GeneralModel{}
 	flattenGeneral(&proclassic.MobileDeviceConfigurationProfileGeneral{
 		UUID:     new("test-uuid"),
-		Payloads: new("<plist/>"),
+		Payloads: new(proclassic.PayloadsXMLText("<plist/>")),
 	}, state)
 	if state.UUID.ValueString() != "test-uuid" {
 		t.Fatalf("UUID: got %v", state.UUID)
 	}
-	if state.Payloads.ValueString() != "<plist/>" {
-		t.Fatalf("Payloads: got %v", state.Payloads)
+	if got := state.Payloads.ValueString(); !strings.Contains(got, "<plist") {
+		t.Fatalf("Payloads: got %v", got)
 	}
 }
 

--- a/internal/resources/pro/configuration_profiles/payloadhelpers/helpers.go
+++ b/internal/resources/pro/configuration_profiles/payloadhelpers/helpers.go
@@ -9,6 +9,7 @@ package payloadhelpers
 
 import (
 	"bytes"
+	"encoding/base64"
 	"fmt"
 	"html"
 	"strings"
@@ -69,6 +70,19 @@ var (
 	// the resource already exposes, and the in-payload form is redundant.
 	serverInjectedPayloadTypes = map[string]struct{}{
 		"com.apple.profileRemovalPassword": {}, // mirrors self_service.authorization_password
+	}
+	// mcxLikePayloadTypes enumerates PayloadType values whose inner
+	// `.PayloadContent` child is opaque user-authored vendor preference data.
+	// For these types, drift detection compares the inner subtree strictly
+	// (keysets must match exactly) so admin-UI key add/remove inside the
+	// vendor preference dict surfaces on the next plan. Apple's MCX format
+	// (com.apple.ManagedClient.preferences) is the canonical case — Jamf Pro
+	// UI exposes it as "Application & Custom Settings" / "Custom Settings".
+	// Jamf is the transport for this subtree, not the editor: it never
+	// injects metadata at the inner preference depth, so strict compare is
+	// safe.
+	mcxLikePayloadTypes = map[string]struct{}{
+		"com.apple.ManagedClient.preferences": {},
 	}
 )
 
@@ -202,12 +216,49 @@ func isEmpty(v any) bool {
 	}
 }
 
-// trimAny recursively trims leading/trailing whitespace from every string
-// value in the plist tree.
+// normalizeBase64InString collapses line-wrap whitespace from string values
+// that decode cleanly as base64. Apple-spec mobileconfig binary blobs live
+// inside `<data>` tags (which howett.net/plist decodes to []byte and carry
+// no whitespace), but some vendor payloads embed base64 inside `<string>`
+// values — and Jamf Pro can line-wrap long base64 strings on the way back.
+// Whitespace-only differences inside such strings would otherwise produce
+// spurious diffs.
+//
+// Heuristic deliberately conservative — only fires when:
+//   - The string contains an explicit newline (`\n` or `\r`). Plain spaces
+//     do not trigger; natural-language values like "Allow 1Password
+//     Launch Item" pass through untouched even when they happen to be
+//     all-alphanumeric.
+//   - After all-whitespace strip, the result is at least 32 characters and
+//     a multiple of 4. Real base64 cert/blob content is nearly always far
+//     longer; multi-line natural-language descriptions are vanishingly
+//     unlikely to satisfy both length floor and length-mod-4.
+//   - The cleaned form decodes successfully under standard base64.
+//
+// Anything that fails any gate is returned unchanged.
+func normalizeBase64InString(s string) string {
+	if !strings.ContainsAny(s, "\n\r") {
+		return s
+	}
+	clean := strings.Join(strings.Fields(s), "")
+	if len(clean) < 32 || len(clean)%4 != 0 {
+		return s
+	}
+	if _, err := base64.StdEncoding.DecodeString(clean); err == nil {
+		return clean
+	}
+	return s
+}
+
+// trimAny recursively trims whitespace from every string value in the plist
+// tree. For ordinary text values this is `strings.TrimSpace`. For string
+// values that decode as base64, internal whitespace is also collapsed (see
+// normalizeBase64InString) so server-side line wrapping does not produce
+// spurious diffs.
 func trimAny(v any) any {
 	switch t := v.(type) {
 	case string:
-		return strings.TrimSpace(t)
+		return strings.TrimSpace(normalizeBase64InString(t))
 	case []any:
 		out := make([]any, len(t))
 		for i, item := range t {
@@ -259,14 +310,19 @@ func PayloadsSemanticallyEqual(a, b []byte) (bool, error) {
 // compare via numericEqual for ints (howett.net/plist returns int64 or
 // uint64 depending on sign).
 //
-// Known limitation: keys server adds out-of-band (admin edits the
-// payload directly in the Jamf Pro UI) at depths the mask doesn't cover
-// will not surface as drift — the intersection compare ignores
-// state-only keys. The trade-off keeps the corpus quiet on Jamf's many
-// conditional-default injections (top-level `PayloadRemovalDisallowed`,
-// per-payload `PayloadEnabled`, PPPC service strips, etc.) without
-// having to enumerate every one. Detecting deep out-of-band UI edits
-// requires a depth-aware variant; pending design.
+// Exception: PayloadContent[i] entries whose PayloadType is in
+// mcxLikePayloadTypes (e.g. com.apple.ManagedClient.preferences — Jamf
+// Pro's "Application & Custom Settings") get their inner `.PayloadContent`
+// child strict-compared via strictEqual. That subtree is opaque
+// user-authored vendor preference data; admin-UI key add/remove inside it
+// is real drift and must surface on the next plan. Remaining keys at the
+// MCX entry depth still use intersection so per-payload metadata defaults
+// Jamf injects (e.g. PayloadEnabled) keep tolerating one-sided presence.
+//
+// Intersection compare elsewhere remains the documented trade-off: it
+// keeps the corpus quiet on Jamf's many conditional-default injections
+// (top-level `PayloadRemovalDisallowed`, per-payload `PayloadEnabled`,
+// PPPC service strips, etc.) without having to enumerate every one.
 func LenientEqualPlist(a, b any) bool {
 	if a == nil || b == nil {
 		return a == nil && b == nil
@@ -276,6 +332,29 @@ func LenientEqualPlist(a, b any) bool {
 		bv, ok := b.(map[string]any)
 		if !ok {
 			return false
+		}
+		if pt, _ := av["PayloadType"].(string); pt != "" {
+			if _, isMCX := mcxLikePayloadTypes[pt]; isMCX {
+				ai, aHas := av["PayloadContent"]
+				bi, bHas := bv["PayloadContent"]
+				if aHas != bHas {
+					return false
+				}
+				if aHas && !strictEqual(ai, bi) {
+					return false
+				}
+				for k, va := range av {
+					if k == "PayloadContent" {
+						continue
+					}
+					if vb, exists := bv[k]; exists {
+						if !LenientEqualPlist(va, vb) {
+							return false
+						}
+					}
+				}
+				return true
+			}
 		}
 		for k, va := range av {
 			if vb, exists := bv[k]; exists {
@@ -292,6 +371,50 @@ func LenientEqualPlist(a, b any) bool {
 		}
 		for i := range av {
 			if !LenientEqualPlist(av[i], bv[i]) {
+				return false
+			}
+		}
+		return true
+	case uint64:
+		return numericEqual(int64(av), b)
+	case int64:
+		return numericEqual(av, b)
+	case int:
+		return numericEqual(int64(av), b)
+	default:
+		return a == b
+	}
+}
+
+// strictEqual is a structural-equality compare for the trimmed plist tree.
+// Unlike LenientEqualPlist, asymmetric keysets fail. Used for opaque
+// user-content subtrees (see mcxLikePayloadTypes) where every key is
+// author-controlled — admin-UI key add/remove inside the subtree is real
+// drift, not Jamf-side metadata injection.
+func strictEqual(a, b any) bool {
+	if a == nil || b == nil {
+		return a == nil && b == nil
+	}
+	switch av := a.(type) {
+	case map[string]any:
+		bv, ok := b.(map[string]any)
+		if !ok || len(av) != len(bv) {
+			return false
+		}
+		for k, va := range av {
+			vb, exists := bv[k]
+			if !exists || !strictEqual(va, vb) {
+				return false
+			}
+		}
+		return true
+	case []any:
+		bv, ok := b.([]any)
+		if !ok || len(av) != len(bv) {
+			return false
+		}
+		for i := range av {
+			if !strictEqual(av[i], bv[i]) {
 				return false
 			}
 		}

--- a/internal/resources/pro/configuration_profiles/payloadhelpers/helpers.go
+++ b/internal/resources/pro/configuration_profiles/payloadhelpers/helpers.go
@@ -21,26 +21,36 @@ import (
 // land here.
 //
 // Keys Jamf Pro only *conditionally* defaults (e.g. `PayloadEnabled` when
-// absent, `PayloadOrganization` when absent, `VendorConfig` only for
-// webcontent-filter payloads) are intentionally **not** in this list. The
-// intersection-compare in LenientEqualPlist drops asymmetric keys at
-// comparison time, which means:
+// absent, `VendorConfig` only for webcontent-filter payloads) are
+// intentionally **not** in this list. The intersection-compare in
+// LenientEqualPlist drops asymmetric keys at comparison time, which means:
 //
 //   - user omits the key → only server side has it → intersection drops it → no spurious diff.
 //   - user authors the key → both sides have it → compared → drift detected if the user later edits.
 //
-// Decision confirmed by the maintainer 2026-05-24: a static skip-list on
-// conditional-default keys would hide user-authored drift.
+// `PayloadOrganization` is in this list — wire-confirmed 2026-05-26 that
+// Jamf Pro Classic always overwrites the field with "JAMF Software" on
+// both top-level and per-PayloadContent slots, regardless of the
+// user-authored value. The previous "conditional default" assumption
+// produced persistent payload diffs on every plan that authored an
+// organization. Trade-off: a user-authored edit to PayloadOrganization
+// will be silently dropped on the wire — but Jamf already drops it
+// regardless, so masking the key matches reality. Drift detection on
+// every other value the user authors is unaffected.
 var (
 	maskedTopLevelKeys = map[string]struct{}{
-		"PayloadDisplayName": {}, // server sets from classic <general><name> on every write
-		"PayloadIdentifier":  {}, // server assigns a new lowercase UUID on create
-		"PayloadUUID":        {}, // server assigns a new lowercase UUID on create
+		"PayloadDisplayName":  {}, // server sets from classic <general><name> on every write
+		"PayloadIdentifier":   {}, // server assigns a new lowercase UUID on create
+		"PayloadUUID":         {}, // server assigns a new lowercase UUID on create
+		"PayloadOrganization": {}, // server always overwrites with "JAMF Software"
+		"PayloadDescription":  {}, // server always empties the top-level description
+		"PayloadEnabled":      {}, // server always strips at top-level (Apple-spec is per-payload, not top-level)
 	}
 	maskedPayloadContentKeys = map[string]struct{}{
-		"PayloadDisplayName": {}, // server-defaulted per PayloadType
-		"PayloadIdentifier":  {}, // server may assign on create
-		"PayloadUUID":        {}, // server may assign on create; preserved on update by InjectTopLevelIdentifiers
+		"PayloadDisplayName":  {}, // server-defaulted per PayloadType
+		"PayloadIdentifier":   {}, // server may assign on create
+		"PayloadUUID":         {}, // server may assign on create; preserved on update by InjectTopLevelIdentifiers
+		"PayloadOrganization": {}, // server always overwrites with "JAMF Software"
 	}
 	// serverInjectedPayloadTypes are PayloadContent[i].PayloadType values Jamf
 	// Pro inserts into the mobileconfig as a side-effect of a *different*
@@ -85,6 +95,28 @@ func MarshalPlist(m map[string]any) ([]byte, error) {
 		return nil, fmt.Errorf("encoding plist: %w", err)
 	}
 	return buf.Bytes(), nil
+}
+
+// CanonicalisePlistXML parses a mobileconfig plist and re-emits it as
+// tab-indented XML. Used on the state-builder side to normalise Jamf's
+// compact single-line wire form into the same shape user-authored
+// payloads typically take (Apple's standard pretty-printed mobileconfig).
+// When state and plan share formatting, Terraform's diff narrows from a
+// whole-payload swap to the specific keys that changed.
+//
+// Falls back to returning the input unchanged if the plist fails to
+// parse — the caller still has a usable string, and the legibility
+// improvement is a UX nicety, not a correctness gate.
+func CanonicalisePlistXML(raw []byte) []byte {
+	parsed, _, err := ParsePlist(raw)
+	if err != nil {
+		return raw
+	}
+	out, err := MarshalPlist(parsed)
+	if err != nil {
+		return raw
+	}
+	return out
 }
 
 // MaskPayload returns a deep-cloned representation of the input plist with
@@ -226,6 +258,15 @@ func PayloadsSemanticallyEqual(a, b []byte) (bool, error) {
 // shared keys must compare equal. Arrays compare positionally. Scalars
 // compare via numericEqual for ints (howett.net/plist returns int64 or
 // uint64 depending on sign).
+//
+// Known limitation: keys server adds out-of-band (admin edits the
+// payload directly in the Jamf Pro UI) at depths the mask doesn't cover
+// will not surface as drift — the intersection compare ignores
+// state-only keys. The trade-off keeps the corpus quiet on Jamf's many
+// conditional-default injections (top-level `PayloadRemovalDisallowed`,
+// per-payload `PayloadEnabled`, PPPC service strips, etc.) without
+// having to enumerate every one. Detecting deep out-of-band UI edits
+// requires a depth-aware variant; pending design.
 func LenientEqualPlist(a, b any) bool {
 	if a == nil || b == nil {
 		return a == nil && b == nil

--- a/internal/resources/pro/configuration_profiles/payloadhelpers/helpers_test.go
+++ b/internal/resources/pro/configuration_profiles/payloadhelpers/helpers_test.go
@@ -270,3 +270,238 @@ func TestLenientEqualPlist_SharedKeyDiffers_NotEqual(t *testing.T) {
 		t.Fatal("differing shared key must not be equal")
 	}
 }
+
+// MCX drift-detection fixtures: a minimal "Application & Custom Settings"
+// payload shaped like local-testing/pro/support_files/minimal_notifications.mobileconfig.
+// The inner mcx_preference_settings dict is opaque user-content; key add/remove
+// inside it must surface as drift.
+const mcxBaseline = `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0"><dict>
+<key>PayloadType</key><string>Configuration</string>
+<key>PayloadVersion</key><integer>1</integer>
+<key>PayloadIdentifier</key><string>top-id</string>
+<key>PayloadUUID</key><string>top-uuid</string>
+<key>PayloadContent</key><array><dict>
+<key>PayloadType</key><string>com.apple.ManagedClient.preferences</string>
+<key>PayloadVersion</key><integer>1</integer>
+<key>PayloadIdentifier</key><string>mcx-id</string>
+<key>PayloadUUID</key><string>mcx-uuid</string>
+<key>PayloadContent</key><dict>
+<key>com.example.app</key><dict>
+<key>Forced</key><array><dict>
+<key>mcx_preference_settings</key><dict>
+<key>FeatureEnabled</key><true/>
+<key>BannerMessage</key><string>hello</string>
+</dict>
+</dict></array>
+</dict>
+</dict>
+</dict></array>
+</dict></plist>`
+
+const mcxAddedInnerKey = `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0"><dict>
+<key>PayloadType</key><string>Configuration</string>
+<key>PayloadVersion</key><integer>1</integer>
+<key>PayloadIdentifier</key><string>top-id</string>
+<key>PayloadUUID</key><string>top-uuid</string>
+<key>PayloadContent</key><array><dict>
+<key>PayloadType</key><string>com.apple.ManagedClient.preferences</string>
+<key>PayloadVersion</key><integer>1</integer>
+<key>PayloadIdentifier</key><string>mcx-id</string>
+<key>PayloadUUID</key><string>mcx-uuid</string>
+<key>PayloadContent</key><dict>
+<key>com.example.app</key><dict>
+<key>Forced</key><array><dict>
+<key>mcx_preference_settings</key><dict>
+<key>FeatureEnabled</key><true/>
+<key>BannerMessage</key><string>hello</string>
+<key>EnablePageZeroProtection2</key><false/>
+</dict>
+</dict></array>
+</dict>
+</dict>
+</dict></array>
+</dict></plist>`
+
+const mcxRemovedInnerKey = `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0"><dict>
+<key>PayloadType</key><string>Configuration</string>
+<key>PayloadVersion</key><integer>1</integer>
+<key>PayloadIdentifier</key><string>top-id</string>
+<key>PayloadUUID</key><string>top-uuid</string>
+<key>PayloadContent</key><array><dict>
+<key>PayloadType</key><string>com.apple.ManagedClient.preferences</string>
+<key>PayloadVersion</key><integer>1</integer>
+<key>PayloadIdentifier</key><string>mcx-id</string>
+<key>PayloadUUID</key><string>mcx-uuid</string>
+<key>PayloadContent</key><dict>
+<key>com.example.app</key><dict>
+<key>Forced</key><array><dict>
+<key>mcx_preference_settings</key><dict>
+<key>FeatureEnabled</key><true/>
+</dict>
+</dict></array>
+</dict>
+</dict>
+</dict></array>
+</dict></plist>`
+
+const mcxChangedInnerValue = `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0"><dict>
+<key>PayloadType</key><string>Configuration</string>
+<key>PayloadVersion</key><integer>1</integer>
+<key>PayloadIdentifier</key><string>top-id</string>
+<key>PayloadUUID</key><string>top-uuid</string>
+<key>PayloadContent</key><array><dict>
+<key>PayloadType</key><string>com.apple.ManagedClient.preferences</string>
+<key>PayloadVersion</key><integer>1</integer>
+<key>PayloadIdentifier</key><string>mcx-id</string>
+<key>PayloadUUID</key><string>mcx-uuid</string>
+<key>PayloadContent</key><dict>
+<key>com.example.app</key><dict>
+<key>Forced</key><array><dict>
+<key>mcx_preference_settings</key><dict>
+<key>FeatureEnabled</key><false/>
+<key>BannerMessage</key><string>hello</string>
+</dict>
+</dict></array>
+</dict>
+</dict>
+</dict></array>
+</dict></plist>`
+
+func TestPayloadsSemanticallyEqual_MCXIdentical_Equal(t *testing.T) {
+	eq, err := PayloadsSemanticallyEqual([]byte(mcxBaseline), []byte(mcxBaseline))
+	if err != nil {
+		t.Fatalf("compare: %v", err)
+	}
+	if !eq {
+		t.Fatal("identical MCX payloads must compare equal")
+	}
+}
+
+func TestPayloadsSemanticallyEqual_MCXAddedInnerKey_NotEqual(t *testing.T) {
+	eq, err := PayloadsSemanticallyEqual([]byte(mcxBaseline), []byte(mcxAddedInnerKey))
+	if err != nil {
+		t.Fatalf("compare: %v", err)
+	}
+	if eq {
+		t.Fatal("admin-injected key inside mcx_preference_settings must produce drift")
+	}
+}
+
+func TestPayloadsSemanticallyEqual_MCXRemovedInnerKey_NotEqual(t *testing.T) {
+	eq, err := PayloadsSemanticallyEqual([]byte(mcxBaseline), []byte(mcxRemovedInnerKey))
+	if err != nil {
+		t.Fatalf("compare: %v", err)
+	}
+	if eq {
+		t.Fatal("admin-removed key inside mcx_preference_settings must produce drift")
+	}
+}
+
+func TestPayloadsSemanticallyEqual_MCXChangedInnerValue_NotEqual(t *testing.T) {
+	eq, err := PayloadsSemanticallyEqual([]byte(mcxBaseline), []byte(mcxChangedInnerValue))
+	if err != nil {
+		t.Fatalf("compare: %v", err)
+	}
+	if eq {
+		t.Fatal("admin-changed value inside mcx_preference_settings must produce drift")
+	}
+}
+
+// Base64-in-string normalization: when a vendor payload embeds a base64 blob
+// inside a <string> value and Jamf Pro line-wraps it on read, the whitespace
+// difference must not produce a spurious diff.
+const base64Compact = `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0"><dict>
+<key>PayloadType</key><string>Configuration</string>
+<key>PayloadVersion</key><integer>1</integer>
+<key>EmbeddedCert</key><string>TUlJRENDQWZpZ0F3SUJBZ0lVTUJ4UkxEdGRCZW9PNkZ3MGZQMzZ5cFppL0VBd0RRWUpLb1pJaHZjTkFRRUw=</string>
+<key>PayloadContent</key><array/>
+</dict></plist>`
+
+const base64Wrapped = `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0"><dict>
+<key>PayloadType</key><string>Configuration</string>
+<key>PayloadVersion</key><integer>1</integer>
+<key>EmbeddedCert</key><string>TUlJRENDQWZpZ0F3SUJBZ0lVTUJ4
+UkxEdGRCZW9PNkZ3MGZQMzZ5cFpp
+L0VBd0RRWUpLb1pJaHZjTkFRRUw=</string>
+<key>PayloadContent</key><array/>
+</dict></plist>`
+
+func TestPayloadsSemanticallyEqual_Base64InString_WrappedAndCompactEqual(t *testing.T) {
+	eq, err := PayloadsSemanticallyEqual([]byte(base64Compact), []byte(base64Wrapped))
+	if err != nil {
+		t.Fatalf("compare: %v", err)
+	}
+	if !eq {
+		t.Fatal("base64-in-string differing only by line-wrap whitespace must compare equal")
+	}
+}
+
+func TestNormalizeBase64InString_NonBase64Unchanged(t *testing.T) {
+	in := "Allow 1Password Launch Item"
+	if got := normalizeBase64InString(in); got != in {
+		t.Errorf("non-base64 text mutated: got %q want %q", got, in)
+	}
+}
+
+func TestNormalizeBase64InString_NoWhitespaceUnchanged(t *testing.T) {
+	in := "TUlJRENDQWZpZw=="
+	if got := normalizeBase64InString(in); got != in {
+		t.Errorf("base64 without whitespace mutated: got %q want %q", got, in)
+	}
+}
+
+func TestNormalizeBase64InString_StripsInternalWhitespace(t *testing.T) {
+	in := "TUlJRENDQWZpZ0F3SUJBZ0lVTUJ4\nUkxEdGRCZW9PNkZ3MGZQMzZ5cFppL0VBd0RRWUpLb1pJaHZjTkFRRUw="
+	want := "TUlJRENDQWZpZ0F3SUJBZ0lVTUJ4UkxEdGRCZW9PNkZ3MGZQMzZ5cFppL0VBd0RRWUpLb1pJaHZjTkFRRUw="
+	if got := normalizeBase64InString(in); got != want {
+		t.Errorf("base64 with whitespace not collapsed: got %q want %q", got, want)
+	}
+}
+
+func TestNormalizeBase64InString_EmptyAfterStripUnchanged(t *testing.T) {
+	in := "   \n\t  "
+	if got := normalizeBase64InString(in); got != in {
+		t.Errorf("whitespace-only string mutated: got %q want %q", got, in)
+	}
+}
+
+func TestNormalizeBase64InString_NaturalTextWithSpacesUnchanged(t *testing.T) {
+	// Natural-language text containing only base64-alphabet characters and
+	// spaces — guards against the heuristic over-firing on values like
+	// "Allow 1Password Launch Item" whose whitespace-stripped form would
+	// coincidentally decode as base64.
+	in := "Allow 1Password Launch Item"
+	if got := normalizeBase64InString(in); got != in {
+		t.Errorf("natural text with spaces mutated: got %q want %q", got, in)
+	}
+}
+
+func TestNormalizeBase64InString_NewlineButTooShortUnchanged(t *testing.T) {
+	// Newline present but stripped form is below the 32-char floor — must
+	// not be collapsed even if it happens to decode as base64.
+	in := "TUlJ\nRENDQQ=="
+	if got := normalizeBase64InString(in); got != in {
+		t.Errorf("short newline-bearing string mutated: got %q want %q", got, in)
+	}
+}
+
+func TestNormalizeBase64InString_NewlineNotBase64Unchanged(t *testing.T) {
+	// Multi-line natural-language string that does not decode as base64 —
+	// must pass through untouched even though it has newlines.
+	in := "This is a multi-line description\nthat continues onto a second line\nand even a third for good measure."
+	if got := normalizeBase64InString(in); got != in {
+		t.Errorf("multi-line non-base64 text mutated: got %q want %q", got, in)
+	}
+}


### PR DESCRIPTION
## Summary

Two fixes to configuration-profile payload diff suppression, shared by `jamfplatform_pro_macos_configuration_profile` and `jamfplatform_pro_mobile_device_configuration_profile`.

### 1. Classic JSSResource `<payloads>` double-decode workaround (2aafdb2)

The classic API returns the mobileconfig text inside `<payloads>` HTML-entity encoded once. When we send a mobileconfig containing characters Jamf re-encodes a second time on the wire round-trip, the resulting state was a double-decoded plist that diff-suppressed inconsistently. The fix canonicalises the state-side payload by pre-encoding HTML entities before stuffing into the SDK envelope, plus mask additions for `PayloadOrganization`, `PayloadDescription`, and top-level `PayloadEnabled` — the three keys Jamf was overwriting / stripping deterministically on every write.

### 2. MCX inner-payload drift detection (06776d2, first half)

`LenientEqualPlist` used intersection compare everywhere. Admin-UI edits that **added or removed** keys inside an `Application & Custom Settings` (`com.apple.ManagedClient.preferences`) payload's inner preference dict slid through silently — `terraform plan` reported no changes even when the on-disk mobileconfig and the Jamf-side mobileconfig diverged.

Inner `.PayloadContent` subtree of an MCX-like `PayloadContent` entry is now strict-compared (keysets must match exactly, recursing through nested arrays/dicts). Non-MCX PayloadTypes and the MCX metadata depth still use intersection so Jamf-side conditional defaults (`PayloadEnabled`, `PayloadDescription`, …) keep tolerating one-sided presence. Future PayloadTypes whose inner subtree is also vendor-opaque can be added via the new `mcxLikePayloadTypes` allow-list without touching `LenientEqualPlist`.

### 3. Base64-in-string line-wrap tolerance (06776d2, second half)

`trimAny` now also collapses line-wrap whitespace inside `<string>` values that decode cleanly as base64. Heuristic deliberately tight: requires an explicit `\n`/`\r`, length ≥ 32 after whitespace strip, length mod 4 == 0, and a successful standard-base64 decode. Natural-language values like "Allow 1Password Launch Item" pass through untouched even when they happen to be all-alphanumeric. Closes the case where Jamf re-emits a vendor-embedded base64 blob (e.g. a cert) with line wraps the user did not author.

## Test plan

- [x] `go test ./internal/resources/pro/configuration_profiles/...` — payloadhelpers + macOS + mobile_device all green
- [x] `make test` — full suite green
- [x] `make lint` — 0 issues
- [x] `make fmt` — clean
- [x] New tests cover: identical MCX equal, MCX added inner key drift, MCX removed inner key drift, MCX changed inner value drift, base64 wrapped/compact equal, plus false-positive guards (natural text with spaces unchanged, multi-line non-base64 prose unchanged, short fragments under length floor unchanged)
- [x] Existing 7-fixture corpus regression net (`TestMaskPayload_SuppressesEveryKnownServerMutation`) and `TestPayloadsSemanticallyEqual_DetectsRealChange` still pass — no false positives introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)