### PR TITLE
fix(validators): defer config-time validators on unknown values

### DIFF
--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -361,6 +361,15 @@ Reference: `internal/resources/pro/inventory/directory_binding/data_source.go` (
 - Read companions via `req.Config.GetAttribute(ctx, path.Root("…") / path.MatchRelative()..., &target)`.
 - Attach errors to the **companion's** path (not the discriminator's), via `resp.Diagnostics.AddAttributeError(companionPath, summary, detail)` — that's where the user needs to look.
 
+##### Config-time validators MUST defer on unknown values — for EVERY attribute they read, not just the discriminator
+
+Config validation (`ValidateConfig` / any `ConfigValidator` / schema `Validate{String,…}`) runs with **unknown** values for anything sourced from a variable, `for_each`, `count`, or another resource. `Unknown` means "not resolvable yet", **not** "missing". A validator that errors on unknown makes the resource unusable from anything but hard-coded literals — it breaks `terraform validate`/`plan` for every reusable module. (Caught provider-wide 2026-05; cf. deploymenttheory/terraform-provider-jamfpro #1111.)
+
+- **Skip on unknown before treating absence as an error.** A "required-when" check must `return` (defer) when the *dependent* attribute is unknown, and error only when it is genuinely `null`. The discriminator is not enough — guard the companion too.
+- **Never let a Go decode hide unknown.** `req.Config.Get(ctx, &model)` collapses `unknown` to a zero value: a nested block becomes a `nil` pointer, a list/set becomes `len() == 0`, a custom "is-set" helper returns false. So `if block == nil`, `if len(slice) == 0`, `if !isSet(x)` all **false-error on unknown**. Read the dependent attribute as its **typed value** (`types.Object` / `types.List` / `types.String`) via `GetAttribute` and branch on `IsUnknown()` / `IsNull()` explicitly — do not infer presence from the decoded Go value.
+- **Forbidden-when checks are safe** (they fire on *presence*, so unknown-treated-as-absent just defers) — but required-when checks are the trap.
+- **Regression-test with unknowns, not just literals.** Acceptance tests use literal HCL (always known) and therefore CANNOT catch this. Add a unit test that feeds `tftypes.UnknownValue` to the dependent attribute and asserts no diagnostic. References: `internal/resources/pro/settings/user_initiated_enrollment_settings/validators_test.go` (`TestCertInvariant_SilentWhenCertUnknown`), `…/inventory/disk_encryption_configuration/validators_test.go`, `…/users/user_group/validators_test.go`. `inventory/ibeacon/validators.go` is the reference body (validates only when both values are known).
+
 Avoid `resource.ResourceWithConfigValidators` even for multi-attribute rules unless the framework's `resourcevalidator` package genuinely cannot express them. Bespoke whole-config validators are a last resort.
 
 ### Configuration profile payload diff suppression (mask-and-compare)

--- a/internal/resources/pro/enrollment/computer_prestage_enrollment/validators.go
+++ b/internal/resources/pro/enrollment/computer_prestage_enrollment/validators.go
@@ -86,7 +86,10 @@ func (recoveryLockPasswordRequiresManualAndEnabledValidator) ValidateString(ctx 
 		resp.Diagnostics.Append(d...)
 		return
 	}
-	if enable.IsNull() || enable.IsUnknown() || !enable.ValueBool() {
+	if enable.IsUnknown() {
+		return
+	}
+	if enable.IsNull() || !enable.ValueBool() {
 		resp.Diagnostics.AddAttributeError(
 			path.Root("recovery_lock_password"),
 			"recovery_lock_password requires enable_recovery_lock = true",
@@ -143,7 +146,10 @@ func (prefillTypeCustomRequiresFullAndUserNamesValidator) ValidateString(ctx con
 			resp.Diagnostics.Append(d...)
 			return
 		}
-		if v.IsNull() || v.IsUnknown() || v.ValueString() == "" {
+		if v.IsUnknown() {
+			return
+		}
+		if v.IsNull() || v.ValueString() == "" {
 			resp.Diagnostics.AddAttributeError(
 				sibling,
 				fmt.Sprintf(`%s is required when prefill_type = "CUSTOM"`, name),

--- a/internal/resources/pro/enrollment/computer_prestage_enrollment/validators_test.go
+++ b/internal/resources/pro/enrollment/computer_prestage_enrollment/validators_test.go
@@ -16,6 +16,16 @@ import (
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
 )
 
+// unknownString / unknownBool are sentinels for buildConfig signalling that an
+// attribute should be set to an UNKNOWN value of the given primitive type.
+type unknownString struct{}
+
+type unknownBool struct{}
+
+// nullBool is a sentinel for buildConfig signalling a null value typed as Bool
+// (the bare nil sentinel defaults to a null String).
+type nullBool struct{}
+
 // buildConfig synthesises a *tfsdk.Config from a small attribute map for
 // use by validators that call req.Config.GetAttribute(...).
 func buildConfig(t *testing.T, attrs map[string]any) tfsdk.Config {
@@ -33,6 +43,18 @@ func buildConfig(t *testing.T, attrs map[string]any) tfsdk.Config {
 		case bool:
 			typeMap[k] = tftypes.Bool
 			valMap[k] = tftypes.NewValue(tftypes.Bool, v)
+			tfsdkAttrs[k] = schema.BoolAttribute{Optional: true}
+		case unknownString:
+			typeMap[k] = tftypes.String
+			valMap[k] = tftypes.NewValue(tftypes.String, tftypes.UnknownValue)
+			tfsdkAttrs[k] = schema.StringAttribute{Optional: true}
+		case unknownBool:
+			typeMap[k] = tftypes.Bool
+			valMap[k] = tftypes.NewValue(tftypes.Bool, tftypes.UnknownValue)
+			tfsdkAttrs[k] = schema.BoolAttribute{Optional: true}
+		case nullBool:
+			typeMap[k] = tftypes.Bool
+			valMap[k] = tftypes.NewValue(tftypes.Bool, nil)
 			tfsdkAttrs[k] = schema.BoolAttribute{Optional: true}
 		case nil:
 			typeMap[k] = tftypes.String
@@ -124,6 +146,86 @@ func TestRecoveryLockPasswordRequiresManualAndEnabled_NoError(t *testing.T) {
 		cfg, "recovery_lock_password", types.StringValue("pwd"))
 	if len(out) != 0 {
 		t.Errorf("happy-path config should not fire validator, got %v", out)
+	}
+}
+
+// Regression for the config-time validators-defer-on-unknown bug: when the
+// companion enable_recovery_lock is UNKNOWN (e.g. wired from a variable), the
+// validator must defer rather than false-error.
+func TestRecoveryLockPasswordRequiresManualAndEnabled_DefersWhenEnableUnknown(t *testing.T) {
+	cfg := buildConfig(t, map[string]any{
+		"enable_recovery_lock":        unknownBool{},
+		"recovery_lock_password_type": "MANUAL",
+	})
+	out := runStringValidator(t, recoveryLockPasswordRequiresManualAndEnabled(),
+		cfg, "recovery_lock_password", types.StringValue("pwd"))
+	if len(out) != 0 {
+		t.Errorf("pwd + enable=UNKNOWN must defer (no diagnostic), got %v", out)
+	}
+}
+
+func TestRecoveryLockPasswordRequiresManualAndEnabled_FiresWhenEnableNull(t *testing.T) {
+	cfg := buildConfig(t, map[string]any{
+		"enable_recovery_lock":        nullBool{},
+		"recovery_lock_password_type": "MANUAL",
+	})
+	out := runStringValidator(t, recoveryLockPasswordRequiresManualAndEnabled(),
+		cfg, "recovery_lock_password", types.StringValue("pwd"))
+	if len(out) == 0 {
+		t.Errorf("pwd + enable null should fire validator")
+	}
+}
+
+func TestPrefillTypeCustomRequiresFullAndUserNames_DefersWhenCompanionUnknown(t *testing.T) {
+	// prefill_type=CUSTOM with a required companion UNKNOWN must defer.
+	cfg := buildConfig(t, map[string]any{
+		"prefill_account_full_name": unknownString{},
+		"prefill_account_user_name": "jdoe",
+	})
+	req := validator.StringRequest{
+		Path:        path.Root("prefill_type"),
+		ConfigValue: types.StringValue("CUSTOM"),
+		Config:      cfg,
+	}
+	var resp validator.StringResponse
+	prefillTypeCustomRequiresFullAndUserNames().ValidateString(context.Background(), req, &resp)
+	if resp.Diagnostics.HasError() {
+		t.Errorf("CUSTOM + unknown companion must defer (no diagnostic), got %v", resp.Diagnostics)
+	}
+}
+
+func TestPrefillTypeCustomRequiresFullAndUserNames_FiresWhenCompanionNull(t *testing.T) {
+	// prefill_type=CUSTOM with a required companion null/absent must error.
+	cfg := buildConfig(t, map[string]any{
+		"prefill_account_user_name": "jdoe",
+		"prefill_account_full_name": nil, // null String
+	})
+	req := validator.StringRequest{
+		Path:        path.Root("prefill_type"),
+		ConfigValue: types.StringValue("CUSTOM"),
+		Config:      cfg,
+	}
+	var resp validator.StringResponse
+	prefillTypeCustomRequiresFullAndUserNames().ValidateString(context.Background(), req, &resp)
+	if !resp.Diagnostics.HasError() {
+		t.Errorf("CUSTOM + null companion should fire validator")
+	}
+}
+
+func TestPrefillTypeCustomRequiresFullAndUserNames_NoErrorWhenBothSet(t *testing.T) {
+	cfg := buildConfig(t, map[string]any{
+		"prefill_account_full_name": "John Doe",
+		"prefill_account_user_name": "jdoe",
+	})
+	req := validator.StringRequest{
+		Path:        path.Root("prefill_type"),
+		ConfigValue: types.StringValue("CUSTOM"),
+		Config:      cfg,
+	}
+	var resp validator.StringResponse
+	prefillTypeCustomRequiresFullAndUserNames().ValidateString(context.Background(), req, &resp)
+	if resp.Diagnostics.HasError() {
+		t.Errorf("CUSTOM + both companions set should not fire validator, got %v", resp.Diagnostics)
 	}
 }
 

--- a/internal/resources/pro/enrollment/enrollment_customization/validators.go
+++ b/internal/resources/pro/enrollment/enrollment_customization/validators.go
@@ -55,6 +55,11 @@ func (accessGroupNameValidator) ValidateString(ctx context.Context, req validato
 	if enrollmentAccess.ValueString() != enrollmentAccessSpecificGroup {
 		return
 	}
+	// Defer when the value is unknown (variable/for_each-driven): config-time
+	// validation cannot see it. Error only when genuinely absent/empty.
+	if req.ConfigValue.IsUnknown() {
+		return
+	}
 	if !req.ConfigValue.IsNull() && !req.ConfigValue.IsUnknown() && req.ConfigValue.ValueString() != "" {
 		return
 	}

--- a/internal/resources/pro/enrollment/enrollment_customization/validators_test.go
+++ b/internal/resources/pro/enrollment/enrollment_customization/validators_test.go
@@ -9,8 +9,11 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
 )
 
 // textPaneObjectType is the framework attr.Type for a single text pane,
@@ -84,6 +87,118 @@ func TestUniqueDisplayNameValidator_PassesUniqueLists(t *testing.T) {
 	UniqueDisplayNameValidator().ValidateList(context.Background(), req, &resp)
 	if resp.Diagnostics.HasError() {
 		t.Fatalf("unique list rejected: %v", resp.Diagnostics)
+	}
+}
+
+// accessGroupConfig builds a tfsdk.Config carrying the two sibling attributes
+// the accessGroupNameValidator reads (enrollment_access discriminator +
+// access_group_name validated value), so GetAttribute on the parent path
+// resolves enrollment_access. Pass tftypes.UnknownValue / nil for the
+// access_group_name value to exercise unknown / null states.
+func accessGroupConfig(enrollmentAccess, accessGroupName tftypes.Value) tfsdk.Config {
+	objType := tftypes.Object{AttributeTypes: map[string]tftypes.Type{
+		"enrollment_access": tftypes.String,
+		"access_group_name": tftypes.String,
+	}}
+	return tfsdk.Config{
+		Schema: schema.Schema{Attributes: map[string]schema.Attribute{
+			"enrollment_access": schema.StringAttribute{Optional: true},
+			"access_group_name": schema.StringAttribute{Optional: true},
+		}},
+		Raw: tftypes.NewValue(objType, map[string]tftypes.Value{
+			"enrollment_access": enrollmentAccess,
+			"access_group_name": accessGroupName,
+		}),
+	}
+}
+
+func runAccessGroupNameValidator(cfg tfsdk.Config, configValue types.String) []string {
+	req := validator.StringRequest{
+		Path:        path.Root("access_group_name"),
+		Config:      cfg,
+		ConfigValue: configValue,
+	}
+	var resp validator.StringResponse
+	AccessGroupNameValidator().ValidateString(context.Background(), req, &resp)
+	out := make([]string, 0, len(resp.Diagnostics))
+	for _, d := range resp.Diagnostics {
+		out = append(out, d.Summary())
+	}
+	return out
+}
+
+// TestAccessGroupName_DefersWhenValueUnknown is the defer-on-unknown regression
+// guard: enrollment_access = "specific_group" (known) + access_group_name
+// UNKNOWN (variable/for_each-driven) must DEFER, not treat unknown as missing
+// and error. See STYLE_GUIDE "Config-time validators must defer on unknown
+// values".
+func TestAccessGroupName_DefersWhenValueUnknown(t *testing.T) {
+	cfg := accessGroupConfig(
+		tftypes.NewValue(tftypes.String, enrollmentAccessSpecificGroup),
+		tftypes.NewValue(tftypes.String, tftypes.UnknownValue),
+	)
+	if out := runAccessGroupNameValidator(cfg, types.StringUnknown()); len(out) != 0 {
+		t.Errorf("specific_group + unknown access_group_name must defer, got %v", out)
+	}
+}
+
+// TestAccessGroupName_ErrorsWhenNull proves the requirement still fires when
+// access_group_name is genuinely absent on a specific_group pane.
+func TestAccessGroupName_ErrorsWhenNull(t *testing.T) {
+	cfg := accessGroupConfig(
+		tftypes.NewValue(tftypes.String, enrollmentAccessSpecificGroup),
+		tftypes.NewValue(tftypes.String, nil),
+	)
+	if out := runAccessGroupNameValidator(cfg, types.StringNull()); len(out) == 0 {
+		t.Error("expected error for specific_group with null access_group_name")
+	}
+}
+
+// TestAccessGroupName_ErrorsWhenEmpty proves an empty-string access_group_name
+// still trips the requirement.
+func TestAccessGroupName_ErrorsWhenEmpty(t *testing.T) {
+	cfg := accessGroupConfig(
+		tftypes.NewValue(tftypes.String, enrollmentAccessSpecificGroup),
+		tftypes.NewValue(tftypes.String, ""),
+	)
+	if out := runAccessGroupNameValidator(cfg, types.StringValue("")); len(out) == 0 {
+		t.Error("expected error for specific_group with empty access_group_name")
+	}
+}
+
+// TestAccessGroupName_PassesWhenPresent proves a populated access_group_name on
+// a specific_group pane passes.
+func TestAccessGroupName_PassesWhenPresent(t *testing.T) {
+	cfg := accessGroupConfig(
+		tftypes.NewValue(tftypes.String, enrollmentAccessSpecificGroup),
+		tftypes.NewValue(tftypes.String, "GroupX"),
+	)
+	if out := runAccessGroupNameValidator(cfg, types.StringValue("GroupX")); len(out) != 0 {
+		t.Errorf("specific_group + populated access_group_name should pass, got %v", out)
+	}
+}
+
+// TestAccessGroupName_PassesForAnyIdpUser proves the validator is a no-op when
+// enrollment_access != "specific_group", regardless of access_group_name.
+func TestAccessGroupName_PassesForAnyIdpUser(t *testing.T) {
+	cfg := accessGroupConfig(
+		tftypes.NewValue(tftypes.String, enrollmentAccessAnyIdpUser),
+		tftypes.NewValue(tftypes.String, nil),
+	)
+	if out := runAccessGroupNameValidator(cfg, types.StringNull()); len(out) != 0 {
+		t.Errorf("any_idp_user must not require access_group_name, got %v", out)
+	}
+}
+
+// TestAccessGroupName_DefersWhenDiscriminatorUnknown proves the validator
+// defers when enrollment_access itself is unknown.
+func TestAccessGroupName_DefersWhenDiscriminatorUnknown(t *testing.T) {
+	cfg := accessGroupConfig(
+		tftypes.NewValue(tftypes.String, tftypes.UnknownValue),
+		tftypes.NewValue(tftypes.String, nil),
+	)
+	if out := runAccessGroupNameValidator(cfg, types.StringNull()); len(out) != 0 {
+		t.Errorf("unknown enrollment_access must defer, got %v", out)
 	}
 }
 

--- a/internal/resources/pro/inventory/disk_encryption_configuration/validators.go
+++ b/internal/resources/pro/inventory/disk_encryption_configuration/validators.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
 // institutionalKeyTypeRequiresIRKConfigValidator enforces the rule that
@@ -39,26 +40,43 @@ func (v institutionalKeyTypeRequiresIRKConfigValidator) MarkdownDescription(ctx 
 
 // ValidateResource implements the plan-time check.
 func (institutionalKeyTypeRequiresIRKConfigValidator) ValidateResource(ctx context.Context, req resource.ValidateConfigRequest, resp *resource.ValidateConfigResponse) {
-	var data DiskEncryptionConfigurationResourceModel
-	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+	// Read only the two attributes this cross-field check needs, via
+	// GetAttribute, so the validator is light to unit-test (no full-model
+	// fixture) and reads no more than necessary.
+	var keyType types.String
+	resp.Diagnostics.Append(req.Config.GetAttribute(ctx, path.Root("key_type"), &keyType)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
-	if data.KeyType.IsNull() || data.KeyType.IsUnknown() {
+	if keyType.IsNull() || keyType.IsUnknown() {
 		return
 	}
 
-	kt := data.KeyType.ValueString()
+	kt := keyType.ValueString()
 	needsIRK := kt == keyTypeInstitutional || kt == keyTypeIndividualInstitutional
 	if !needsIRK {
+		return
+	}
+
+	// Read the block as a typed Object to tell "unknown" (driven by a variable /
+	// for_each / another resource) apart from "absent": decoding into the Go
+	// *struct collapses both to nil. Config-time validation cannot see an
+	// unknown value, so defer — erroring here would break every non-literal
+	// config. Only a genuinely-absent (null) block is the error.
+	var irk types.Object
+	resp.Diagnostics.Append(req.Config.GetAttribute(ctx, path.Root("institutional_recovery_key"), &irk)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	if irk.IsUnknown() {
 		return
 	}
 
 	// IRK block absent: error. `data` and `certificate_type` are marked
 	// Required at the schema layer so we don't double-check them here —
 	// the framework rejects a partially-populated block at plan time.
-	if data.InstitutionalRecoveryKey == nil {
+	if irk.IsNull() {
 		resp.Diagnostics.AddAttributeError(
 			path.Root("institutional_recovery_key"),
 			fmt.Sprintf("institutional_recovery_key required when key_type = %q", kt),

--- a/internal/resources/pro/inventory/disk_encryption_configuration/validators_test.go
+++ b/internal/resources/pro/inventory/disk_encryption_configuration/validators_test.go
@@ -1,0 +1,130 @@
+// Copyright Jamf Software LLC 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package disk_encryption_configuration
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+)
+
+// irkObjType is the tftypes shape of the institutional_recovery_key block.
+var irkObjType = tftypes.Object{AttributeTypes: map[string]tftypes.Type{
+	"key":                 tftypes.String,
+	"certificate_type":    tftypes.String,
+	"password":            tftypes.String,
+	"password_wo_version": tftypes.Number,
+	"data":                tftypes.String,
+}}
+
+// irkValidatorConfig builds a Config carrying only key_type and the
+// institutional_recovery_key block — the two attributes the ConfigValidator
+// reads via GetAttribute. keyType nil → null; irk is null, unknown, or present
+// per the args.
+func irkValidatorConfig(keyType *string, irkUnknown, irkPresent bool) tfsdk.Config {
+	keyTypeVal := tftypes.NewValue(tftypes.String, nil)
+	if keyType != nil {
+		keyTypeVal = tftypes.NewValue(tftypes.String, *keyType)
+	}
+
+	var irkVal tftypes.Value
+	switch {
+	case irkUnknown:
+		irkVal = tftypes.NewValue(irkObjType, tftypes.UnknownValue)
+	case irkPresent:
+		irkVal = tftypes.NewValue(irkObjType, map[string]tftypes.Value{
+			"key":                 tftypes.NewValue(tftypes.String, nil),
+			"certificate_type":    tftypes.NewValue(tftypes.String, "PKCS12"),
+			"password":            tftypes.NewValue(tftypes.String, "pw"),
+			"password_wo_version": tftypes.NewValue(tftypes.Number, 1),
+			"data":                tftypes.NewValue(tftypes.String, "aGVsbG8="),
+		})
+	default:
+		irkVal = tftypes.NewValue(irkObjType, nil)
+	}
+
+	objType := tftypes.Object{AttributeTypes: map[string]tftypes.Type{
+		"key_type":                   tftypes.String,
+		"institutional_recovery_key": irkObjType,
+	}}
+
+	return tfsdk.Config{
+		Schema: schema.Schema{Attributes: map[string]schema.Attribute{
+			"key_type": schema.StringAttribute{Optional: true},
+			"institutional_recovery_key": schema.SingleNestedAttribute{
+				Optional: true,
+				Attributes: map[string]schema.Attribute{
+					"key":                 schema.StringAttribute{Computed: true},
+					"certificate_type":    schema.StringAttribute{Required: true},
+					"password":            schema.StringAttribute{Optional: true},
+					"password_wo_version": schema.Int64Attribute{Optional: true},
+					"data":                schema.StringAttribute{Required: true},
+				},
+			},
+		}},
+		Raw: tftypes.NewValue(objType, map[string]tftypes.Value{
+			"key_type":                   keyTypeVal,
+			"institutional_recovery_key": irkVal,
+		}),
+	}
+}
+
+func runIRKValidator(cfg tfsdk.Config) []string {
+	var resp resource.ValidateConfigResponse
+	institutionalKeyTypeRequiresIRKConfigValidator{}.ValidateResource(
+		context.Background(),
+		resource.ValidateConfigRequest{Config: cfg},
+		&resp,
+	)
+	out := make([]string, 0, len(resp.Diagnostics))
+	for _, d := range resp.Diagnostics {
+		out = append(out, d.Summary())
+	}
+	return out
+}
+
+// TestIRK_DefersWhenBlockUnknown is the defer-on-unknown regression guard: with
+// key_type = "Institutional" (known) and the institutional_recovery_key block
+// UNKNOWN (e.g. variable-driven), the validator must DEFER, not treat unknown
+// as a missing block and error. See STYLE_GUIDE "Config-time validators must
+// defer on unknown values".
+func TestIRK_DefersWhenBlockUnknown(t *testing.T) {
+	kt := keyTypeInstitutional
+	if out := runIRKValidator(irkValidatorConfig(&kt, true, false)); len(out) != 0 {
+		t.Errorf("validator must defer when IRK block is unknown, got %v", out)
+	}
+}
+
+// TestIRK_ErrorsWhenRequiredAndAbsent proves the invariant still fires when the
+// block is genuinely absent (null) for a key_type that requires it.
+func TestIRK_ErrorsWhenRequiredAndAbsent(t *testing.T) {
+	kt := keyTypeInstitutional
+	if out := runIRKValidator(irkValidatorConfig(&kt, false, false)); len(out) == 0 {
+		t.Error("expected error when key_type=Institutional and no IRK block")
+	}
+}
+
+// TestIRK_SilentWhenPresent proves no error when the block is supplied.
+func TestIRK_SilentWhenPresent(t *testing.T) {
+	kt := keyTypeIndividualInstitutional
+	if out := runIRKValidator(irkValidatorConfig(&kt, false, true)); len(out) != 0 {
+		t.Errorf("validator should not fire when IRK block present, got %v", out)
+	}
+}
+
+// TestIRK_SilentWhenKeyTypeNotRequiringIRK proves no error for a key_type that
+// does not need the block, and defers when key_type itself is null/unset.
+func TestIRK_SilentWhenKeyTypeNotRequiringIRK(t *testing.T) {
+	individual := "Individual"
+	if out := runIRKValidator(irkValidatorConfig(&individual, false, false)); len(out) != 0 {
+		t.Errorf("validator should not fire for key_type=Individual, got %v", out)
+	}
+	if out := runIRKValidator(irkValidatorConfig(nil, false, false)); len(out) != 0 {
+		t.Errorf("validator should defer when key_type is unset, got %v", out)
+	}
+}

--- a/internal/resources/pro/inventory/printer/validators.go
+++ b/internal/resources/pro/inventory/printer/validators.go
@@ -86,6 +86,13 @@ func (useGenericPPDConfigValidator) ValidateResource(ctx context.Context, req re
 	}
 
 	// use_generic = false
+	// Defer when ppd_path is unknown (variable/for_each/resource-driven):
+	// config-time validation cannot see its eventual value, so treating unknown
+	// as "missing" would false-error on every non-literal config. isSet() treats
+	// unknown as not-set, so guard explicitly here.
+	if data.PPDPath.IsUnknown() {
+		return
+	}
 	if !isSet(data.PPDPath) {
 		resp.Diagnostics.AddAttributeError(
 			path.Root("ppd_path"),

--- a/internal/resources/pro/policies/policy/validators.go
+++ b/internal/resources/pro/policies/policy/validators.go
@@ -83,10 +83,20 @@ func (deferralTypeCompanionsValidator) ValidateString(ctx context.Context, req v
 	untilSet := !untilVal.IsNull() && !untilVal.IsUnknown()
 	daysSet := !daysVal.IsNull() && !daysVal.IsUnknown()
 
-	// When deferral_type is null/unknown we still reject orphaned siblings —
+	// When deferral_type is UNKNOWN (e.g. sourced from a variable) a
+	// config-time validator must DEFER — see STYLE_GUIDE "Config-time
+	// validators MUST defer on unknown values". The discriminator's value is
+	// not yet decidable, so we cannot judge the companions.
+	if req.ConfigValue.IsUnknown() {
+		return
+	}
+
+	// When deferral_type is genuinely NULL we still reject orphaned siblings —
 	// the trio is a single Optional concept and a companion without its
-	// discriminator is meaningless.
-	if req.ConfigValue.IsNull() || req.ConfigValue.IsUnknown() {
+	// discriminator is meaningless. These are forbidden-when checks (error on
+	// PRESENT), so unknown companions are correctly ignored (untilSet/daysSet
+	// are false for unknown).
+	if req.ConfigValue.IsNull() {
 		if untilSet {
 			resp.Diagnostics.AddAttributeError(
 				untilPath,
@@ -121,7 +131,9 @@ func (deferralTypeCompanionsValidator) ValidateString(ctx context.Context, req v
 			)
 		}
 	case "date":
-		if !untilSet {
+		// Required-when check: error only when deferral_until_utc is genuinely
+		// null; defer when it is unknown (unknown != absent).
+		if untilVal.IsNull() {
 			resp.Diagnostics.AddAttributeError(
 				untilPath,
 				"deferral_until_utc required when deferral_type = \"date\"",
@@ -136,13 +148,15 @@ func (deferralTypeCompanionsValidator) ValidateString(ctx context.Context, req v
 			)
 		}
 	case "duration":
-		if !daysSet {
+		// Required-when check: error only when deferral_days is genuinely null;
+		// defer when it is unknown (unknown != absent).
+		if daysVal.IsNull() {
 			resp.Diagnostics.AddAttributeError(
 				daysPath,
 				"deferral_days required when deferral_type = \"duration\"",
 				"Provide a positive day count (e.g. `deferral_days = 3`).",
 			)
-		} else if daysVal.ValueInt64() < 1 {
+		} else if !daysVal.IsUnknown() && daysVal.ValueInt64() < 1 {
 			resp.Diagnostics.AddAttributeError(
 				daysPath,
 				"deferral_days must be >= 1",

--- a/internal/resources/pro/policies/policy/validators_test.go
+++ b/internal/resources/pro/policies/policy/validators_test.go
@@ -1,0 +1,222 @@
+// Copyright Jamf Software LLC 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package policy
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+)
+
+// uiObjType is the tftypes shape of the user_interaction block, restricted to
+// the deferral trio the validator reads.
+var uiObjType = tftypes.Object{AttributeTypes: map[string]tftypes.Type{
+	"deferral_type":      tftypes.String,
+	"deferral_until_utc": tftypes.String,
+	"deferral_days":      tftypes.Number,
+}}
+
+var rootObjType = tftypes.Object{AttributeTypes: map[string]tftypes.Type{
+	"user_interaction": uiObjType,
+}}
+
+// attrState is the tri-state a fixture attribute can take.
+type attrState int
+
+const (
+	stNull attrState = iota
+	stUnknown
+	stSet
+)
+
+// strVal builds a String tftypes value for the given state. The set value is
+// the caller-supplied literal.
+func strVal(s attrState, set string) tftypes.Value {
+	switch s {
+	case stUnknown:
+		return tftypes.NewValue(tftypes.String, tftypes.UnknownValue)
+	case stSet:
+		return tftypes.NewValue(tftypes.String, set)
+	default:
+		return tftypes.NewValue(tftypes.String, nil)
+	}
+}
+
+// numVal builds a Number tftypes value for the given state.
+func numVal(s attrState, set int64) tftypes.Value {
+	switch s {
+	case stUnknown:
+		return tftypes.NewValue(tftypes.Number, tftypes.UnknownValue)
+	case stSet:
+		return tftypes.NewValue(tftypes.Number, set)
+	default:
+		return tftypes.NewValue(tftypes.Number, nil)
+	}
+}
+
+// deferralConfig assembles a tfsdk.Config carrying a user_interaction block
+// with the three deferral attributes in the requested states, mirroring the
+// nesting the validator walks via req.Path.ParentPath().AtName(...).
+func deferralConfig(typeVal, untilVal tftypes.Value, daysVal tftypes.Value) tfsdk.Config {
+	uiSchema := schema.SingleNestedAttribute{
+		Optional: true,
+		Attributes: map[string]schema.Attribute{
+			"deferral_type":      schema.StringAttribute{Optional: true},
+			"deferral_until_utc": schema.StringAttribute{Optional: true},
+			"deferral_days":      schema.Int64Attribute{Optional: true},
+		},
+	}
+
+	return tfsdk.Config{
+		Schema: schema.Schema{Attributes: map[string]schema.Attribute{
+			"user_interaction": uiSchema,
+		}},
+		Raw: tftypes.NewValue(rootObjType, map[string]tftypes.Value{
+			"user_interaction": tftypes.NewValue(uiObjType, map[string]tftypes.Value{
+				"deferral_type":      typeVal,
+				"deferral_until_utc": untilVal,
+				"deferral_days":      daysVal,
+			}),
+		}),
+	}
+}
+
+// runDeferralValidator drives deferralTypeCompanionsValidator against a config,
+// setting req.ConfigValue + req.Path to the user_interaction.deferral_type
+// attribute, and returns diagnostic summaries.
+func runDeferralValidator(cfg tfsdk.Config, configValue types.String) []string {
+	req := validator.StringRequest{
+		Path:        path.Root("user_interaction").AtName("deferral_type"),
+		ConfigValue: configValue,
+		Config:      cfg,
+	}
+	var resp validator.StringResponse
+	deferralTypeCompanionsValidator{}.ValidateString(context.Background(), req, &resp)
+
+	out := make([]string, 0, len(resp.Diagnostics))
+	for _, d := range resp.Diagnostics {
+		out = append(out, d.Summary())
+	}
+	return out
+}
+
+// TestDeferral_DefersWhenTypeUnknown is the defer-on-unknown regression guard:
+// deferral_type unknown (variable-driven) with a known companion set must
+// DEFER, not reject the companion as orphaned. See STYLE_GUIDE "Config-time
+// validators MUST defer on unknown values".
+func TestDeferral_DefersWhenTypeUnknown(t *testing.T) {
+	cfg := deferralConfig(
+		strVal(stUnknown, ""),
+		strVal(stSet, "2027-01-01T01:00:00.000+0000"),
+		numVal(stNull, 0),
+	)
+	if out := runDeferralValidator(cfg, types.StringUnknown()); len(out) != 0 {
+		t.Errorf("unknown deferral_type must defer, got %v", out)
+	}
+}
+
+// TestDeferral_DateUntilUnknownDefers proves date + unknown deferral_until_utc
+// defers rather than false-erroring "required".
+func TestDeferral_DateUntilUnknownDefers(t *testing.T) {
+	cfg := deferralConfig(
+		strVal(stSet, "date"),
+		strVal(stUnknown, ""),
+		numVal(stNull, 0),
+	)
+	if out := runDeferralValidator(cfg, types.StringValue("date")); len(out) != 0 {
+		t.Errorf("date + unknown deferral_until_utc must defer, got %v", out)
+	}
+}
+
+// TestDeferral_DateUntilNullErrors proves the required-when check still fires
+// when deferral_until_utc is genuinely null.
+func TestDeferral_DateUntilNullErrors(t *testing.T) {
+	cfg := deferralConfig(
+		strVal(stSet, "date"),
+		strVal(stNull, ""),
+		numVal(stNull, 0),
+	)
+	if out := runDeferralValidator(cfg, types.StringValue("date")); len(out) == 0 {
+		t.Error("date + null deferral_until_utc must error")
+	}
+}
+
+// TestDeferral_DateUntilSetOK proves date + known deferral_until_utc passes.
+func TestDeferral_DateUntilSetOK(t *testing.T) {
+	cfg := deferralConfig(
+		strVal(stSet, "date"),
+		strVal(stSet, "2027-01-01T01:00:00.000+0000"),
+		numVal(stNull, 0),
+	)
+	if out := runDeferralValidator(cfg, types.StringValue("date")); len(out) != 0 {
+		t.Errorf("date + set deferral_until_utc should pass, got %v", out)
+	}
+}
+
+// TestDeferral_DurationDaysUnknownDefers proves duration + unknown deferral_days
+// defers rather than false-erroring "required" or ">= 1".
+func TestDeferral_DurationDaysUnknownDefers(t *testing.T) {
+	cfg := deferralConfig(
+		strVal(stSet, "duration"),
+		strVal(stNull, ""),
+		numVal(stUnknown, 0),
+	)
+	if out := runDeferralValidator(cfg, types.StringValue("duration")); len(out) != 0 {
+		t.Errorf("duration + unknown deferral_days must defer, got %v", out)
+	}
+}
+
+// TestDeferral_DurationDaysNullErrors proves the required-when check still fires
+// when deferral_days is genuinely null.
+func TestDeferral_DurationDaysNullErrors(t *testing.T) {
+	cfg := deferralConfig(
+		strVal(stSet, "duration"),
+		strVal(stNull, ""),
+		numVal(stNull, 0),
+	)
+	if out := runDeferralValidator(cfg, types.StringValue("duration")); len(out) == 0 {
+		t.Error("duration + null deferral_days must error")
+	}
+}
+
+// TestDeferral_DurationDaysBounds proves the >= 1 rule still works for known
+// values: 3 passes, 0 errors.
+func TestDeferral_DurationDaysBounds(t *testing.T) {
+	okCfg := deferralConfig(
+		strVal(stSet, "duration"),
+		strVal(stNull, ""),
+		numVal(stSet, 3),
+	)
+	if out := runDeferralValidator(okCfg, types.StringValue("duration")); len(out) != 0 {
+		t.Errorf("duration + deferral_days=3 should pass, got %v", out)
+	}
+
+	zeroCfg := deferralConfig(
+		strVal(stSet, "duration"),
+		strVal(stNull, ""),
+		numVal(stSet, 0),
+	)
+	if out := runDeferralValidator(zeroCfg, types.StringValue("duration")); len(out) == 0 {
+		t.Error("duration + deferral_days=0 must error (>= 1 rule)")
+	}
+}
+
+// TestDeferral_NoneForbidsCompanion proves the none case still forbids a present
+// companion (forbidden-when checks unchanged).
+func TestDeferral_NoneForbidsCompanion(t *testing.T) {
+	cfg := deferralConfig(
+		strVal(stSet, "none"),
+		strVal(stSet, "2027-01-01T01:00:00.000+0000"),
+		numVal(stNull, 0),
+	)
+	if out := runDeferralValidator(cfg, types.StringValue("none")); len(out) == 0 {
+		t.Error("none + deferral_until_utc set must error")
+	}
+}

--- a/internal/resources/pro/settings/sso_settings/validators.go
+++ b/internal/resources/pro/settings/sso_settings/validators.go
@@ -63,8 +63,10 @@ func (configurationTypeBlockValidator) ValidateString(ctx context.Context, req v
 		return
 	}
 
+	// "Present" (known, non-null) drives the forbidden checks; a genuinely-null
+	// block drives the required checks. An UNKNOWN block (variable-driven)
+	// defers on both — it is neither proven present nor proven absent.
 	samlSet := !samlPresent.IsNull() && !samlPresent.IsUnknown()
-	oidcSet := !oidcPresent.IsNull() && !oidcPresent.IsUnknown()
 
 	switch req.ConfigValue.ValueString() {
 	case configurationTypeOIDC:
@@ -75,7 +77,7 @@ func (configurationTypeBlockValidator) ValidateString(ctx context.Context, req v
 				"Remove the `saml_settings` block, or set `configuration_type = \"OIDC_WITH_SAML\"` to mix both modes.",
 			)
 		}
-		if !oidcSet {
+		if oidcPresent.IsNull() {
 			resp.Diagnostics.AddAttributeError(
 				path.Root("oidc_settings"),
 				"oidc_settings required when configuration_type = \"OIDC\"",
@@ -83,7 +85,7 @@ func (configurationTypeBlockValidator) ValidateString(ctx context.Context, req v
 			)
 		}
 	case configurationTypeSAML:
-		if !samlSet {
+		if samlPresent.IsNull() {
 			resp.Diagnostics.AddAttributeError(
 				path.Root("saml_settings"),
 				"saml_settings required when configuration_type = \"SAML\"",
@@ -91,14 +93,14 @@ func (configurationTypeBlockValidator) ValidateString(ctx context.Context, req v
 			)
 		}
 	case configurationTypeOIDCWithSAML:
-		if !samlSet {
+		if samlPresent.IsNull() {
 			resp.Diagnostics.AddAttributeError(
 				path.Root("saml_settings"),
 				"saml_settings required when configuration_type = \"OIDC_WITH_SAML\"",
 				"Both `saml_settings` and `oidc_settings` must be supplied.",
 			)
 		}
-		if !oidcSet {
+		if oidcPresent.IsNull() {
 			resp.Diagnostics.AddAttributeError(
 				path.Root("oidc_settings"),
 				"oidc_settings required when configuration_type = \"OIDC_WITH_SAML\"",
@@ -168,7 +170,12 @@ func validateSamlActiveStringNonEmpty(ctx context.Context, req validator.StringR
 	if configType.ValueString() != configurationTypeSAML && configType.ValueString() != configurationTypeOIDCWithSAML {
 		return
 	}
-	if !req.ConfigValue.IsNull() && !req.ConfigValue.IsUnknown() && req.ConfigValue.ValueString() != "" {
+	// Defer when the validated value is unknown (variable/for_each-driven):
+	// config-time validation cannot see it. Error only when genuinely null/empty.
+	if req.ConfigValue.IsUnknown() {
+		return
+	}
+	if !req.ConfigValue.IsNull() && req.ConfigValue.ValueString() != "" {
 		return
 	}
 	resp.Diagnostics.AddAttributeError(
@@ -217,7 +224,7 @@ func (metadataSourceBranchValidator) ValidateString(ctx context.Context, req val
 
 	switch req.ConfigValue.ValueString() {
 	case metadataSourceURL:
-		if !isStringConfigured(idpURL) {
+		if !isStringConfigured(idpURL) && !idpURL.IsUnknown() {
 			resp.Diagnostics.AddAttributeError(
 				parent.AtName("idp_url"),
 				"idp_url required when metadata_source = \"URL\"",
@@ -239,14 +246,14 @@ func (metadataSourceBranchValidator) ValidateString(ctx context.Context, req val
 			)
 		}
 	case metadataSourceFILE:
-		if !isStringConfigured(fmf) {
+		if !isStringConfigured(fmf) && !fmf.IsUnknown() {
 			resp.Diagnostics.AddAttributeError(
 				parent.AtName("federation_metadata_file"),
 				"federation_metadata_file required when metadata_source = \"FILE\"",
 				"Supply `federation_metadata_file = filebase64(\"idp-metadata.xml\")`.",
 			)
 		}
-		if !isStringConfigured(mfn) {
+		if !isStringConfigured(mfn) && !mfn.IsUnknown() {
 			resp.Diagnostics.AddAttributeError(
 				parent.AtName("metadata_file_name"),
 				"metadata_file_name required when metadata_source = \"FILE\"",
@@ -295,7 +302,7 @@ func (idpProviderTypeOtherValidator) ValidateString(ctx context.Context, req val
 	if d := req.Config.GetAttribute(ctx, parent.AtName("other_provider_type_name"), &other); d.HasError() {
 		return
 	}
-	if isStringConfigured(other) {
+	if other.IsUnknown() || isStringConfigured(other) {
 		return
 	}
 	resp.Diagnostics.AddAttributeError(
@@ -337,7 +344,7 @@ func (userAttributeEnabledValidator) ValidateBool(ctx context.Context, req valid
 	if d := req.Config.GetAttribute(ctx, parent.AtName("user_attribute_name"), &name); d.HasError() {
 		return
 	}
-	if isStringConfigured(name) {
+	if name.IsUnknown() || isStringConfigured(name) {
 		return
 	}
 	resp.Diagnostics.AddAttributeError(
@@ -436,7 +443,7 @@ func (groupEnrollmentAccessEnabledValidator) ValidateBool(ctx context.Context, r
 	if d := req.Config.GetAttribute(ctx, path.Root("group_enrollment_access_name"), &name); d.HasError() {
 		return
 	}
-	if isStringConfigured(name) {
+	if name.IsUnknown() || isStringConfigured(name) {
 		return
 	}
 	resp.Diagnostics.AddAttributeError(
@@ -489,7 +496,7 @@ func (signingCertificateSetupTypeValidator) ValidateString(ctx context.Context, 
 		if d := req.Config.GetAttribute(ctx, parent.AtName(name), &v); d.HasError() {
 			continue
 		}
-		if isStringConfigured(v) {
+		if v.IsUnknown() || isStringConfigured(v) {
 			continue
 		}
 		resp.Diagnostics.AddAttributeError(

--- a/internal/resources/pro/settings/sso_settings/validators_test.go
+++ b/internal/resources/pro/settings/sso_settings/validators_test.go
@@ -1,0 +1,754 @@
+// Copyright Jamf Software LLC 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package sso_settings
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+)
+
+// These tests cover the defer-on-unknown fixes applied to the SSO settings
+// config-time validators. The invariant under test (per validator): when a
+// value the validator reads is UNKNOWN (variable/for_each-driven), the
+// validator must DEFER (emit no diagnostic); it errors only when the value is
+// genuinely null/empty, and passes for valid known input.
+//
+// Each defer-on-unknown regression is proven by holding every other attribute
+// constant and flipping exactly ONE attribute between unknown and null: the
+// unknown case must yield len(diags)==0 and the null case len(diags)>0.
+
+// ===== tri-state helpers (shared) ===========================================
+
+type attrState int
+
+const (
+	stNull attrState = iota
+	stUnknown
+	stSet
+)
+
+func strVal(s attrState, set string) tftypes.Value {
+	switch s {
+	case stUnknown:
+		return tftypes.NewValue(tftypes.String, tftypes.UnknownValue)
+	case stSet:
+		return tftypes.NewValue(tftypes.String, set)
+	default:
+		return tftypes.NewValue(tftypes.String, nil)
+	}
+}
+
+func boolVal(s attrState, set bool) tftypes.Value {
+	switch s {
+	case stUnknown:
+		return tftypes.NewValue(tftypes.Bool, tftypes.UnknownValue)
+	case stSet:
+		return tftypes.NewValue(tftypes.Bool, set)
+	default:
+		return tftypes.NewValue(tftypes.Bool, nil)
+	}
+}
+
+func stringDiagSummaries(resp validator.StringResponse) []string {
+	out := make([]string, 0, len(resp.Diagnostics))
+	for _, d := range resp.Diagnostics {
+		out = append(out, d.Summary())
+	}
+	return out
+}
+
+func boolDiagSummaries(resp validator.BoolResponse) []string {
+	out := make([]string, 0, len(resp.Diagnostics))
+	for _, d := range resp.Diagnostics {
+		out = append(out, d.Summary())
+	}
+	return out
+}
+
+// ===== validateSamlActiveStringNonEmpty (entity_id / group_attribute_name) ==
+
+// samlActiveConfig builds a Config holding just configuration_type at root.
+// The validated string (entity_id / group_attribute_name) arrives via
+// req.ConfigValue, so it need not be part of the Config schema.
+func samlActiveConfig(configType tftypes.Value) tfsdk.Config {
+	objType := tftypes.Object{AttributeTypes: map[string]tftypes.Type{
+		"configuration_type": tftypes.String,
+	}}
+	return tfsdk.Config{
+		Schema: schema.Schema{Attributes: map[string]schema.Attribute{
+			"configuration_type": schema.StringAttribute{Optional: true},
+		}},
+		Raw: tftypes.NewValue(objType, map[string]tftypes.Value{
+			"configuration_type": configType,
+		}),
+	}
+}
+
+func runSamlActiveValidator(v validator.String, attrName string, configType, value tftypes.Value) []string {
+	req := validator.StringRequest{
+		Path:        path.Root(attrName),
+		ConfigValue: types.StringValue(""), // placeholder, overwritten below
+		Config:      samlActiveConfig(configType),
+	}
+	// Build the validated value as a types.String reflecting the tftypes value.
+	var cv types.String
+	if value.IsKnown() {
+		if value.IsNull() {
+			cv = types.StringNull()
+		} else {
+			var s string
+			_ = value.As(&s)
+			cv = types.StringValue(s)
+		}
+	} else {
+		cv = types.StringUnknown()
+	}
+	req.ConfigValue = cv
+
+	var resp validator.StringResponse
+	v.ValidateString(context.Background(), req, &resp)
+	return stringDiagSummaries(resp)
+}
+
+// TestSamlEntityID_DefersWhenValueUnknown is the defer-on-unknown regression
+// guard for entity_id.
+func TestSamlEntityID_DefersWhenValueUnknown(t *testing.T) {
+	out := runSamlActiveValidator(
+		SamlEntityIDRequiredValidator(), "entity_id",
+		strVal(stSet, configurationTypeSAML),
+		strVal(stUnknown, ""),
+	)
+	if len(out) != 0 {
+		t.Errorf("entity_id validator must defer when value unknown, got %v", out)
+	}
+}
+
+func TestSamlEntityID_ErrorsWhenValueNull(t *testing.T) {
+	out := runSamlActiveValidator(
+		SamlEntityIDRequiredValidator(), "entity_id",
+		strVal(stSet, configurationTypeSAML),
+		strVal(stNull, ""),
+	)
+	if len(out) == 0 {
+		t.Error("entity_id validator must error when SAML active and value null")
+	}
+}
+
+func TestSamlEntityID_PassesWhenValueSet(t *testing.T) {
+	out := runSamlActiveValidator(
+		SamlEntityIDRequiredValidator(), "entity_id",
+		strVal(stSet, configurationTypeSAML),
+		strVal(stSet, "x"),
+	)
+	if len(out) != 0 {
+		t.Errorf("entity_id validator should pass when value set, got %v", out)
+	}
+}
+
+func TestSamlEntityID_SilentWhenOIDC(t *testing.T) {
+	out := runSamlActiveValidator(
+		SamlEntityIDRequiredValidator(), "entity_id",
+		strVal(stSet, configurationTypeOIDC),
+		strVal(stNull, ""),
+	)
+	if len(out) != 0 {
+		t.Errorf("entity_id validator should not fire under OIDC, got %v", out)
+	}
+}
+
+func TestSamlGroupAttributeName_DefersWhenValueUnknown(t *testing.T) {
+	out := runSamlActiveValidator(
+		SamlGroupAttributeNameRequiredValidator(), "group_attribute_name",
+		strVal(stSet, configurationTypeSAML),
+		strVal(stUnknown, ""),
+	)
+	if len(out) != 0 {
+		t.Errorf("group_attribute_name validator must defer when value unknown, got %v", out)
+	}
+}
+
+func TestSamlGroupAttributeName_ErrorsWhenValueNull(t *testing.T) {
+	out := runSamlActiveValidator(
+		SamlGroupAttributeNameRequiredValidator(), "group_attribute_name",
+		strVal(stSet, configurationTypeSAML),
+		strVal(stNull, ""),
+	)
+	if len(out) == 0 {
+		t.Error("group_attribute_name validator must error when SAML active and value null")
+	}
+}
+
+func TestSamlGroupAttributeName_PassesWhenValueSet(t *testing.T) {
+	out := runSamlActiveValidator(
+		SamlGroupAttributeNameRequiredValidator(), "group_attribute_name",
+		strVal(stSet, configurationTypeSAML),
+		strVal(stSet, "x"),
+	)
+	if len(out) != 0 {
+		t.Errorf("group_attribute_name validator should pass when value set, got %v", out)
+	}
+}
+
+func TestSamlGroupAttributeName_SilentWhenOIDC(t *testing.T) {
+	out := runSamlActiveValidator(
+		SamlGroupAttributeNameRequiredValidator(), "group_attribute_name",
+		strVal(stSet, configurationTypeOIDC),
+		strVal(stNull, ""),
+	)
+	if len(out) != 0 {
+		t.Errorf("group_attribute_name validator should not fire under OIDC, got %v", out)
+	}
+}
+
+// ===== configurationTypeBlockValidator ======================================
+//
+// Reads path.Root("saml_settings") and path.Root("oidc_settings") as objects;
+// only their presence matters. Minimal but schema-consistent object shapes.
+
+var cfgSamlObjType = tftypes.Object{AttributeTypes: map[string]tftypes.Type{
+	"entity_id": tftypes.String,
+}}
+
+var cfgOidcObjType = tftypes.Object{AttributeTypes: map[string]tftypes.Type{
+	"user_mapping": tftypes.String,
+}}
+
+var cfgRootObjType = tftypes.Object{AttributeTypes: map[string]tftypes.Type{
+	"configuration_type": tftypes.String,
+	"saml_settings":      cfgSamlObjType,
+	"oidc_settings":      cfgOidcObjType,
+}}
+
+func configTypeConfig(configType, samlSettings, oidcSettings tftypes.Value) tfsdk.Config {
+	samlSchema := schema.SingleNestedAttribute{
+		Optional: true,
+		Attributes: map[string]schema.Attribute{
+			"entity_id": schema.StringAttribute{Optional: true},
+		},
+	}
+	oidcSchema := schema.SingleNestedAttribute{
+		Optional: true,
+		Attributes: map[string]schema.Attribute{
+			"user_mapping": schema.StringAttribute{Optional: true},
+		},
+	}
+	return tfsdk.Config{
+		Schema: schema.Schema{Attributes: map[string]schema.Attribute{
+			"configuration_type": schema.StringAttribute{Optional: true},
+			"saml_settings":      samlSchema,
+			"oidc_settings":      oidcSchema,
+		}},
+		Raw: tftypes.NewValue(cfgRootObjType, map[string]tftypes.Value{
+			"configuration_type": configType,
+			"saml_settings":      samlSettings,
+			"oidc_settings":      oidcSettings,
+		}),
+	}
+}
+
+func samlObj(present bool) tftypes.Value {
+	if !present {
+		return tftypes.NewValue(cfgSamlObjType, nil)
+	}
+	return tftypes.NewValue(cfgSamlObjType, map[string]tftypes.Value{
+		"entity_id": tftypes.NewValue(tftypes.String, "ent"),
+	})
+}
+
+func oidcObj(present bool) tftypes.Value {
+	if !present {
+		return tftypes.NewValue(cfgOidcObjType, nil)
+	}
+	return tftypes.NewValue(cfgOidcObjType, map[string]tftypes.Value{
+		"user_mapping": tftypes.NewValue(tftypes.String, "EMAIL"),
+	})
+}
+
+func runConfigTypeValidator(configType, samlSettings, oidcSettings tftypes.Value) []string {
+	req := validator.StringRequest{
+		Path:        path.Root("configuration_type"),
+		ConfigValue: tftypesToTypesString(configType),
+		Config:      configTypeConfig(configType, samlSettings, oidcSettings),
+	}
+	var resp validator.StringResponse
+	ConfigurationTypeBlockValidator().ValidateString(context.Background(), req, &resp)
+	return stringDiagSummaries(resp)
+}
+
+func tftypesToTypesString(v tftypes.Value) types.String {
+	if !v.IsKnown() {
+		return types.StringUnknown()
+	}
+	if v.IsNull() {
+		return types.StringNull()
+	}
+	var s string
+	_ = v.As(&s)
+	return types.StringValue(s)
+}
+
+// TestConfigTypeBlock_DefersWhenSamlUnknown is the SAML-branch defer-on-unknown
+// regression guard: configuration_type = SAML with saml_settings UNKNOWN must
+// NOT error (the block is not proven absent).
+func TestConfigTypeBlock_DefersWhenSamlUnknown(t *testing.T) {
+	out := runConfigTypeValidator(
+		strVal(stSet, configurationTypeSAML),
+		tftypes.NewValue(cfgSamlObjType, tftypes.UnknownValue),
+		oidcObj(false),
+	)
+	if len(out) != 0 {
+		t.Errorf("configuration_type validator must defer when saml_settings unknown, got %v", out)
+	}
+}
+
+func TestConfigTypeBlock_ErrorsWhenSamlNull(t *testing.T) {
+	out := runConfigTypeValidator(
+		strVal(stSet, configurationTypeSAML),
+		samlObj(false),
+		oidcObj(false),
+	)
+	if len(out) == 0 {
+		t.Error("configuration_type = SAML must error when saml_settings null")
+	}
+}
+
+func TestConfigTypeBlock_OIDCForbidsSamlPresent(t *testing.T) {
+	out := runConfigTypeValidator(
+		strVal(stSet, configurationTypeOIDC),
+		samlObj(true),
+		oidcObj(true),
+	)
+	if len(out) == 0 {
+		t.Error("configuration_type = OIDC must error when saml_settings present")
+	}
+}
+
+func TestConfigTypeBlock_OIDCErrorsWhenOidcNull(t *testing.T) {
+	out := runConfigTypeValidator(
+		strVal(stSet, configurationTypeOIDC),
+		samlObj(false),
+		oidcObj(false),
+	)
+	if len(out) == 0 {
+		t.Error("configuration_type = OIDC must error when oidc_settings null")
+	}
+}
+
+// TestConfigTypeBlock_DefersWhenOidcUnknown: OIDC with oidc_settings UNKNOWN
+// and saml_settings null must NOT error. saml_settings is held null so the
+// forbidden-check stays quiet, isolating the oidc_settings defer.
+func TestConfigTypeBlock_DefersWhenOidcUnknown(t *testing.T) {
+	out := runConfigTypeValidator(
+		strVal(stSet, configurationTypeOIDC),
+		samlObj(false),
+		tftypes.NewValue(cfgOidcObjType, tftypes.UnknownValue),
+	)
+	if len(out) != 0 {
+		t.Errorf("configuration_type validator must defer when oidc_settings unknown, got %v", out)
+	}
+}
+
+// ===== metadataSourceBranchValidator ========================================
+//
+// Reads idp_url, federation_metadata_file, metadata_file_name as siblings of
+// metadata_source under a parent object (saml_settings).
+
+var mdParentObjType = tftypes.Object{AttributeTypes: map[string]tftypes.Type{
+	"metadata_source":          tftypes.String,
+	"idp_url":                  tftypes.String,
+	"federation_metadata_file": tftypes.String,
+	"metadata_file_name":       tftypes.String,
+}}
+
+var mdRootObjType = tftypes.Object{AttributeTypes: map[string]tftypes.Type{
+	"saml_settings": mdParentObjType,
+}}
+
+func metadataConfig(source, idpURL, fmf, mfn tftypes.Value) tfsdk.Config {
+	parentSchema := schema.SingleNestedAttribute{
+		Optional: true,
+		Attributes: map[string]schema.Attribute{
+			"metadata_source":          schema.StringAttribute{Optional: true},
+			"idp_url":                  schema.StringAttribute{Optional: true},
+			"federation_metadata_file": schema.StringAttribute{Optional: true},
+			"metadata_file_name":       schema.StringAttribute{Optional: true},
+		},
+	}
+	return tfsdk.Config{
+		Schema: schema.Schema{Attributes: map[string]schema.Attribute{
+			"saml_settings": parentSchema,
+		}},
+		Raw: tftypes.NewValue(mdRootObjType, map[string]tftypes.Value{
+			"saml_settings": tftypes.NewValue(mdParentObjType, map[string]tftypes.Value{
+				"metadata_source":          source,
+				"idp_url":                  idpURL,
+				"federation_metadata_file": fmf,
+				"metadata_file_name":       mfn,
+			}),
+		}),
+	}
+}
+
+func runMetadataValidator(source, idpURL, fmf, mfn tftypes.Value) []string {
+	req := validator.StringRequest{
+		Path:        path.Root("saml_settings").AtName("metadata_source"),
+		ConfigValue: tftypesToTypesString(source),
+		Config:      metadataConfig(source, idpURL, fmf, mfn),
+	}
+	var resp validator.StringResponse
+	MetadataSourceBranchValidator().ValidateString(context.Background(), req, &resp)
+	return stringDiagSummaries(resp)
+}
+
+// TestMetadata_URL_DefersWhenIdpURLUnknown: URL branch, idp_url UNKNOWN (others
+// null) must NOT error.
+func TestMetadata_URL_DefersWhenIdpURLUnknown(t *testing.T) {
+	out := runMetadataValidator(
+		strVal(stSet, metadataSourceURL),
+		strVal(stUnknown, ""),
+		strVal(stNull, ""),
+		strVal(stNull, ""),
+	)
+	if len(out) != 0 {
+		t.Errorf("metadata_source = URL must defer when idp_url unknown, got %v", out)
+	}
+}
+
+func TestMetadata_URL_ErrorsWhenIdpURLNull(t *testing.T) {
+	out := runMetadataValidator(
+		strVal(stSet, metadataSourceURL),
+		strVal(stNull, ""),
+		strVal(stNull, ""),
+		strVal(stNull, ""),
+	)
+	if len(out) == 0 {
+		t.Error("metadata_source = URL must error when idp_url null")
+	}
+}
+
+// TestMetadata_FILE_DefersWhenFmfUnknown: FILE requires BOTH
+// federation_metadata_file AND metadata_file_name. To isolate the fmf defer,
+// metadata_file_name is held set and idp_url null.
+func TestMetadata_FILE_DefersWhenFmfUnknown(t *testing.T) {
+	out := runMetadataValidator(
+		strVal(stSet, metadataSourceFILE),
+		strVal(stNull, ""),
+		strVal(stUnknown, ""),
+		strVal(stSet, "idp.xml"),
+	)
+	if len(out) != 0 {
+		t.Errorf("metadata_source = FILE must defer when federation_metadata_file unknown, got %v", out)
+	}
+}
+
+func TestMetadata_FILE_ErrorsWhenFmfNull(t *testing.T) {
+	out := runMetadataValidator(
+		strVal(stSet, metadataSourceFILE),
+		strVal(stNull, ""),
+		strVal(stNull, ""),
+		strVal(stSet, "idp.xml"),
+	)
+	if len(out) == 0 {
+		t.Error("metadata_source = FILE must error when federation_metadata_file null")
+	}
+}
+
+// ===== idpProviderTypeOtherValidator ========================================
+
+var idpParentObjType = tftypes.Object{AttributeTypes: map[string]tftypes.Type{
+	"idp_provider_type":        tftypes.String,
+	"other_provider_type_name": tftypes.String,
+}}
+
+var idpRootObjType = tftypes.Object{AttributeTypes: map[string]tftypes.Type{
+	"saml_settings": idpParentObjType,
+}}
+
+func idpConfig(provider, other tftypes.Value) tfsdk.Config {
+	parentSchema := schema.SingleNestedAttribute{
+		Optional: true,
+		Attributes: map[string]schema.Attribute{
+			"idp_provider_type":        schema.StringAttribute{Optional: true},
+			"other_provider_type_name": schema.StringAttribute{Optional: true},
+		},
+	}
+	return tfsdk.Config{
+		Schema: schema.Schema{Attributes: map[string]schema.Attribute{
+			"saml_settings": parentSchema,
+		}},
+		Raw: tftypes.NewValue(idpRootObjType, map[string]tftypes.Value{
+			"saml_settings": tftypes.NewValue(idpParentObjType, map[string]tftypes.Value{
+				"idp_provider_type":        provider,
+				"other_provider_type_name": other,
+			}),
+		}),
+	}
+}
+
+func runIdpValidator(provider, other tftypes.Value) []string {
+	req := validator.StringRequest{
+		Path:        path.Root("saml_settings").AtName("idp_provider_type"),
+		ConfigValue: tftypesToTypesString(provider),
+		Config:      idpConfig(provider, other),
+	}
+	var resp validator.StringResponse
+	IdpProviderTypeOtherValidator().ValidateString(context.Background(), req, &resp)
+	return stringDiagSummaries(resp)
+}
+
+func TestIdpOther_DefersWhenNameUnknown(t *testing.T) {
+	out := runIdpValidator(strVal(stSet, "OTHER"), strVal(stUnknown, ""))
+	if len(out) != 0 {
+		t.Errorf("idp_provider_type = OTHER must defer when other_provider_type_name unknown, got %v", out)
+	}
+}
+
+func TestIdpOther_ErrorsWhenNameNull(t *testing.T) {
+	out := runIdpValidator(strVal(stSet, "OTHER"), strVal(stNull, ""))
+	if len(out) == 0 {
+		t.Error("idp_provider_type = OTHER must error when other_provider_type_name null")
+	}
+}
+
+func TestIdpOther_PassesWhenNameSet(t *testing.T) {
+	out := runIdpValidator(strVal(stSet, "OTHER"), strVal(stSet, "x"))
+	if len(out) != 0 {
+		t.Errorf("idp_provider_type = OTHER should pass when name set, got %v", out)
+	}
+}
+
+// ===== userAttributeEnabledValidator (Bool) =================================
+
+var uaParentObjType = tftypes.Object{AttributeTypes: map[string]tftypes.Type{
+	"user_attribute_enabled": tftypes.Bool,
+	"user_attribute_name":    tftypes.String,
+}}
+
+var uaRootObjType = tftypes.Object{AttributeTypes: map[string]tftypes.Type{
+	"saml_settings": uaParentObjType,
+}}
+
+func userAttrConfig(enabled, name tftypes.Value) tfsdk.Config {
+	parentSchema := schema.SingleNestedAttribute{
+		Optional: true,
+		Attributes: map[string]schema.Attribute{
+			"user_attribute_enabled": schema.BoolAttribute{Optional: true},
+			"user_attribute_name":    schema.StringAttribute{Optional: true},
+		},
+	}
+	return tfsdk.Config{
+		Schema: schema.Schema{Attributes: map[string]schema.Attribute{
+			"saml_settings": parentSchema,
+		}},
+		Raw: tftypes.NewValue(uaRootObjType, map[string]tftypes.Value{
+			"saml_settings": tftypes.NewValue(uaParentObjType, map[string]tftypes.Value{
+				"user_attribute_enabled": enabled,
+				"user_attribute_name":    name,
+			}),
+		}),
+	}
+}
+
+func tftypesToTypesBool(v tftypes.Value) types.Bool {
+	if !v.IsKnown() {
+		return types.BoolUnknown()
+	}
+	if v.IsNull() {
+		return types.BoolNull()
+	}
+	var b bool
+	_ = v.As(&b)
+	return types.BoolValue(b)
+}
+
+func runUserAttrValidator(enabled, name tftypes.Value) []string {
+	req := validator.BoolRequest{
+		Path:        path.Root("saml_settings").AtName("user_attribute_enabled"),
+		ConfigValue: tftypesToTypesBool(enabled),
+		Config:      userAttrConfig(enabled, name),
+	}
+	var resp validator.BoolResponse
+	UserAttributeEnabledValidator().ValidateBool(context.Background(), req, &resp)
+	return boolDiagSummaries(resp)
+}
+
+func TestUserAttr_DefersWhenNameUnknown(t *testing.T) {
+	out := runUserAttrValidator(boolVal(stSet, true), strVal(stUnknown, ""))
+	if len(out) != 0 {
+		t.Errorf("user_attribute_enabled = true must defer when name unknown, got %v", out)
+	}
+}
+
+func TestUserAttr_ErrorsWhenNameNull(t *testing.T) {
+	out := runUserAttrValidator(boolVal(stSet, true), strVal(stNull, ""))
+	if len(out) == 0 {
+		t.Error("user_attribute_enabled = true must error when name null")
+	}
+}
+
+func TestUserAttr_PassesWhenNameSet(t *testing.T) {
+	out := runUserAttrValidator(boolVal(stSet, true), strVal(stSet, "x"))
+	if len(out) != 0 {
+		t.Errorf("user_attribute_enabled = true should pass when name set, got %v", out)
+	}
+}
+
+// ===== groupEnrollmentAccessEnabledValidator (Bool) =========================
+//
+// Reads path.Root("sso_for_enrollment_enabled") and
+// path.Root("group_enrollment_access_name").
+
+var geRootObjType = tftypes.Object{AttributeTypes: map[string]tftypes.Type{
+	"group_enrollment_access_enabled": tftypes.Bool,
+	"sso_for_enrollment_enabled":      tftypes.Bool,
+	"group_enrollment_access_name":    tftypes.String,
+}}
+
+func groupEnrollConfig(enabled, ssoForEnroll, name tftypes.Value) tfsdk.Config {
+	return tfsdk.Config{
+		Schema: schema.Schema{Attributes: map[string]schema.Attribute{
+			"group_enrollment_access_enabled": schema.BoolAttribute{Optional: true},
+			"sso_for_enrollment_enabled":      schema.BoolAttribute{Optional: true},
+			"group_enrollment_access_name":    schema.StringAttribute{Optional: true},
+		}},
+		Raw: tftypes.NewValue(geRootObjType, map[string]tftypes.Value{
+			"group_enrollment_access_enabled": enabled,
+			"sso_for_enrollment_enabled":      ssoForEnroll,
+			"group_enrollment_access_name":    name,
+		}),
+	}
+}
+
+func runGroupEnrollValidator(enabled, ssoForEnroll, name tftypes.Value) []string {
+	req := validator.BoolRequest{
+		Path:        path.Root("group_enrollment_access_enabled"),
+		ConfigValue: tftypesToTypesBool(enabled),
+		Config:      groupEnrollConfig(enabled, ssoForEnroll, name),
+	}
+	var resp validator.BoolResponse
+	GroupEnrollmentAccessEnabledValidator().ValidateBool(context.Background(), req, &resp)
+	return boolDiagSummaries(resp)
+}
+
+func TestGroupEnroll_DefersWhenNameUnknown(t *testing.T) {
+	out := runGroupEnrollValidator(
+		boolVal(stSet, true),
+		boolVal(stSet, true),
+		strVal(stUnknown, ""),
+	)
+	if len(out) != 0 {
+		t.Errorf("group_enrollment_access_enabled must defer when name unknown, got %v", out)
+	}
+}
+
+func TestGroupEnroll_ErrorsWhenNameNull(t *testing.T) {
+	out := runGroupEnrollValidator(
+		boolVal(stSet, true),
+		boolVal(stSet, true),
+		strVal(stNull, ""),
+	)
+	if len(out) == 0 {
+		t.Error("group_enrollment_access_enabled must error when name null and sso_for_enrollment_enabled true")
+	}
+}
+
+// ===== signingCertificateSetupTypeValidator =================================
+//
+// Reads type, key, keystore_file, keystore_file_name, keystore_password,
+// password as siblings of setup_type under a parent object (signing_certificate).
+
+var scParentObjType = tftypes.Object{AttributeTypes: map[string]tftypes.Type{
+	"setup_type":         tftypes.String,
+	"type":               tftypes.String,
+	"key":                tftypes.String,
+	"keystore_file":      tftypes.String,
+	"keystore_file_name": tftypes.String,
+	"keystore_password":  tftypes.String,
+	"password":           tftypes.String,
+}}
+
+var scRootObjType = tftypes.Object{AttributeTypes: map[string]tftypes.Type{
+	"signing_certificate": scParentObjType,
+}}
+
+func signingConfig(setupType, typ, key, ksFile, ksFileName, ksPass, pass tftypes.Value) tfsdk.Config {
+	parentSchema := schema.SingleNestedAttribute{
+		Optional: true,
+		Attributes: map[string]schema.Attribute{
+			"setup_type":         schema.StringAttribute{Optional: true},
+			"type":               schema.StringAttribute{Optional: true},
+			"key":                schema.StringAttribute{Optional: true},
+			"keystore_file":      schema.StringAttribute{Optional: true},
+			"keystore_file_name": schema.StringAttribute{Optional: true},
+			"keystore_password":  schema.StringAttribute{Optional: true},
+			"password":           schema.StringAttribute{Optional: true},
+		},
+	}
+	return tfsdk.Config{
+		Schema: schema.Schema{Attributes: map[string]schema.Attribute{
+			"signing_certificate": parentSchema,
+		}},
+		Raw: tftypes.NewValue(scRootObjType, map[string]tftypes.Value{
+			"signing_certificate": tftypes.NewValue(scParentObjType, map[string]tftypes.Value{
+				"setup_type":         setupType,
+				"type":               typ,
+				"key":                key,
+				"keystore_file":      ksFile,
+				"keystore_file_name": ksFileName,
+				"keystore_password":  ksPass,
+				"password":           pass,
+			}),
+		}),
+	}
+}
+
+func runSigningValidator(setupType, typ, key, ksFile, ksFileName, ksPass, pass tftypes.Value) []string {
+	req := validator.StringRequest{
+		Path:        path.Root("signing_certificate").AtName("setup_type"),
+		ConfigValue: tftypesToTypesString(setupType),
+		Config:      signingConfig(setupType, typ, key, ksFile, ksFileName, ksPass, pass),
+	}
+	var resp validator.StringResponse
+	SigningCertificateSetupTypeValidator().ValidateString(context.Background(), req, &resp)
+	return stringDiagSummaries(resp)
+}
+
+// TestSigning_DefersWhenOneSiblingUnknown: setup_type = UPLOADED with `type`
+// UNKNOWN and all other five required siblings set must NOT error.
+func TestSigning_DefersWhenOneSiblingUnknown(t *testing.T) {
+	out := runSigningValidator(
+		strVal(stSet, setupTypeUploaded),
+		strVal(stUnknown, ""), // type
+		strVal(stSet, "k"),    // key
+		strVal(stSet, "f"),    // keystore_file
+		strVal(stSet, "n"),    // keystore_file_name
+		strVal(stSet, "p"),    // keystore_password
+		strVal(stSet, "pw"),   // password
+	)
+	if len(out) != 0 {
+		t.Errorf("setup_type = UPLOADED must defer when a required sibling is unknown, got %v", out)
+	}
+}
+
+func TestSigning_ErrorsWhenAllSiblingsNull(t *testing.T) {
+	out := runSigningValidator(
+		strVal(stSet, setupTypeUploaded),
+		strVal(stNull, ""),
+		strVal(stNull, ""),
+		strVal(stNull, ""),
+		strVal(stNull, ""),
+		strVal(stNull, ""),
+		strVal(stNull, ""),
+	)
+	if len(out) == 0 {
+		t.Error("setup_type = UPLOADED must error when required siblings null")
+	}
+}

--- a/internal/resources/pro/settings/user_initiated_enrollment_settings/validators.go
+++ b/internal/resources/pro/settings/user_initiated_enrollment_settings/validators.go
@@ -51,7 +51,14 @@ func (mdmSigningCertificateRequiredValidator) ValidateResource(ctx context.Conte
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	if !cert.IsNull() && !cert.IsUnknown() {
+	// Defer when the certificate block is unknown (e.g. driven by a variable,
+	// for_each, or another resource): config-time validation cannot see its
+	// eventual value, and erroring here would break every non-literal config.
+	// Only a genuinely-absent (null) block is an error.
+	if cert.IsUnknown() {
+		return
+	}
+	if !cert.IsNull() {
 		return
 	}
 	resp.Diagnostics.AddAttributeError(

--- a/internal/resources/pro/settings/user_initiated_enrollment_settings/validators_test.go
+++ b/internal/resources/pro/settings/user_initiated_enrollment_settings/validators_test.go
@@ -24,28 +24,30 @@ var certObjType = tftypes.Object{AttributeTypes: map[string]tftypes.Type{
 	"serial_number":                tftypes.String,
 }}
 
+// validatorCertSchema / validatorObjType are the schema + tftypes shapes the
+// mdm_signing_certificate ConfigValidator reads, shared across fixtures.
+var validatorCertSchema = schema.SingleNestedAttribute{
+	Optional: true,
+	Attributes: map[string]schema.Attribute{
+		"keystore_file":                schema.StringAttribute{Optional: true},
+		"keystore_file_name":           schema.StringAttribute{Optional: true, Computed: true},
+		"keystore_password":            schema.StringAttribute{Optional: true},
+		"keystore_password_wo_version": schema.Int64Attribute{Optional: true},
+		"subject":                      schema.StringAttribute{Computed: true},
+		"serial_number":                schema.StringAttribute{Computed: true},
+	},
+}
+
+var validatorObjType = tftypes.Object{AttributeTypes: map[string]tftypes.Type{
+	"signing_mdm_profile_enabled": tftypes.Bool,
+	"mdm_signing_certificate":     certObjType,
+}}
+
 // buildValidatorConfig synthesises a tfsdk.Config carrying
 // signing_mdm_profile_enabled and an (optionally present) mdm_signing_certificate
 // block, matching the attributes the ConfigValidator reads.
 func buildValidatorConfig(t *testing.T, enabled *bool, certPresent bool) tfsdk.Config {
 	t.Helper()
-
-	certSchema := schema.SingleNestedAttribute{
-		Optional: true,
-		Attributes: map[string]schema.Attribute{
-			"keystore_file":                schema.StringAttribute{Optional: true},
-			"keystore_file_name":           schema.StringAttribute{Optional: true, Computed: true},
-			"keystore_password":            schema.StringAttribute{Optional: true},
-			"keystore_password_wo_version": schema.Int64Attribute{Optional: true},
-			"subject":                      schema.StringAttribute{Computed: true},
-			"serial_number":                schema.StringAttribute{Computed: true},
-		},
-	}
-
-	objType := tftypes.Object{AttributeTypes: map[string]tftypes.Type{
-		"signing_mdm_profile_enabled": tftypes.Bool,
-		"mdm_signing_certificate":     certObjType,
-	}}
 
 	var enabledVal tftypes.Value
 	if enabled == nil {
@@ -66,12 +68,19 @@ func buildValidatorConfig(t *testing.T, enabled *bool, certPresent bool) tfsdk.C
 		})
 	}
 
+	return validatorConfigFrom(enabledVal, certVal)
+}
+
+// validatorConfigFrom assembles the tfsdk.Config from already-built tftypes
+// values, so callers can inject states the bool-driven helper can't express
+// (notably an unknown mdm_signing_certificate block).
+func validatorConfigFrom(enabledVal, certVal tftypes.Value) tfsdk.Config {
 	return tfsdk.Config{
 		Schema: schema.Schema{Attributes: map[string]schema.Attribute{
 			"signing_mdm_profile_enabled": schema.BoolAttribute{Optional: true},
-			"mdm_signing_certificate":     certSchema,
+			"mdm_signing_certificate":     validatorCertSchema,
 		}},
-		Raw: tftypes.NewValue(objType, map[string]tftypes.Value{
+		Raw: tftypes.NewValue(validatorObjType, map[string]tftypes.Value{
 			"signing_mdm_profile_enabled": enabledVal,
 			"mdm_signing_certificate":     certVal,
 		}),
@@ -127,5 +136,21 @@ func TestCertInvariant_SilentWhenUnset(t *testing.T) {
 	out := runCertValidator(t, buildValidatorConfig(t, nil, false))
 	if len(out) != 0 {
 		t.Errorf("validator should not fire when toggle unset, got %v", out)
+	}
+}
+
+// TestCertInvariant_SilentWhenCertUnknown is the defer-on-unknown regression
+// guard: with signing_mdm_profile_enabled = true (known) and the
+// mdm_signing_certificate block UNKNOWN (e.g. sourced from a variable), a
+// config-time validator must DEFER, not treat unknown as missing and error.
+// See STYLE_GUIDE "Config-time validators must defer on unknown values".
+func TestCertInvariant_SilentWhenCertUnknown(t *testing.T) {
+	cfg := validatorConfigFrom(
+		tftypes.NewValue(tftypes.Bool, true),
+		tftypes.NewValue(certObjType, tftypes.UnknownValue),
+	)
+	out := runCertValidator(t, cfg)
+	if len(out) != 0 {
+		t.Errorf("validator must defer (not fire) when cert block is unknown, got %v", out)
 	}
 }

--- a/internal/resources/pro/users/user_group/validators.go
+++ b/internal/resources/pro/users/user_group/validators.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/types"
 
 	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/common/helpers"
 )
@@ -37,25 +38,45 @@ func (v smartStaticConfigValidator) MarkdownDescription(ctx context.Context) str
 
 // ValidateResource implements the plan-time cross-field check.
 func (smartStaticConfigValidator) ValidateResource(ctx context.Context, req resource.ValidateConfigRequest, resp *resource.ValidateConfigResponse) {
-	var data UserGroupResourceModel
-	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+	// Read only the three attributes this cross-field check needs, via
+	// GetAttribute, so the validator is light to unit-test (no full-model
+	// fixture). Reading criteria/members as their typed collection values is
+	// also what lets the check tell "unknown" (variable/for_each-driven) apart
+	// from "empty"/"absent" — decoding into Go slices collapses unknown to len 0.
+	var groupType types.String
+	resp.Diagnostics.Append(req.Config.GetAttribute(ctx, path.Root("group_type"), &groupType)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	if data.GroupType.IsNull() || data.GroupType.IsUnknown() {
+	if groupType.IsNull() || groupType.IsUnknown() {
 		return
 	}
 
-	switch data.GroupType.ValueString() {
+	var criteria types.List
+	resp.Diagnostics.Append(req.Config.GetAttribute(ctx, path.Root("criteria"), &criteria)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	var members types.Set
+	resp.Diagnostics.Append(req.Config.GetAttribute(ctx, path.Root("members"), &members)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	switch groupType.ValueString() {
 	case "smart":
-		if len(data.Criteria) == 0 {
+		// Config-time validation cannot see an unknown value, so defer on
+		// unknown criteria — flagging it would false-error on every non-literal
+		// config. Only a known-empty list is the error.
+		if !criteria.IsUnknown() && len(criteria.Elements()) == 0 {
 			resp.Diagnostics.AddAttributeError(
 				path.Root("criteria"),
 				"Missing required criteria",
 				"Smart user groups require at least one criterion. Supply `criteria = [...]` or change `group_type` to `\"static\"`.",
 			)
 		}
-		if helpers.IsConfiguredValue(data.Members) {
+		if helpers.IsConfiguredValue(members) {
 			resp.Diagnostics.AddAttributeError(
 				path.Root("members"),
 				"members forbidden on smart user groups",
@@ -63,7 +84,8 @@ func (smartStaticConfigValidator) ValidateResource(ctx context.Context, req reso
 			)
 		}
 	case "static":
-		if len(data.Criteria) > 0 {
+		// Defer on unknown criteria; only a known, non-empty list is forbidden.
+		if !criteria.IsNull() && !criteria.IsUnknown() && len(criteria.Elements()) > 0 {
 			resp.Diagnostics.AddAttributeError(
 				path.Root("criteria"),
 				"criteria forbidden on static user groups",

--- a/internal/resources/pro/users/user_group/validators_test.go
+++ b/internal/resources/pro/users/user_group/validators_test.go
@@ -1,0 +1,170 @@
+// Copyright Jamf Software LLC 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package user_group
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+)
+
+var critObjType = tftypes.Object{AttributeTypes: map[string]tftypes.Type{
+	"priority":                tftypes.Number,
+	"name":                    tftypes.String,
+	"search_type":             tftypes.String,
+	"value":                   tftypes.String,
+	"and_or":                  tftypes.String,
+	"has_opening_parenthesis": tftypes.Bool,
+	"has_closing_parenthesis": tftypes.Bool,
+}}
+
+var (
+	criteriaListType = tftypes.List{ElementType: critObjType}
+	membersSetType   = tftypes.Set{ElementType: tftypes.String}
+)
+
+// criteriaMode selects the tftypes value for the criteria attribute.
+type criteriaMode int
+
+const (
+	critNull criteriaMode = iota
+	critUnknown
+	critEmpty
+	critOne
+)
+
+func criteriaValue(m criteriaMode) tftypes.Value {
+	switch m {
+	case critUnknown:
+		return tftypes.NewValue(criteriaListType, tftypes.UnknownValue)
+	case critEmpty:
+		return tftypes.NewValue(criteriaListType, []tftypes.Value{})
+	case critOne:
+		return tftypes.NewValue(criteriaListType, []tftypes.Value{
+			tftypes.NewValue(critObjType, map[string]tftypes.Value{
+				"priority":                tftypes.NewValue(tftypes.Number, 0),
+				"name":                    tftypes.NewValue(tftypes.String, "Username"),
+				"search_type":             tftypes.NewValue(tftypes.String, "is"),
+				"value":                   tftypes.NewValue(tftypes.String, "jappleseed"),
+				"and_or":                  tftypes.NewValue(tftypes.String, "and"),
+				"has_opening_parenthesis": tftypes.NewValue(tftypes.Bool, false),
+				"has_closing_parenthesis": tftypes.NewValue(tftypes.Bool, false),
+			}),
+		})
+	default:
+		return tftypes.NewValue(criteriaListType, nil)
+	}
+}
+
+// ugConfig builds a Config with only the three attributes the validator reads.
+func ugConfig(groupType *string, crit criteriaMode, membersSet bool) tfsdk.Config {
+	gtVal := tftypes.NewValue(tftypes.String, nil)
+	if groupType != nil {
+		gtVal = tftypes.NewValue(tftypes.String, *groupType)
+	}
+	membersVal := tftypes.NewValue(membersSetType, nil)
+	if membersSet {
+		membersVal = tftypes.NewValue(membersSetType, []tftypes.Value{
+			tftypes.NewValue(tftypes.String, "123"),
+		})
+	}
+
+	objType := tftypes.Object{AttributeTypes: map[string]tftypes.Type{
+		"group_type": tftypes.String,
+		"criteria":   criteriaListType,
+		"members":    membersSetType,
+	}}
+
+	critAttrs := map[string]schema.Attribute{
+		"priority":                schema.Int64Attribute{Optional: true, Computed: true},
+		"name":                    schema.StringAttribute{Required: true},
+		"search_type":             schema.StringAttribute{Required: true},
+		"value":                   schema.StringAttribute{Required: true},
+		"and_or":                  schema.StringAttribute{Optional: true, Computed: true},
+		"has_opening_parenthesis": schema.BoolAttribute{Optional: true, Computed: true},
+		"has_closing_parenthesis": schema.BoolAttribute{Optional: true, Computed: true},
+	}
+
+	return tfsdk.Config{
+		Schema: schema.Schema{Attributes: map[string]schema.Attribute{
+			"group_type": schema.StringAttribute{Optional: true},
+			"members":    schema.SetAttribute{Optional: true, ElementType: types.StringType},
+			"criteria": schema.ListNestedAttribute{
+				Optional:     true,
+				NestedObject: schema.NestedAttributeObject{Attributes: critAttrs},
+			},
+		}},
+		Raw: tftypes.NewValue(objType, map[string]tftypes.Value{
+			"group_type": gtVal,
+			"criteria":   criteriaValue(crit),
+			"members":    membersVal,
+		}),
+	}
+}
+
+func runSmartStaticValidator(cfg tfsdk.Config) []string {
+	var resp resource.ValidateConfigResponse
+	smartStaticConfigValidator{}.ValidateResource(
+		context.Background(),
+		resource.ValidateConfigRequest{Config: cfg},
+		&resp,
+	)
+	out := make([]string, 0, len(resp.Diagnostics))
+	for _, d := range resp.Diagnostics {
+		out = append(out, d.Summary())
+	}
+	return out
+}
+
+// TestSmartStatic_DefersWhenCriteriaUnknown is the defer-on-unknown regression
+// guard: smart group + unknown criteria (e.g. variable-driven) must DEFER, not
+// treat unknown as an empty/missing list and error. See STYLE_GUIDE
+// "Config-time validators must defer on unknown values".
+func TestSmartStatic_DefersWhenCriteriaUnknown(t *testing.T) {
+	if out := runSmartStaticValidator(ugConfig(new("smart"), critUnknown, false)); len(out) != 0 {
+		t.Errorf("smart + unknown criteria must defer, got %v", out)
+	}
+}
+
+// TestSmartStatic_ErrorsWhenSmartCriteriaEmpty proves the requirement still
+// fires for a known-empty/absent criteria on a smart group.
+func TestSmartStatic_ErrorsWhenSmartCriteriaEmpty(t *testing.T) {
+	if out := runSmartStaticValidator(ugConfig(new("smart"), critEmpty, false)); len(out) == 0 {
+		t.Error("expected error for smart group with empty criteria")
+	}
+	if out := runSmartStaticValidator(ugConfig(new("smart"), critNull, false)); len(out) == 0 {
+		t.Error("expected error for smart group with no criteria")
+	}
+}
+
+// TestSmartStatic_SmartWithCriteriaOK proves a smart group with criteria passes.
+func TestSmartStatic_SmartWithCriteriaOK(t *testing.T) {
+	if out := runSmartStaticValidator(ugConfig(new("smart"), critOne, false)); len(out) != 0 {
+		t.Errorf("smart + one criterion should pass, got %v", out)
+	}
+}
+
+// TestSmartStatic_StaticForbidsKnownCriteria proves a static group errors on a
+// known non-empty criteria but DEFERS on unknown criteria.
+func TestSmartStatic_StaticForbidsKnownCriteria(t *testing.T) {
+	if out := runSmartStaticValidator(ugConfig(new("static"), critOne, true)); len(out) == 0 {
+		t.Error("expected error for static group with criteria set")
+	}
+	if out := runSmartStaticValidator(ugConfig(new("static"), critUnknown, false)); len(out) != 0 {
+		t.Errorf("static + unknown criteria must defer, got %v", out)
+	}
+}
+
+// TestSmartStatic_DefersWhenGroupTypeUnknownOrUnset proves the validator defers
+// when the discriminator is not yet known.
+func TestSmartStatic_DefersWhenGroupTypeUnknownOrUnset(t *testing.T) {
+	if out := runSmartStaticValidator(ugConfig(nil, critNull, false)); len(out) != 0 {
+		t.Errorf("unset group_type must defer, got %v", out)
+	}
+}


### PR DESCRIPTION
## Summary

Provider-wide fix for a config-time validator bug: custom value-discriminated validators that treated an **unknown** dependent attribute (variable / `for_each` / `count` / cross-resource reference) as "missing" and false-errored at plan, making the resources unusable from reusable modules. Surfaced by deploymenttheory/terraform-provider-jamfpro #1111; audited across this entire provider.

**Rule:** a config-time validator must **defer** (return, no diagnostic) when a value it needs is unknown, and error only when it is genuinely null. Forbidden-when checks are unaffected (they fire on *presence*). This changes behaviour **only for unknown values** — known-value validation is byte-identical.

## Hardened validators

| Resource | Attribute(s) |
|---|---|
| `user_initiated_enrollment_settings` | `mdm_signing_certificate` |
| `inventory/printer` | `ppd_path` |
| `inventory/disk_encryption_configuration` | `institutional_recovery_key` |
| `users/user_group` | `criteria` |
| `enrollment/enrollment_customization` | `access_group_name` |
| `policies/policy` | `deferral_until_utc` / `deferral_days` (+ unknown-vs-null discriminator split) |
| `settings/sso_settings` | `configuration_type` block, `entity_id`, `group_attribute_name`, `metadata_source` companions, `idp_provider_type=OTHER`, `user_attribute_name`, `group_enrollment_access_name`, `signing_certificate` UPLOADED |
| `enrollment/computer_prestage_enrollment` | `enable_recovery_lock`, prefill `CUSTOM` companions |

Several were refactored to read dependent attributes as their typed value via `GetAttribute`, so unknown is distinguishable from absent (decoding into Go types collapses unknown to a `nil` pointer / `len 0`).

## Tests

Unit tests added/extended feeding `tftypes.UnknownValue` — the case **acceptance tests cannot reach** (literal HCL is always known), which is why this slipped through. Every fixed resource is covered except `printer` (heavy custom-type fixture; its one-line fix mirrors the tested pattern). Regression guards were confirmed to fail without the fix.

## Prevention

`STYLE_GUIDE.md` now documents the rule under **"Config-time validators MUST defer on unknown values"**, with the typed-value-vs-Go-decode gotcha and the "test with unknowns, not literals" requirement.

## Verified clean (no change)

`scope.allFlagConflictsWith`, `ibeacon`, `sso_settings.ssoBypassAllowed`, `directory_binding`, `printer.noLiteralSentinel`, `network_segment.ipv4`, `enrollment_customization.uniqueDisplayName`; all Platform Services (non-`pro`) resources use off-the-shelf framework validators (unknown-safe by design).

`make fix fmt lint test` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)