### PR TITLE
fix(pro): mobile_device_app preferences/os_type/echo follow-ups + plisthelpers extraction

### DIFF
--- a/docs/data-sources/pro_mobile_device_app.md
+++ b/docs/data-sources/pro_mobile_device_app.md
@@ -43,7 +43,6 @@ data "jamfplatform_pro_mobile_device_app" "by_id" {
 - `category_id` (String) Category ID.
 - `category_name` (String) Category display name.
 - `deployment_type` (String) Install method.
-- `internal_app` (Boolean) Whether Jamf Pro treats the app as in-house.
 - `is_free` (Boolean) Whether the app is free.
 - `os_type` (String) Operating system the app targets (`iOS` or `tvOS`). Populated for in-house apps once set; null otherwise.
 - `site_id` (String) Site ID. `-1` means no site.

--- a/docs/resources/pro_mobile_device_app.md
+++ b/docs/resources/pro_mobile_device_app.md
@@ -98,7 +98,7 @@ resource "jamfplatform_pro_mobile_device_app" "automatic" {
 
 ### Required
 
-- `general` (Attributes) General settings. `name`, `version`, and `bundle_id` are required; `os_type` is required only for in-house apps. Read-only fields (`description`, `internal_app`, `category_name`, `site_name`, `id`) are returned by Jamf Pro. The app's display name always equals `name`, so it is not modeled separately. (see [below for nested schema](#nestedatt--general))
+- `general` (Attributes) General settings. `name`, `version`, and `bundle_id` are required; `os_type` is required only for in-house apps. Read-only fields (`description`, `category_name`, `site_name`, `id`) are returned by Jamf Pro. The app's display name always equals `name`, so it is not modeled separately. (see [below for nested schema](#nestedatt--general))
 
 ### Optional
 
@@ -149,7 +149,6 @@ Read-Only:
 - `category_name` (String) Category display name. Returned by Jamf Pro; not user-settable.
 - `description` (String) App description. App-Store-synced when `keep_description_and_icon_up_to_date = true`; not user-settable.
 - `id` (String) App ID under `general`. Matches the top-level `id`. Returned by Jamf Pro.
-- `internal_app` (Boolean) Whether Jamf Pro treats the app as in-house. Server-managed — it flips to false only as a side-effect of a coherent external-hosting combination (`is_free = true` + `host_externally = true` + `external_url`), not by direct assignment.
 - `site_name` (String) Site display name. Returned by Jamf Pro; not user-settable.
 
 

--- a/docs/resources/pro_mobile_device_app.md
+++ b/docs/resources/pro_mobile_device_app.md
@@ -3,15 +3,15 @@
 page_title: "jamfplatform_pro_mobile_device_app Resource - terraform-provider-jamfplatform"
 subcategory: ""
 description: |-
-  Manages a Jamf Pro mobile device app (the classic /mobiledeviceapplications endpoint — the "App Store App" / in-house app entries under the "Mobile Device Apps" sidebar). The resource models the app's metadata; there is no IPA binary-upload endpoint, so in-house binary upload is not modeled. general.name, general.version, general.bundle_id, and general.os_type are required. os_type is sent on every write because the server demands it on a PUT to an in-house app. Scope targets are flat sets of Jamf Pro IDs; interpolate jamfplatform_device_group.<x>.jamf_pro_id to bridge from Platform Services. Scope omits iBeacon limitations/exclusions because the endpoint drops them.
-  Update is a partial-merge: the provider sends the full plan payload on every update, so in-place edits converge cleanly, but removing an entire optional block (scope / self_service / vpp / app_configuration) from config retains the previously-stored block server-side. To clear a block, null its individual fields rather than deleting the block.
+  Manages a Jamf Pro mobile device app — the "App Store App" / in-house app entries under the "Mobile Device Apps" sidebar. The resource models the app's metadata; uploading an in-house binary (IPA) is not supported. general.name, general.version, and general.bundle_id are required. general.os_type is required only for in-house apps; App Store apps (with an itunes_store_url) do not need it. Scope targets are flat sets of Jamf Pro IDs; interpolate jamfplatform_device_group.<x>.jamf_pro_id to bridge from Platform Services. iBeacon scope limitations/exclusions are not supported for mobile device apps.
+  Updates are merged, not replaced: removing an entire optional block (scope / self_service / vpp / app_configuration) from config does not clear it — the previously-set values are retained. To clear a block, null its individual fields rather than deleting the block.
 ---
 
 # jamfplatform_pro_mobile_device_app (Resource)
 
-Manages a Jamf Pro mobile device app (the classic `/mobiledeviceapplications` endpoint — the "App Store App" / in-house app entries under the "Mobile Device Apps" sidebar). The resource models the app's **metadata**; there is no IPA binary-upload endpoint, so in-house binary upload is not modeled. `general.name`, `general.version`, `general.bundle_id`, and `general.os_type` are required. `os_type` is sent on every write because the server demands it on a PUT to an in-house app. Scope targets are flat sets of Jamf Pro IDs; interpolate `jamfplatform_device_group.<x>.jamf_pro_id` to bridge from Platform Services. Scope omits iBeacon limitations/exclusions because the endpoint drops them.
+Manages a Jamf Pro mobile device app — the "App Store App" / in-house app entries under the "Mobile Device Apps" sidebar. The resource models the app's **metadata**; uploading an in-house binary (IPA) is not supported. `general.name`, `general.version`, and `general.bundle_id` are required. `general.os_type` is required only for in-house apps; App Store apps (with an `itunes_store_url`) do not need it. Scope targets are flat sets of Jamf Pro IDs; interpolate `jamfplatform_device_group.<x>.jamf_pro_id` to bridge from Platform Services. iBeacon scope limitations/exclusions are not supported for mobile device apps.
 
-**Update is a partial-merge**: the provider sends the full plan payload on every update, so in-place edits converge cleanly, but removing an entire optional block (`scope` / `self_service` / `vpp` / `app_configuration`) from config retains the previously-stored block server-side. To clear a block, null its individual fields rather than deleting the block.
+**Updates are merged, not replaced**: removing an entire optional block (`scope` / `self_service` / `vpp` / `app_configuration`) from config does not clear it — the previously-set values are retained. To clear a block, null its individual fields rather than deleting the block.
 
 ## Example Usage
 
@@ -98,15 +98,15 @@ resource "jamfplatform_pro_mobile_device_app" "automatic" {
 
 ### Required
 
-- `general` (Attributes) General settings. `name`, `version`, `bundle_id`, and `os_type` are required. Read-only fields (`description`, `internal_app`, `category_name`, `site_name`, `id`) are returned by Jamf Pro. The app's display name is always equal to `name` (the server forces it), so it is not modeled separately. (see [below for nested schema](#nestedatt--general))
+- `general` (Attributes) General settings. `name`, `version`, and `bundle_id` are required; `os_type` is required only for in-house apps. Read-only fields (`description`, `internal_app`, `category_name`, `site_name`, `id`) are returned by Jamf Pro. The app's display name always equals `name`, so it is not modeled separately. (see [below for nested schema](#nestedatt--general))
 
 ### Optional
 
 - `app_configuration` (Attributes) Managed-app configuration. `preferences` carries the app-configuration plist; CRLF and LF newlines are treated as equivalent so an import or admin-UI edit does not permadiff against an LF-authored config. (see [below for nested schema](#nestedatt--app_configuration))
-- `scope` (Attributes) App scope. Targets are flat sets of Jamf Pro IDs; interpolate `jamfplatform_device_group.<x>.jamf_pro_id` to bridge from Platform Services. Setting `all_mobile_devices = true` forbids `mobile_device_ids`, `mobile_device_group_ids`, `building_ids`, `department_ids`. Setting `all_jss_users = true` forbids `user_ids` and `user_group_ids`. iBeacon limitations/exclusions are intentionally absent — the endpoint drops them. (see [below for nested schema](#nestedatt--scope))
+- `scope` (Attributes) App scope. Targets are flat sets of Jamf Pro IDs; interpolate `jamfplatform_device_group.<x>.jamf_pro_id` to bridge from Platform Services. Setting `all_mobile_devices = true` forbids `mobile_device_ids`, `mobile_device_group_ids`, `building_ids`, `department_ids`. Setting `all_jss_users = true` forbids `user_ids` and `user_group_ids`. iBeacon limitations/exclusions are not supported for mobile device apps. (see [below for nested schema](#nestedatt--scope))
 - `self_service` (Attributes) Self Service integration. Relevant when `general.deployment_type` is `Make Available in Self Service`. (see [below for nested schema](#nestedatt--self_service))
 - `timeouts` (Attributes) (see [below for nested schema](#nestedatt--timeouts))
-- `vpp` (Attributes) Volume Purchasing (VPP) assignment. `assign_vpp_device_based_licenses` and `vpp_admin_account_id` are writable only for a genuinely VPP-backed title — setting `assign_vpp_device_based_licenses = true` on a non-VPP app returns HTTP 409 "App is not available for device assignment". (see [below for nested schema](#nestedatt--vpp))
+- `vpp` (Attributes) Volume Purchasing (VPP) assignment. `assign_vpp_device_based_licenses` and `vpp_admin_account_id` are writable only for a genuinely VPP-backed title; setting `assign_vpp_device_based_licenses = true` on an app that is not VPP-backed is rejected. (see [below for nested schema](#nestedatt--vpp))
 
 ### Read-Only
 
@@ -118,9 +118,8 @@ resource "jamfplatform_pro_mobile_device_app" "automatic" {
 Required:
 
 - `bundle_id` (String) App bundle identifier (e.g. `com.apple.Maps`). Required on create.
-- `name` (String) App display name. Must be unique within the tenant. The server forces the app's `display_name` to equal this value.
-- `os_type` (String) Operating system the app targets. One of `iOS` or `tvOS`. The server requires this on every write to an in-house app (the common case), so the provider always sends it; it is echoed back on read once set.
-- `version` (String) App version string. Required by the server on create.
+- `name` (String) App display name. Must be unique within the tenant; also used as the app's display name in Self Service.
+- `version` (String) App version string.
 
 Optional:
 
@@ -128,7 +127,7 @@ Optional:
 - `category_id` (String) Jamf Pro category ID. Use `-1` for "No category".
 - `deploy_as_managed_app` (Boolean) Deploy as a managed app (enables managed-app capabilities such as app configuration).
 - `deploy_automatically` (Boolean) Automatically push the app to in-scope devices.
-- `deployment_type` (String) Install method. One of `Make Available in Self Service` or `Install Automatically/Prompt Users to Install`. Server-defaults to `Make Available in Self Service`.
+- `deployment_type` (String) Install method. One of `Make Available in Self Service` or `Install Automatically/Prompt Users to Install`. Defaults to `Make Available in Self Service`.
 - `external_url` (String) External / in-house hosting URL. Independent of the App Store URL; setting it flips `host_externally` to true server-side.
 - `host_externally` (Boolean) Host the app externally (in-house hosting). Flips to true automatically when an `external_url` or App Store URL is set.
 - `is_free` (Boolean) Whether the app is free.
@@ -138,6 +137,7 @@ Optional:
 - `keep_app_updated_on_devices` (Boolean) Automatically update the app on managed devices when a new version ships.
 - `keep_description_and_icon_up_to_date` (Boolean) Keep the app description and icon in sync with the App Store listing.
 - `make_available_after_install` (Boolean) Make the app available in Self Service after it is installed automatically.
+- `os_type` (String) Operating system the app targets. One of `iOS` or `tvOS`. Required for in-house apps; App Store apps (those with an `itunes_store_url`) do not need it.
 - `prevent_backup_of_app_data` (Boolean) Prevent the app's data from being backed up to iCloud / iTunes.
 - `remove_app_when_mdm_profile_is_removed` (Boolean) Remove the app from a device when its MDM profile is removed.
 - `require_network_tethered` (Boolean) Require a network-tethered connection to install. Relevant for automatically-deployed apps.
@@ -158,7 +158,7 @@ Read-Only:
 
 Optional:
 
-- `preferences` (String) App-configuration plist content. Round-trips verbatim; newline style (CRLF vs LF) is normalised when comparing.
+- `preferences` (String) App-configuration property list content. Whitespace, indentation, and newline-style differences are ignored when comparing, so reformatting the same configuration does not show as a change.
 
 
 <a id="nestedatt--scope"></a>

--- a/internal/common/plisthelpers/plisthelpers.go
+++ b/internal/common/plisthelpers/plisthelpers.go
@@ -1,0 +1,134 @@
+// Copyright Jamf Software LLC 2026
+// SPDX-License-Identifier: MPL-2.0
+
+// Package plisthelpers provides generic, resource-agnostic plist (Apple
+// Property List) primitives: parse, marshal, canonicalise, and structural
+// equality. It carries no mobileconfig- or resource-specific knowledge — the
+// configuration-profile masking / lenient-compare logic that layers on top of
+// these primitives lives in the payloadhelpers package, which imports this one.
+package plisthelpers
+
+import (
+	"bytes"
+	"fmt"
+
+	"howett.net/plist"
+)
+
+// ParsePlist decodes a plist (XML or binary) into a Go map. The returned int is
+// howett.net/plist's format identifier (plist.XMLFormat, plist.BinaryFormat,
+// etc.) — typed as int because the library exposes formats as untyped int
+// constants. A bare `<dict>…</dict>` fragment (no <plist> wrapper) parses fine.
+func ParsePlist(raw []byte) (map[string]any, int, error) {
+	var out map[string]any
+	format, err := plist.Unmarshal(raw, &out)
+	if err != nil {
+		return nil, 0, fmt.Errorf("parsing plist: %w", err)
+	}
+	return out, format, nil
+}
+
+// MarshalPlist serialises a plist dict back to tab-indented XML form.
+func MarshalPlist(m map[string]any) ([]byte, error) {
+	buf := &bytes.Buffer{}
+	enc := plist.NewEncoderForFormat(buf, plist.XMLFormat)
+	enc.Indent("\t")
+	if err := enc.Encode(m); err != nil {
+		return nil, fmt.Errorf("encoding plist: %w", err)
+	}
+	return buf.Bytes(), nil
+}
+
+// CanonicalisePlistXML parses a plist and re-emits it as tab-indented XML so two
+// documents that differ only in formatting (whitespace, indentation, line
+// endings, trailing newline) render identically. Falls back to returning the
+// input unchanged when it fails to parse — the caller still has a usable string.
+func CanonicalisePlistXML(raw []byte) []byte {
+	parsed, _, err := ParsePlist(raw)
+	if err != nil {
+		return raw
+	}
+	out, err := MarshalPlist(parsed)
+	if err != nil {
+		return raw
+	}
+	return out
+}
+
+// Equal is a structural-equality compare for parsed plist trees: dicts require
+// matching keysets, arrays compare positionally, and the int64/uint64/int trio
+// howett.net/plist emits compares numerically. Use this when every key is
+// author-controlled and there are no server-injected keys to tolerate (the
+// common case for opaque user-authored plist content). For mobileconfig
+// payloads — where Jamf Pro injects/defaults keys — use the intersection-aware
+// comparator in payloadhelpers instead.
+func Equal(a, b any) bool {
+	if a == nil || b == nil {
+		return a == nil && b == nil
+	}
+	switch av := a.(type) {
+	case map[string]any:
+		bv, ok := b.(map[string]any)
+		if !ok || len(av) != len(bv) {
+			return false
+		}
+		for k, va := range av {
+			vb, exists := bv[k]
+			if !exists || !Equal(va, vb) {
+				return false
+			}
+		}
+		return true
+	case []any:
+		bv, ok := b.([]any)
+		if !ok || len(av) != len(bv) {
+			return false
+		}
+		for i := range av {
+			if !Equal(av[i], bv[i]) {
+				return false
+			}
+		}
+		return true
+	case uint64:
+		return NumericEqual(int64(av), b)
+	case int64:
+		return NumericEqual(av, b)
+	case int:
+		return NumericEqual(int64(av), b)
+	default:
+		return a == b
+	}
+}
+
+// NumericEqual reports whether int64 a equals b across the int64/uint64/int
+// representations howett.net/plist may emit for the same plist <integer>.
+func NumericEqual(a int64, b any) bool {
+	switch bv := b.(type) {
+	case uint64:
+		return a >= 0 && uint64(a) == bv
+	case int64:
+		return a == bv
+	case int:
+		return a == int64(bv)
+	default:
+		return false
+	}
+}
+
+// SemanticallyEqual reports whether two plist documents are structurally equal
+// once parsed — erasing all formatting differences (whitespace, indentation,
+// line endings, trailing newline, dict key order). The bool ok is false when
+// either input fails to parse as a plist, signalling the caller to fall back to
+// a byte/string comparison for non-plist content.
+func SemanticallyEqual(a, b []byte) (equal bool, ok bool) {
+	pa, _, err := ParsePlist(a)
+	if err != nil {
+		return false, false
+	}
+	pb, _, err := ParsePlist(b)
+	if err != nil {
+		return false, false
+	}
+	return Equal(pa, pb), true
+}

--- a/internal/common/plisthelpers/plisthelpers_test.go
+++ b/internal/common/plisthelpers/plisthelpers_test.go
@@ -1,0 +1,126 @@
+// Copyright Jamf Software LLC 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package plisthelpers
+
+import "testing"
+
+const minimalPlist = `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0"><dict>
+<key>PayloadType</key><string>Configuration</string>
+<key>PayloadVersion</key><integer>1</integer>
+<key>PayloadContent</key><array/>
+</dict></plist>`
+
+func TestParsePlist_BasicRoundTrip(t *testing.T) {
+	m, _, err := ParsePlist([]byte(minimalPlist))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if m["PayloadType"] != "Configuration" {
+		t.Fatalf("PayloadType: got %v", m["PayloadType"])
+	}
+}
+
+func TestParsePlist_InvalidInput(t *testing.T) {
+	if _, _, err := ParsePlist([]byte("not a plist")); err == nil {
+		t.Fatal("expected error on invalid input")
+	}
+}
+
+func TestParsePlist_BareDictFragment(t *testing.T) {
+	// Managed-app-config preferences arrive as a bare <dict> with no <plist>
+	// wrapper — must parse.
+	m, _, err := ParsePlist([]byte("<dict>\n  <key>ServerURL</key>\n  <string>https://example.com</string>\n</dict>\n"))
+	if err != nil {
+		t.Fatalf("parse bare dict: %v", err)
+	}
+	if m["ServerURL"] != "https://example.com" {
+		t.Fatalf("ServerURL: got %v", m["ServerURL"])
+	}
+}
+
+func TestMarshalPlist_RoundTrip(t *testing.T) {
+	parsed, _, err := ParsePlist([]byte(minimalPlist))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	out, err := MarshalPlist(parsed)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	reparsed, _, err := ParsePlist(out)
+	if err != nil {
+		t.Fatalf("reparse: %v", err)
+	}
+	if reparsed["PayloadType"] != parsed["PayloadType"] {
+		t.Errorf("PayloadType: got=%v want=%v", reparsed["PayloadType"], parsed["PayloadType"])
+	}
+}
+
+func TestCanonicalisePlistXML_UnparseableReturnedUnchanged(t *testing.T) {
+	in := []byte("not a plist")
+	if got := CanonicalisePlistXML(in); string(got) != string(in) {
+		t.Fatalf("expected unparseable input returned unchanged, got %q", got)
+	}
+}
+
+func TestEqual(t *testing.T) {
+	cases := []struct {
+		name string
+		a, b any
+		want bool
+	}{
+		{"equal maps", map[string]any{"k": "v"}, map[string]any{"k": "v"}, true},
+		{"asymmetric keyset", map[string]any{"k": "v", "x": 1}, map[string]any{"k": "v"}, false},
+		{"value mismatch", map[string]any{"k": "v"}, map[string]any{"k": "w"}, false},
+		{"arrays positional", []any{"a", "b"}, []any{"a", "b"}, true},
+		{"array length mismatch", []any{"a"}, []any{"a", "b"}, false},
+		{"int trio uint64/int64", uint64(5), int64(5), true},
+		{"nil both", nil, nil, true},
+		{"nil one side", nil, "x", false},
+	}
+	for _, tc := range cases {
+		if got := Equal(tc.a, tc.b); got != tc.want {
+			t.Errorf("%s: Equal=%v want %v", tc.name, got, tc.want)
+		}
+	}
+}
+
+func TestNumericEqual(t *testing.T) {
+	if !NumericEqual(5, uint64(5)) || !NumericEqual(5, int64(5)) || !NumericEqual(5, 5) {
+		t.Error("5 should equal its uint64/int64/int forms")
+	}
+	if NumericEqual(-1, uint64(1)) {
+		t.Error("negative int64 must not equal a uint64")
+	}
+	if NumericEqual(5, "5") {
+		t.Error("numeric must not equal a string")
+	}
+}
+
+func TestSemanticallyEqual(t *testing.T) {
+	// Same dict, different formatting (indent, key order, trailing newline).
+	a := "<dict>\n\t<key>A</key><string>1</string>\n\t<key>B</key><integer>2</integer>\n</dict>\n"
+	b := "<dict><key>B</key><integer>2</integer><key>A</key><string>1</string></dict>"
+	eq, ok := SemanticallyEqual([]byte(a), []byte(b))
+	if !ok {
+		t.Fatal("both should parse as plist")
+	}
+	if !eq {
+		t.Error("same dict modulo formatting/key-order should be equal")
+	}
+
+	// Real value change.
+	c := "<dict><key>A</key><string>2</string></dict>"
+	d := "<dict><key>A</key><string>3</string></dict>"
+	if eq, _ := SemanticallyEqual([]byte(c), []byte(d)); eq {
+		t.Error("different values must not be equal")
+	}
+
+	// Non-plist → ok=false (caller falls back).
+	if _, ok := SemanticallyEqual([]byte("plain text"), []byte("plain text")); ok {
+		t.Error("non-plist input should report ok=false")
+	}
+}

--- a/internal/resources/pro/apps/mobile_device_app/data_source.go
+++ b/internal/resources/pro/apps/mobile_device_app/data_source.go
@@ -63,7 +63,6 @@ func (d *MobileAppDataSource) Schema(ctx context.Context, req datasource.SchemaR
 			// server echoes it on GET after a PUT); null for never-set or
 			// externally-hosted apps.
 			"os_type":         schema.StringAttribute{MarkdownDescription: "Operating system the app targets (`iOS` or `tvOS`). Populated for in-house apps once set; null otherwise.", Computed: true},
-			"internal_app":    schema.BoolAttribute{MarkdownDescription: "Whether Jamf Pro treats the app as in-house.", Computed: true},
 			"is_free":         schema.BoolAttribute{MarkdownDescription: "Whether the app is free.", Computed: true},
 			"deployment_type": schema.StringAttribute{MarkdownDescription: "Install method.", Computed: true},
 			"category_id":     schema.StringAttribute{MarkdownDescription: "Category ID.", Computed: true},
@@ -156,7 +155,6 @@ func assignMobileAppFlatDataSource(state *MobileAppDataSourceModel, a *proclassi
 		state.Version = helpers.StringPointerValueOrNull(a.General.Version)
 		state.BundleID = helpers.StringPointerValueOrNull(a.General.BundleID)
 		state.OsType = helpers.StringPointerValueOrNull(a.General.OsType)
-		state.InternalApp = helpers.BoolPointerValueOrNull(a.General.InternalApp)
 		state.IsFree = helpers.BoolPointerValueOrNull(a.General.Free)
 		state.DeploymentType = helpers.StringPointerValueOrNull(a.General.DeploymentType)
 		if a.General.Category != nil {

--- a/internal/resources/pro/apps/mobile_device_app/helpers.go
+++ b/internal/resources/pro/apps/mobile_device_app/helpers.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
 	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/common/helpers"
+	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/common/plisthelpers"
 )
 
 // deploymentTypeSelfService and deploymentTypeAutomatic are the two wire values
@@ -165,4 +166,38 @@ func buildMobileNotification(enabled types.Bool) *proclassic.NotificationValue {
 // does not permadiff against an LF-authored config.
 func normalizeNewlines(s string) string {
 	return strings.ReplaceAll(strings.ReplaceAll(s, "\r\n", "\n"), "\r", "\n")
+}
+
+// preferencesEqual reports whether two app_configuration.preferences values are
+// semantically equal. preferences is an Apple property list; the primary
+// comparison parses both as plist and compares the decoded structures
+// (plisthelpers.SemanticallyEqual), which erases every formatting difference —
+// whitespace, indentation, line endings, the server's stripped trailing newline,
+// and dict key order — generically, rather than guessing at the specific
+// normalisations the server applies. Falls back to a string normalise
+// (CRLF→LF + trailing-newline trim) when either side is not valid plist.
+func preferencesEqual(a, b string) bool {
+	if eq, ok := plisthelpers.SemanticallyEqual([]byte(a), []byte(b)); ok {
+		return eq
+	}
+	return normalizePreferences(a) == normalizePreferences(b)
+}
+
+// normalizePreferences is the string-level fallback normaliser for
+// preferencesEqual when the content is not valid plist: CRLF→LF plus a
+// trailing-newline trim (the server strips the trailing newline on round-trip).
+func normalizePreferences(s string) string {
+	return strings.TrimRight(normalizeNewlines(s), "\n")
+}
+
+// preservePreferences keeps the caller's configured preferences when the server
+// value is semantically equal (see preferencesEqual). This makes apply
+// consistent on create/update (the flattened value stays equal to the planned
+// config) while still surfacing a genuine server-side content change as drift.
+func preservePreferences(api *string, current types.String) types.String {
+	if api != nil && helpers.IsConfiguredValue(current) &&
+		preferencesEqual(*api, current.ValueString()) {
+		return current
+	}
+	return helpers.StringPointerValueOrNull(api)
 }

--- a/internal/resources/pro/apps/mobile_device_app/helpers.go
+++ b/internal/resources/pro/apps/mobile_device_app/helpers.go
@@ -132,6 +132,13 @@ func serverWhenPresentString(api *string, current types.String) types.String {
 	if api != nil {
 		return types.StringValue(*api)
 	}
+	// Server omitted it. Keep the caller's value only if it is known (a
+	// configured value, or a prior-state null); never propagate an unknown
+	// (Optional+Computed unset on create), which would leave an unknown value
+	// after apply. Resolve unknown to null.
+	if current.IsUnknown() {
+		return types.StringNull()
+	}
 	return current
 }
 

--- a/internal/resources/pro/apps/mobile_device_app/input_builders_test.go
+++ b/internal/resources/pro/apps/mobile_device_app/input_builders_test.go
@@ -206,3 +206,26 @@ func TestNormalizeNewlines(t *testing.T) {
 		t.Errorf("normalizeNewlines = %q", got)
 	}
 }
+
+func TestPreferencesEqual(t *testing.T) {
+	const lf = "<dict>\n  <key>ServerURL</key>\n  <string>https://example.com</string>\n</dict>"
+	cases := []struct {
+		name string
+		a, b string
+		want bool
+	}{
+		// Plist semantic equality (the primary path):
+		{"trailing newline (server strips it)", lf, lf + "\n", true},
+		{"CRLF vs LF", lf, "<dict>\r\n  <key>ServerURL</key>\r\n  <string>https://example.com</string>\r\n</dict>", true},
+		{"reindented + key order", lf, "<dict><key>ServerURL</key><string>https://example.com</string></dict>", true},
+		{"real value change", lf, "<dict><key>ServerURL</key><string>https://other.com</string></dict>", false},
+		// Non-plist content → string-normalise fallback:
+		{"non-plist trailing newline equal", "plain config", "plain config\n", true},
+		{"non-plist real diff", "plain config", "other config", false},
+	}
+	for _, tc := range cases {
+		if got := preferencesEqual(tc.a, tc.b); got != tc.want {
+			t.Errorf("%s: preferencesEqual=%v want %v", tc.name, got, tc.want)
+		}
+	}
+}

--- a/internal/resources/pro/apps/mobile_device_app/input_builders_test.go
+++ b/internal/resources/pro/apps/mobile_device_app/input_builders_test.go
@@ -201,6 +201,27 @@ func TestBuildMobileAppAppConfiguration(t *testing.T) {
 	}
 }
 
+func TestServerWhenPresentString(t *testing.T) {
+	v := "tvOS"
+	// Server present → server value wins.
+	if got := serverWhenPresentString(&v, types.StringValue("iOS")); got.ValueString() != "tvOS" {
+		t.Errorf("server present: got %q want tvOS", got.ValueString())
+	}
+	// Server absent + known configured current → keep current.
+	if got := serverWhenPresentString(nil, types.StringValue("iOS")); got.ValueString() != "iOS" {
+		t.Errorf("server absent, known current: got %q want iOS", got.ValueString())
+	}
+	// Server absent + known null current → null.
+	if got := serverWhenPresentString(nil, types.StringNull()); !got.IsNull() {
+		t.Errorf("server absent, null current: got %q want null", got.ValueString())
+	}
+	// Server absent + UNKNOWN current (Optional+Computed unset on create) → null,
+	// never unknown (else "unknown value after apply").
+	if got := serverWhenPresentString(nil, types.StringUnknown()); got.IsUnknown() || !got.IsNull() {
+		t.Errorf("server absent, unknown current: got unknown=%v null=%v want null", got.IsUnknown(), got.IsNull())
+	}
+}
+
 func TestNormalizeNewlines(t *testing.T) {
 	if got := normalizeNewlines("a\r\nb\rc\nd"); got != "a\nb\nc\nd" {
 		t.Errorf("normalizeNewlines = %q", got)

--- a/internal/resources/pro/apps/mobile_device_app/model_types.go
+++ b/internal/resources/pro/apps/mobile_device_app/model_types.go
@@ -28,11 +28,11 @@ type MobileAppResourceModel struct {
 }
 
 // MobileAppGeneralModel models <mobile_device_application><general>. name,
-// version, bundle_id, and os_type are required on create; the server 409s on a
-// PUT to an in-house app without os_type, so the provider sends it on every
-// write. description / internal_app are server-managed and surfaced read-only.
-// The app's display name (server-forced == name) and url (a deprecated mirror of
-// itunes_store_url) are not modeled.
+// version, and bundle_id are required on create; os_type is optional (only
+// in-house apps need it — the server 409s on a write to an in-house app without
+// it; App Store apps do not). description / internal_app are server-managed and
+// surfaced read-only. The app's display name (server-forced == name) and url (a
+// deprecated mirror of itunes_store_url) are not modeled.
 type MobileAppGeneralModel struct {
 	ID                               types.String `tfsdk:"id"`
 	Name                             types.String `tfsdk:"name"`

--- a/internal/resources/pro/apps/mobile_device_app/model_types.go
+++ b/internal/resources/pro/apps/mobile_device_app/model_types.go
@@ -29,10 +29,12 @@ type MobileAppResourceModel struct {
 
 // MobileAppGeneralModel models <mobile_device_application><general>. name,
 // version, and bundle_id are required on create; os_type is optional (only
-// in-house apps need it — the server 409s on a write to an in-house app without
-// it; App Store apps do not). description / internal_app are server-managed and
-// surfaced read-only. The app's display name (server-forced == name) and url (a
-// deprecated mirror of itunes_store_url) are not modeled.
+// in-house apps need it). description is server-managed and surfaced read-only.
+// Not modeled: the app's display name (always == name); url (a deprecated mirror
+// of itunes_store_url); and internal_app — a read-only flag the server flips
+// based on the store/hosting inputs, so modeling it would trip a plan/apply
+// inconsistency when those change (in-house status is derivable from whether a
+// store/external URL is set).
 type MobileAppGeneralModel struct {
 	ID                               types.String `tfsdk:"id"`
 	Name                             types.String `tfsdk:"name"`
@@ -40,7 +42,6 @@ type MobileAppGeneralModel struct {
 	BundleID                         types.String `tfsdk:"bundle_id"`
 	OsType                           types.String `tfsdk:"os_type"`
 	Description                      types.String `tfsdk:"description"`
-	InternalApp                      types.Bool   `tfsdk:"internal_app"`
 	IsFree                           types.Bool   `tfsdk:"is_free"`
 	DeploymentType                   types.String `tfsdk:"deployment_type"`
 	ExternalURL                      types.String `tfsdk:"external_url"`
@@ -119,7 +120,6 @@ type MobileAppDataSourceModel struct {
 	Version        types.String             `tfsdk:"version"`
 	BundleID       types.String             `tfsdk:"bundle_id"`
 	OsType         types.String             `tfsdk:"os_type"`
-	InternalApp    types.Bool               `tfsdk:"internal_app"`
 	IsFree         types.Bool               `tfsdk:"is_free"`
 	DeploymentType types.String             `tfsdk:"deployment_type"`
 	CategoryID     types.String             `tfsdk:"category_id"`

--- a/internal/resources/pro/apps/mobile_device_app/plan_modifiers.go
+++ b/internal/resources/pro/apps/mobile_device_app/plan_modifiers.go
@@ -11,17 +11,18 @@ import (
 
 // preferencesNewlineSemanticEquality suppresses a plan diff on
 // app_configuration.preferences when the only difference between the prior state
-// and the planned config is newline style (CRLF vs LF). Jamf Pro round-trips
-// provider-authored content verbatim, but UI-authored or imported apps store
-// CRLF; without this, an LF-authored config would permadiff against a CRLF
-// server value. Real content edits still surface — only newline-only differences
-// are collapsed (to the prior state value, so the wire bytes stay stable).
+// and the planned config is newline style (CRLF vs LF) or a trailing newline.
+// Jamf Pro round-trips the content but strips the trailing newline and stores
+// CRLF for UI-authored/imported apps; without this, an LF-authored or heredoc
+// (`<<-EOT`, trailing newline) config would permadiff against the server value.
+// Real content edits still surface — only those normalisations are collapsed
+// (to the prior state value, so the wire bytes stay stable).
 type preferencesNewlineSemanticEquality struct{}
 
 var _ planmodifier.String = preferencesNewlineSemanticEquality{}
 
 func (preferencesNewlineSemanticEquality) Description(_ context.Context) string {
-	return "Treats CRLF and LF newlines as equivalent so newline-only differences do not produce a diff."
+	return "Treats CRLF/LF and a trailing newline as equivalent so those differences do not produce a diff."
 }
 
 func (m preferencesNewlineSemanticEquality) MarkdownDescription(ctx context.Context) string {
@@ -37,7 +38,7 @@ func (preferencesNewlineSemanticEquality) PlanModifyString(_ context.Context, re
 	if req.ConfigValue.IsNull() || req.ConfigValue.IsUnknown() {
 		return
 	}
-	if normalizeNewlines(req.StateValue.ValueString()) == normalizeNewlines(req.ConfigValue.ValueString()) {
+	if preferencesEqual(req.StateValue.ValueString(), req.ConfigValue.ValueString()) {
 		resp.PlanValue = req.StateValue
 	}
 }

--- a/internal/resources/pro/apps/mobile_device_app/resource.go
+++ b/internal/resources/pro/apps/mobile_device_app/resource.go
@@ -96,7 +96,7 @@ func (r *MobileAppResource) Schema(ctx context.Context, req resource.SchemaReque
 				PlanModifiers:       []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
 			},
 			"general": schema.SingleNestedAttribute{
-				MarkdownDescription: "General settings. `name`, `version`, and `bundle_id` are required; `os_type` is required only for in-house apps. Read-only fields (`description`, `internal_app`, `category_name`, `site_name`, `id`) are returned by Jamf Pro. The app's display name always equals `name`, so it is not modeled separately.",
+				MarkdownDescription: "General settings. `name`, `version`, and `bundle_id` are required; `os_type` is required only for in-house apps. Read-only fields (`description`, `category_name`, `site_name`, `id`) are returned by Jamf Pro. The app's display name always equals `name`, so it is not modeled separately.",
 				Required:            true,
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
@@ -128,9 +128,8 @@ func (r *MobileAppResource) Schema(ctx context.Context, req resource.SchemaReque
 							stringvalidator.OneOf(osTypeIOS, osTypeTVOS),
 						},
 					},
-					"description":  computedString("App description. App-Store-synced when `keep_description_and_icon_up_to_date = true`; not user-settable."),
-					"internal_app": computedBool("Whether Jamf Pro treats the app as in-house. Server-managed — it flips to false only as a side-effect of a coherent external-hosting combination (`is_free = true` + `host_externally = true` + `external_url`), not by direct assignment."),
-					"is_free":      optComputedBool("Whether the app is free."),
+					"description": computedString("App description. App-Store-synced when `keep_description_and_icon_up_to_date = true`; not user-settable."),
+					"is_free":     optComputedBool("Whether the app is free."),
 					"deployment_type": schema.StringAttribute{
 						MarkdownDescription: "Install method. One of `Make Available in Self Service` or `Install Automatically/Prompt Users to Install`. Defaults to `Make Available in Self Service`.",
 						Optional:            true,
@@ -363,24 +362,17 @@ func optComputedInt64(desc string) schema.Int64Attribute {
 // site_name from category_id/site_id, description from the App Store sync). If a
 // user changes the driving input, the plan shows the stale echo and the apply
 // recomputes it — the accepted ProClassic latent posture (mac_app carries the
-// same). It is NOT used for display_name: that echo is deterministically == name
-// and would trip "inconsistent result after apply" on any rename, so display_name
-// is not modeled (callers read `name`).
+// same).
+//
+// NB: this is intentionally NOT used for display_name (deterministically ==
+// name) or internal_app (server-flips based on the store/hosting inputs) —
+// those echoes would trip "inconsistent result after apply" when their driving
+// input changes, so they are not modeled at all (callers read `name`, and
+// in-house status is derivable from whether a store/external URL is set).
 func computedString(desc string) schema.StringAttribute {
 	return schema.StringAttribute{
 		MarkdownDescription: desc,
 		Computed:            true,
 		PlanModifiers:       []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
-	}
-}
-
-// computedBool is the bool sibling of computedString (internal_app, which the
-// server flips as a side-effect of the free + host_externally + external_url
-// combo; unchanged by a rename, so UseStateForUnknown is consistent here).
-func computedBool(desc string) schema.BoolAttribute {
-	return schema.BoolAttribute{
-		MarkdownDescription: desc,
-		Computed:            true,
-		PlanModifiers:       []planmodifier.Bool{boolplanmodifier.UseStateForUnknown()},
 	}
 }

--- a/internal/resources/pro/apps/mobile_device_app/resource.go
+++ b/internal/resources/pro/apps/mobile_device_app/resource.go
@@ -88,7 +88,7 @@ func (r *MobileAppResource) IdentitySchema(ctx context.Context, req resource.Ide
 // attribute descriptions.
 func (r *MobileAppResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = schema.Schema{
-		MarkdownDescription: "Manages a Jamf Pro mobile device app (the classic `/mobiledeviceapplications` endpoint — the \"App Store App\" / in-house app entries under the \"Mobile Device Apps\" sidebar). The resource models the app's **metadata**; there is no IPA binary-upload endpoint, so in-house binary upload is not modeled. `general.name`, `general.version`, `general.bundle_id`, and `general.os_type` are required. `os_type` is sent on every write because the server demands it on a PUT to an in-house app. Scope targets are flat sets of Jamf Pro IDs; interpolate `jamfplatform_device_group.<x>.jamf_pro_id` to bridge from Platform Services. Scope omits iBeacon limitations/exclusions because the endpoint drops them.\n\n**Update is a partial-merge**: the provider sends the full plan payload on every update, so in-place edits converge cleanly, but removing an entire optional block (`scope` / `self_service` / `vpp` / `app_configuration`) from config retains the previously-stored block server-side. To clear a block, null its individual fields rather than deleting the block.",
+		MarkdownDescription: "Manages a Jamf Pro mobile device app — the \"App Store App\" / in-house app entries under the \"Mobile Device Apps\" sidebar. The resource models the app's **metadata**; uploading an in-house binary (IPA) is not supported. `general.name`, `general.version`, and `general.bundle_id` are required. `general.os_type` is required only for in-house apps; App Store apps (with an `itunes_store_url`) do not need it. Scope targets are flat sets of Jamf Pro IDs; interpolate `jamfplatform_device_group.<x>.jamf_pro_id` to bridge from Platform Services. iBeacon scope limitations/exclusions are not supported for mobile device apps.\n\n**Updates are merged, not replaced**: removing an entire optional block (`scope` / `self_service` / `vpp` / `app_configuration`) from config does not clear it — the previously-set values are retained. To clear a block, null its individual fields rather than deleting the block.",
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
 				MarkdownDescription: "App ID assigned by Jamf Pro.",
@@ -96,7 +96,7 @@ func (r *MobileAppResource) Schema(ctx context.Context, req resource.SchemaReque
 				PlanModifiers:       []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
 			},
 			"general": schema.SingleNestedAttribute{
-				MarkdownDescription: "General settings. `name`, `version`, `bundle_id`, and `os_type` are required. Read-only fields (`description`, `internal_app`, `category_name`, `site_name`, `id`) are returned by Jamf Pro. The app's display name is always equal to `name` (the server forces it), so it is not modeled separately.",
+				MarkdownDescription: "General settings. `name`, `version`, and `bundle_id` are required; `os_type` is required only for in-house apps. Read-only fields (`description`, `internal_app`, `category_name`, `site_name`, `id`) are returned by Jamf Pro. The app's display name always equals `name`, so it is not modeled separately.",
 				Required:            true,
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
@@ -105,12 +105,12 @@ func (r *MobileAppResource) Schema(ctx context.Context, req resource.SchemaReque
 						PlanModifiers:       []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
 					},
 					"name": schema.StringAttribute{
-						MarkdownDescription: "App display name. Must be unique within the tenant. The server forces the app's `display_name` to equal this value.",
+						MarkdownDescription: "App display name. Must be unique within the tenant; also used as the app's display name in Self Service.",
 						Required:            true,
 						Validators:          []validator.String{stringvalidator.LengthAtLeast(1)},
 					},
 					"version": schema.StringAttribute{
-						MarkdownDescription: "App version string. Required by the server on create.",
+						MarkdownDescription: "App version string.",
 						Required:            true,
 						Validators:          []validator.String{stringvalidator.LengthAtLeast(1)},
 					},
@@ -120,8 +120,10 @@ func (r *MobileAppResource) Schema(ctx context.Context, req resource.SchemaReque
 						Validators:          []validator.String{stringvalidator.LengthAtLeast(1)},
 					},
 					"os_type": schema.StringAttribute{
-						MarkdownDescription: "Operating system the app targets. One of `iOS` or `tvOS`. The server requires this on every write to an in-house app (the common case), so the provider always sends it; it is echoed back on read once set.",
-						Required:            true,
+						MarkdownDescription: "Operating system the app targets. One of `iOS` or `tvOS`. Required for in-house apps; App Store apps (those with an `itunes_store_url`) do not need it.",
+						Optional:            true,
+						Computed:            true,
+						PlanModifiers:       []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
 						Validators: []validator.String{
 							stringvalidator.OneOf(osTypeIOS, osTypeTVOS),
 						},
@@ -130,7 +132,7 @@ func (r *MobileAppResource) Schema(ctx context.Context, req resource.SchemaReque
 					"internal_app": computedBool("Whether Jamf Pro treats the app as in-house. Server-managed — it flips to false only as a side-effect of a coherent external-hosting combination (`is_free = true` + `host_externally = true` + `external_url`), not by direct assignment."),
 					"is_free":      optComputedBool("Whether the app is free."),
 					"deployment_type": schema.StringAttribute{
-						MarkdownDescription: "Install method. One of `Make Available in Self Service` or `Install Automatically/Prompt Users to Install`. Server-defaults to `Make Available in Self Service`.",
+						MarkdownDescription: "Install method. One of `Make Available in Self Service` or `Install Automatically/Prompt Users to Install`. Defaults to `Make Available in Self Service`.",
 						Optional:            true,
 						Computed:            true,
 						PlanModifiers:       []planmodifier.String{stringplanmodifier.UseNonNullStateForUnknown()},
@@ -160,7 +162,7 @@ func (r *MobileAppResource) Schema(ctx context.Context, req resource.SchemaReque
 				},
 			},
 			"scope": schema.SingleNestedAttribute{
-				MarkdownDescription: "App scope. Targets are flat sets of Jamf Pro IDs; interpolate `jamfplatform_device_group.<x>.jamf_pro_id` to bridge from Platform Services. Setting `all_mobile_devices = true` forbids `mobile_device_ids`, `mobile_device_group_ids`, `building_ids`, `department_ids`. Setting `all_jss_users = true` forbids `user_ids` and `user_group_ids`. iBeacon limitations/exclusions are intentionally absent — the endpoint drops them.",
+				MarkdownDescription: "App scope. Targets are flat sets of Jamf Pro IDs; interpolate `jamfplatform_device_group.<x>.jamf_pro_id` to bridge from Platform Services. Setting `all_mobile_devices = true` forbids `mobile_device_ids`, `mobile_device_group_ids`, `building_ids`, `department_ids`. Setting `all_jss_users = true` forbids `user_ids` and `user_group_ids`. iBeacon limitations/exclusions are not supported for mobile device apps.",
 				Optional:            true,
 				Attributes:          scope.MobileScopeAttributes(scope.MobileScopeOptions{IncludeIbeacons: false}),
 			},
@@ -189,15 +191,15 @@ func (r *MobileAppResource) Schema(ctx context.Context, req resource.SchemaReque
 						NestedObject: schema.NestedAttributeObject{
 							Attributes: map[string]schema.Attribute{
 								"id":         schema.StringAttribute{MarkdownDescription: "Category ID.", Required: true},
-								"name":       optComputedString("Category display name. Returned by Jamf Pro."),
-								"display_in": optComputedBool("Display the app in this category."),
+								"name":       optComputedStringInList("Category display name. Returned by Jamf Pro."),
+								"display_in": optComputedBoolInList("Display the app in this category."),
 							},
 						},
 					},
 				},
 			},
 			"vpp": schema.SingleNestedAttribute{
-				MarkdownDescription: "Volume Purchasing (VPP) assignment. `assign_vpp_device_based_licenses` and `vpp_admin_account_id` are writable only for a genuinely VPP-backed title — setting `assign_vpp_device_based_licenses = true` on a non-VPP app returns HTTP 409 \"App is not available for device assignment\".",
+				MarkdownDescription: "Volume Purchasing (VPP) assignment. `assign_vpp_device_based_licenses` and `vpp_admin_account_id` are writable only for a genuinely VPP-backed title; setting `assign_vpp_device_based_licenses = true` on an app that is not VPP-backed is rejected.",
 				Optional:            true,
 				Attributes: map[string]schema.Attribute{
 					"assign_vpp_device_based_licenses": optComputedBool("Assign VPP device-based licenses."),
@@ -209,7 +211,7 @@ func (r *MobileAppResource) Schema(ctx context.Context, req resource.SchemaReque
 				Optional:            true,
 				Attributes: map[string]schema.Attribute{
 					"preferences": schema.StringAttribute{
-						MarkdownDescription: "App-configuration plist content. Round-trips verbatim; newline style (CRLF vs LF) is normalised when comparing.",
+						MarkdownDescription: "App-configuration property list content. Whitespace, indentation, and newline-style differences are ignored when comparing, so reformatting the same configuration does not show as a change.",
 						Optional:            true,
 						Computed:            true,
 						PlanModifiers:       []planmodifier.String{preferencesNewlineSemanticEquality{}},
@@ -285,12 +287,43 @@ func (r *MobileAppResource) ModifyPlan(ctx context.Context, req resource.ModifyP
 	}
 }
 
-// optComputedString returns an Optional+Computed StringAttribute with the
-// UseNonNullStateForUnknown plan modifier for server-augmented fields. Used both
-// at top level and inside SetNested list elements — see the policy resource doc
-// comment for why UseNonNullStateForUnknown (not UseStateForUnknown) is required
-// for nested-list growth.
+// optComputedString returns a top-level Optional+Computed StringAttribute with
+// UseStateForUnknown. UseStateForUnknown copies the prior state value — INCLUDING
+// null — into an unset plan, so a field the server omits when unconfigured (e.g.
+// self_service.after_install_button_text, which the server returns absent → null)
+// stays null on every plan instead of churning to "(known after apply)". For
+// fields the server does default (e.g. install_button_text → "Install") the prior
+// state is non-null and the behaviour is identical to UseNonNullStateForUnknown.
+//
+// Do NOT use this inside SetNested/ListNested elements: list growth produces a
+// null prior for the new element, which UseStateForUnknown would copy as a known
+// null and then trip "inconsistent result" when the element materialises — use
+// optComputedStringInList there.
 func optComputedString(desc string) schema.StringAttribute {
+	return schema.StringAttribute{
+		MarkdownDescription: desc,
+		Optional:            true,
+		Computed:            true,
+		PlanModifiers:       []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
+	}
+}
+
+// optComputedBool is the bool sibling of optComputedString (top-level).
+func optComputedBool(desc string) schema.BoolAttribute {
+	return schema.BoolAttribute{
+		MarkdownDescription: desc,
+		Optional:            true,
+		Computed:            true,
+		PlanModifiers:       []planmodifier.Bool{boolplanmodifier.UseStateForUnknown()},
+	}
+}
+
+// optComputedStringInList is the SetNested/ListNested-element flavour of
+// optComputedString: it uses UseNonNullStateForUnknown so a new element's null
+// prior is NOT copied as a known value (which would break the post-apply
+// consistency check as the set grows). See the policy/profile resources for why
+// nested-list Optional+Computed must use the non-null variant.
+func optComputedStringInList(desc string) schema.StringAttribute {
 	return schema.StringAttribute{
 		MarkdownDescription: desc,
 		Optional:            true,
@@ -299,8 +332,8 @@ func optComputedString(desc string) schema.StringAttribute {
 	}
 }
 
-// optComputedBool is the bool sibling of optComputedString.
-func optComputedBool(desc string) schema.BoolAttribute {
+// optComputedBoolInList is the bool sibling of optComputedStringInList.
+func optComputedBoolInList(desc string) schema.BoolAttribute {
 	return schema.BoolAttribute{
 		MarkdownDescription: desc,
 		Optional:            true,

--- a/internal/resources/pro/apps/mobile_device_app/resource_acceptance_test.go
+++ b/internal/resources/pro/apps/mobile_device_app/resource_acceptance_test.go
@@ -150,9 +150,9 @@ func TestAccResource_ProMobileApp_Basic(t *testing.T) {
 			},
 			{
 				// Rename: guards that an update changing name applies cleanly. The
-				// server-derived echo fields (description / internal_app /
-				// category_name / site_name) do not change on a rename, so their
-				// UseStateForUnknown plan values stay consistent through apply.
+				// server-derived echo fields (description / category_name /
+				// site_name) do not change on a rename, so their UseStateForUnknown
+				// plan values stay consistent through apply.
 				Config: mobileAppGeneralOnlyConfig(name+"-renamed", "2.0", "Install Automatically/Prompt Users to Install"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(mobileAppResourceAddr, "general.name", name+"-renamed"),

--- a/internal/resources/pro/apps/mobile_device_app/schema_test.go
+++ b/internal/resources/pro/apps/mobile_device_app/schema_test.go
@@ -67,7 +67,7 @@ func TestMobileAppResource_Schema(t *testing.T) {
 	} else if a.IsRequired() || !a.IsOptional() || !a.IsComputed() {
 		t.Error("general.os_type must be Optional+Computed")
 	}
-	for _, name := range []string{"description", "internal_app", "category_name", "site_name"} {
+	for _, name := range []string{"description", "category_name", "site_name"} {
 		a, ok := general.Attributes[name]
 		if !ok {
 			t.Errorf("general missing %q", name)

--- a/internal/resources/pro/apps/mobile_device_app/schema_test.go
+++ b/internal/resources/pro/apps/mobile_device_app/schema_test.go
@@ -50,8 +50,7 @@ func TestMobileAppResource_Schema(t *testing.T) {
 	if !ok {
 		t.Fatalf("general must be a SingleNestedAttribute")
 	}
-	// os_type is required (the server demands it on every write to an in-house app).
-	for _, name := range []string{"name", "version", "bundle_id", "os_type"} {
+	for _, name := range []string{"name", "version", "bundle_id"} {
 		a, ok := general.Attributes[name]
 		if !ok {
 			t.Errorf("general missing %q", name)
@@ -60,6 +59,13 @@ func TestMobileAppResource_Schema(t *testing.T) {
 		if !a.IsRequired() {
 			t.Errorf("general.%s must be required", name)
 		}
+	}
+	// os_type is Optional+Computed: only required for in-house apps, which the
+	// server enforces with a 409 — the schema does not force it.
+	if a, ok := general.Attributes["os_type"]; !ok {
+		t.Error("general missing os_type")
+	} else if a.IsRequired() || !a.IsOptional() || !a.IsComputed() {
+		t.Error("general.os_type must be Optional+Computed")
 	}
 	for _, name := range []string{"description", "internal_app", "category_name", "site_name"} {
 		a, ok := general.Attributes[name]

--- a/internal/resources/pro/apps/mobile_device_app/state_builders.go
+++ b/internal/resources/pro/apps/mobile_device_app/state_builders.go
@@ -47,7 +47,10 @@ func assignMobileAppResourceModel(ctx context.Context, state *MobileAppResourceM
 		flattenMobileAppVpp(a.Vpp, state.Vpp)
 	}
 	if state.AppConfiguration != nil && a.AppConfiguration != nil {
-		state.AppConfiguration.Preferences = helpers.StringPointerValueOrNull(a.AppConfiguration.Preferences)
+		// Preserve the configured value when the server differs only by newline
+		// style / a stripped trailing newline (server strips it on round-trip);
+		// otherwise reflect the server value as drift.
+		state.AppConfiguration.Preferences = preservePreferences(a.AppConfiguration.Preferences, state.AppConfiguration.Preferences)
 	}
 
 	return diags

--- a/internal/resources/pro/apps/mobile_device_app/state_builders.go
+++ b/internal/resources/pro/apps/mobile_device_app/state_builders.go
@@ -73,10 +73,9 @@ func flattenMobileAppGeneral(g *proclassic.MobileDeviceApplicationGeneral, state
 	// follow-up PUT precisely so the server persists it and this echo is present.
 	state.OsType = serverWhenPresentString(g.OsType, state.OsType)
 
-	// Server-managed read-only fields. (display_name is not modeled — it is
-	// always == name server-side.)
+	// Server-managed read-only field. (display_name and internal_app are not
+	// modeled — see MobileAppGeneralModel.)
 	state.Description = helpers.StringPointerValueOrNull(g.Description)
-	state.InternalApp = helpers.BoolPointerValueOrNull(g.InternalApp)
 
 	// Optional+Computed echoes.
 	state.IsFree = preferCurrentBoolPointer(g.Free, state.IsFree)

--- a/internal/resources/pro/apps/mobile_device_app/state_builders_test.go
+++ b/internal/resources/pro/apps/mobile_device_app/state_builders_test.go
@@ -43,9 +43,6 @@ func TestFlattenMobileAppGeneral_RoundTrip(t *testing.T) {
 	if state.Description.ValueString() != "Apple Maps" {
 		t.Errorf("description not flattened: %q", state.Description.ValueString())
 	}
-	if !state.InternalApp.ValueBool() {
-		t.Errorf("internal_app not flattened")
-	}
 	if !state.IsFree.ValueBool() {
 		t.Errorf("is_free (free) not flattened")
 	}

--- a/internal/resources/pro/configuration_profiles/macos_configuration_profile/helpers_test.go
+++ b/internal/resources/pro/configuration_profiles/macos_configuration_profile/helpers_test.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/common/plisthelpers"
 	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/resources/pro/configuration_profiles/payloadhelpers"
 )
 
@@ -77,7 +78,7 @@ func TestPayloadsSemanticallyEqual_DetectsRealChange(t *testing.T) {
 	_, serverResp := loadInputAndServer(t, "1Password__managed_login_items_profile")
 	// Mutate the server payload to flip a non-masked field — Rules array
 	// inside PayloadContent[0] has a `Comment` field that survives masking.
-	parsed, _, err := payloadhelpers.ParsePlist(serverResp)
+	parsed, _, err := plisthelpers.ParsePlist(serverResp)
 	if err != nil {
 		t.Fatalf("parse: %v", err)
 	}
@@ -86,7 +87,7 @@ func TestPayloadsSemanticallyEqual_DetectsRealChange(t *testing.T) {
 	rules := first["Rules"].([]any)
 	rule0 := rules[0].(map[string]any)
 	rule0["Comment"] = "tampered comment value"
-	mutated, err := payloadhelpers.MarshalPlist(parsed)
+	mutated, err := plisthelpers.MarshalPlist(parsed)
 	if err != nil {
 		t.Fatalf("marshal: %v", err)
 	}
@@ -150,13 +151,13 @@ func TestMaskPayload_StripsWhitespaceFromNestedStrings(t *testing.T) {
 func TestInjectTopLevelIdentifiers_PreservesUUIDAndIdentifier(t *testing.T) {
 	_, existing := loadInputAndServer(t, "1Password__managed_login_items_profile")
 	// Build a "new" payload by mutating the existing one's top-level UUIDs.
-	parsed, _, err := payloadhelpers.ParsePlist(existing)
+	parsed, _, err := plisthelpers.ParsePlist(existing)
 	if err != nil {
 		t.Fatalf("parse: %v", err)
 	}
 	parsed["PayloadUUID"] = "00000000-NEW-NEW-NEW-000000000000"
 	parsed["PayloadIdentifier"] = "00000000-NEW-NEW-NEW-000000000000"
-	newPayload, err := payloadhelpers.MarshalPlist(parsed)
+	newPayload, err := plisthelpers.MarshalPlist(parsed)
 	if err != nil {
 		t.Fatalf("marshal: %v", err)
 	}
@@ -165,11 +166,11 @@ func TestInjectTopLevelIdentifiers_PreservesUUIDAndIdentifier(t *testing.T) {
 		t.Fatalf("inject: %v", err)
 	}
 	// Re-parse and verify the identifiers came from `existing`.
-	check, _, err := payloadhelpers.ParsePlist(out)
+	check, _, err := plisthelpers.ParsePlist(out)
 	if err != nil {
 		t.Fatalf("parse output: %v", err)
 	}
-	existingParsed, _, _ := payloadhelpers.ParsePlist(existing)
+	existingParsed, _, _ := plisthelpers.ParsePlist(existing)
 	if got, want := check["PayloadUUID"], existingParsed["PayloadUUID"]; got != want {
 		t.Errorf("PayloadUUID not preserved: got=%v want=%v", got, want)
 	}
@@ -214,7 +215,7 @@ func TestExtractServerPayloadFromGeneral_DecodesEntities(t *testing.T) {
 	if err != nil {
 		t.Fatalf("extract: %v", err)
 	}
-	if _, _, err := payloadhelpers.ParsePlist(payload); err != nil {
+	if _, _, err := plisthelpers.ParsePlist(payload); err != nil {
 		t.Fatalf("extracted bytes did not parse as plist: %v", err)
 	}
 }

--- a/internal/resources/pro/configuration_profiles/macos_configuration_profile/plan_modifiers.go
+++ b/internal/resources/pro/configuration_profiles/macos_configuration_profile/plan_modifiers.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
+	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/common/plisthelpers"
 	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/common/scope"
 	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/resources/pro/configuration_profiles/payloadhelpers"
 )
@@ -90,7 +91,7 @@ func reconcileReadDrift(ctx context.Context, priv privatePayloadReader, state *R
 		// (lenient) self-healing behaviour.
 		return diags
 	}
-	canonicalisedServer := payloadhelpers.CanonicalisePlistXML(rawServerCanonical)
+	canonicalisedServer := plisthelpers.CanonicalisePlistXML(rawServerCanonical)
 	equal, err := payloadhelpers.PayloadsStructurallyEqual(lastCanonical, canonicalisedServer)
 	if err != nil {
 		diags.AddWarning("Read-side drift compare failed; leaving lenient self-healing in place", err.Error())
@@ -143,7 +144,7 @@ func writePrivatePayloadRefs(ctx context.Context, w privatePayloadWriter, userAu
 		// Re-emit through CanonicalisePlistXML so the bytes share the
 		// same tab-indented format used elsewhere, keeping the strict
 		// compare in PayloadsStructurallyEqual formatting-insensitive.
-		canonicalised := payloadhelpers.CanonicalisePlistXML(rawServerCanonical)
+		canonicalised := plisthelpers.CanonicalisePlistXML(rawServerCanonical)
 		encoded, err := encodePrivatePayload(canonicalised)
 		if err != nil {
 			diags.AddError("Failed to encode last-applied canonical for private state", err.Error())
@@ -167,7 +168,7 @@ func writePrivateServerNow(ctx context.Context, w privatePayloadWriter, rawServe
 	if w == nil || len(rawServerCanonical) == 0 {
 		return diags
 	}
-	canonicalised := payloadhelpers.CanonicalisePlistXML(rawServerCanonical)
+	canonicalised := plisthelpers.CanonicalisePlistXML(rawServerCanonical)
 	encoded, err := encodePrivatePayload(canonicalised)
 	if err != nil {
 		diags.AddError("Failed to encode server-now canonical for private state", err.Error())

--- a/internal/resources/pro/configuration_profiles/macos_configuration_profile/resource_acceptance_test.go
+++ b/internal/resources/pro/configuration_profiles/macos_configuration_profile/resource_acceptance_test.go
@@ -28,7 +28,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 
 	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/common/helpers"
-	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/resources/pro/configuration_profiles/payloadhelpers"
+	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/common/plisthelpers"
 	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/testhelpers"
 )
 
@@ -636,7 +636,7 @@ func mutatePPPCProfileChangeIdentifier(t *testing.T, profileID, newIdentifierVal
 	}
 	currentPayload := []byte(string(*got.General.Payloads))
 
-	parsed, _, err := payloadhelpers.ParsePlist(currentPayload)
+	parsed, _, err := plisthelpers.ParsePlist(currentPayload)
 	if err != nil {
 		t.Fatalf("ParsePlist for profile %s: %v", profileID, err)
 	}
@@ -679,7 +679,7 @@ func mutatePPPCProfileChangeIdentifier(t *testing.T, profileID, newIdentifierVal
 		t.Fatalf("profile %s had no Services[*] entries to mutate", profileID)
 	}
 
-	newPayloadBytes, err := payloadhelpers.MarshalPlist(parsed)
+	newPayloadBytes, err := plisthelpers.MarshalPlist(parsed)
 	if err != nil {
 		t.Fatalf("MarshalPlist for profile %s: %v", profileID, err)
 	}
@@ -785,7 +785,7 @@ func mutatePPPCProfileAddValidService(t *testing.T, profileID, serviceKey string
 		t.Fatalf("GetOSXConfigurationProfileByID(%s): %v", profileID, err)
 	}
 	currentPayload := []byte(string(*got.General.Payloads))
-	parsed, _, err := payloadhelpers.ParsePlist(currentPayload)
+	parsed, _, err := plisthelpers.ParsePlist(currentPayload)
 	if err != nil {
 		t.Fatalf("ParsePlist: %v", err)
 	}
@@ -798,7 +798,7 @@ func mutatePPPCProfileAddValidService(t *testing.T, profileID, serviceKey string
 			"IdentifierType":  "bundleID",
 		},
 	}
-	newPayloadBytes, err := payloadhelpers.MarshalPlist(parsed)
+	newPayloadBytes, err := plisthelpers.MarshalPlist(parsed)
 	if err != nil {
 		t.Fatalf("MarshalPlist: %v", err)
 	}
@@ -827,7 +827,7 @@ func mutatePPPCProfileRemoveFirstService(t *testing.T, profileID string) {
 		t.Fatalf("GetOSXConfigurationProfileByID(%s): %v", profileID, err)
 	}
 	currentPayload := []byte(string(*got.General.Payloads))
-	parsed, _, err := payloadhelpers.ParsePlist(currentPayload)
+	parsed, _, err := plisthelpers.ParsePlist(currentPayload)
 	if err != nil {
 		t.Fatalf("ParsePlist: %v", err)
 	}
@@ -840,7 +840,7 @@ func mutatePPPCProfileRemoveFirstService(t *testing.T, profileID string) {
 		delete(services, k)
 		break
 	}
-	newPayloadBytes, err := payloadhelpers.MarshalPlist(parsed)
+	newPayloadBytes, err := plisthelpers.MarshalPlist(parsed)
 	if err != nil {
 		t.Fatalf("MarshalPlist: %v", err)
 	}

--- a/internal/resources/pro/configuration_profiles/macos_configuration_profile/state_builders.go
+++ b/internal/resources/pro/configuration_profiles/macos_configuration_profile/state_builders.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
 	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/common/helpers"
+	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/common/plisthelpers"
 	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/common/scope"
 	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/resources/pro/configuration_profiles/payloadhelpers"
 )
@@ -88,7 +89,7 @@ func flattenGeneral(g *proclassic.OsXConfigurationProfileGeneral, state *General
 			}
 		}
 		if !keep {
-			state.Payloads = types.StringValue(string(payloadhelpers.CanonicalisePlistXML([]byte(server))))
+			state.Payloads = types.StringValue(string(plisthelpers.CanonicalisePlistXML([]byte(server))))
 		}
 	}
 	state.DistributionMethod = helpers.ReconcileOptionalStringPointer(g.DistributionMethod, state.DistributionMethod)

--- a/internal/resources/pro/configuration_profiles/mobile_device_configuration_profile/helpers_test.go
+++ b/internal/resources/pro/configuration_profiles/mobile_device_configuration_profile/helpers_test.go
@@ -6,6 +6,7 @@ package mobile_device_configuration_profile
 import (
 	"testing"
 
+	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/common/plisthelpers"
 	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/resources/pro/configuration_profiles/payloadhelpers"
 )
 
@@ -100,15 +101,15 @@ func TestPayloadsSemanticallyEqual_DetectsRealChange(t *testing.T) {
 
 // TestMarshalPlist_RoundTrip verifies parsePlist + marshalPlist preserves key values.
 func TestMarshalPlist_RoundTrip(t *testing.T) {
-	parsed, _, err := payloadhelpers.ParsePlist([]byte(minimalMobileconfig))
+	parsed, _, err := plisthelpers.ParsePlist([]byte(minimalMobileconfig))
 	if err != nil {
 		t.Fatalf("parse: %v", err)
 	}
-	out, err := payloadhelpers.MarshalPlist(parsed)
+	out, err := plisthelpers.MarshalPlist(parsed)
 	if err != nil {
 		t.Fatalf("marshal: %v", err)
 	}
-	reparsed, _, err := payloadhelpers.ParsePlist(out)
+	reparsed, _, err := plisthelpers.ParsePlist(out)
 	if err != nil {
 		t.Fatalf("reparse: %v", err)
 	}
@@ -121,13 +122,13 @@ func TestMarshalPlist_RoundTrip(t *testing.T) {
 // overwrites PayloadUUID / PayloadIdentifier from the existing source.
 func TestInjectTopLevelIdentifiers_Preserves(t *testing.T) {
 	existing := []byte(minimalMobileconfig)
-	parsed, _, err := payloadhelpers.ParsePlist(existing)
+	parsed, _, err := plisthelpers.ParsePlist(existing)
 	if err != nil {
 		t.Fatalf("parse: %v", err)
 	}
 	parsed["PayloadUUID"] = "NEW-UUID"
 	parsed["PayloadIdentifier"] = "NEW-IDENTIFIER"
-	newPayload, err := payloadhelpers.MarshalPlist(parsed)
+	newPayload, err := plisthelpers.MarshalPlist(parsed)
 	if err != nil {
 		t.Fatalf("marshal: %v", err)
 	}
@@ -135,7 +136,7 @@ func TestInjectTopLevelIdentifiers_Preserves(t *testing.T) {
 	if err != nil {
 		t.Fatalf("inject: %v", err)
 	}
-	check, _, err := payloadhelpers.ParsePlist(out)
+	check, _, err := plisthelpers.ParsePlist(out)
 	if err != nil {
 		t.Fatalf("parse output: %v", err)
 	}
@@ -166,7 +167,7 @@ func TestExtractServerPayloadFromGeneral_DecodesEntities(t *testing.T) {
 	if err != nil {
 		t.Fatalf("extract: %v", err)
 	}
-	if _, _, err := payloadhelpers.ParsePlist(payload); err != nil {
+	if _, _, err := plisthelpers.ParsePlist(payload); err != nil {
 		t.Fatalf("extracted bytes are not valid plist: %v", err)
 	}
 }

--- a/internal/resources/pro/configuration_profiles/mobile_device_configuration_profile/plan_modifiers.go
+++ b/internal/resources/pro/configuration_profiles/mobile_device_configuration_profile/plan_modifiers.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
+	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/common/plisthelpers"
 	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/common/scope"
 	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/resources/pro/configuration_profiles/payloadhelpers"
 )
@@ -70,7 +71,7 @@ func reconcileReadDrift(ctx context.Context, priv privatePayloadReader, state *R
 	if err != nil || len(lastCanonical) == 0 {
 		return diags
 	}
-	canonicalisedServer := payloadhelpers.CanonicalisePlistXML(rawServerCanonical)
+	canonicalisedServer := plisthelpers.CanonicalisePlistXML(rawServerCanonical)
 	equal, err := payloadhelpers.PayloadsStructurallyEqual(lastCanonical, canonicalisedServer)
 	if err != nil {
 		diags.AddWarning("Read-side drift compare failed; leaving lenient self-healing in place", err.Error())
@@ -108,7 +109,7 @@ func writePrivatePayloadRefs(ctx context.Context, w privatePayloadWriter, userAu
 		diags.Append(w.SetKey(ctx, privateKeyLastInput, encoded)...)
 	}
 	if len(rawServerCanonical) > 0 {
-		canonicalised := payloadhelpers.CanonicalisePlistXML(rawServerCanonical)
+		canonicalised := plisthelpers.CanonicalisePlistXML(rawServerCanonical)
 		encoded, err := encodePrivatePayload(canonicalised)
 		if err != nil {
 			diags.AddError("Failed to encode last-applied canonical for private state", err.Error())
@@ -127,7 +128,7 @@ func writePrivateServerNow(ctx context.Context, w privatePayloadWriter, rawServe
 	if w == nil || len(rawServerCanonical) == 0 {
 		return diags
 	}
-	canonicalised := payloadhelpers.CanonicalisePlistXML(rawServerCanonical)
+	canonicalised := plisthelpers.CanonicalisePlistXML(rawServerCanonical)
 	encoded, err := encodePrivatePayload(canonicalised)
 	if err != nil {
 		diags.AddError("Failed to encode server-now canonical for private state", err.Error())

--- a/internal/resources/pro/configuration_profiles/mobile_device_configuration_profile/state_builders.go
+++ b/internal/resources/pro/configuration_profiles/mobile_device_configuration_profile/state_builders.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
 	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/common/helpers"
+	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/common/plisthelpers"
 	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/common/scope"
 	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/resources/pro/configuration_profiles/payloadhelpers"
 )
@@ -74,7 +75,7 @@ func flattenGeneral(g *proclassic.MobileDeviceConfigurationProfileGeneral, state
 			}
 		}
 		if !keep {
-			state.Payloads = types.StringValue(string(payloadhelpers.CanonicalisePlistXML([]byte(server))))
+			state.Payloads = types.StringValue(string(plisthelpers.CanonicalisePlistXML([]byte(server))))
 		}
 	}
 	// Wire element is <deployment_method>; TF attribute is distribution_method (UI-canonical).

--- a/internal/resources/pro/configuration_profiles/payloadhelpers/helpers.go
+++ b/internal/resources/pro/configuration_profiles/payloadhelpers/helpers.go
@@ -15,6 +15,8 @@ import (
 	"strings"
 
 	"howett.net/plist"
+
+	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/common/plisthelpers"
 )
 
 // Server-controlled keys skipped on both sides before diff comparison.
@@ -86,53 +88,6 @@ var (
 	}
 )
 
-// ParsePlist decodes a mobileconfig XML plist into a Go map. The returned
-// int is howett.net/plist's format identifier (plist.XMLFormat,
-// plist.BinaryFormat, etc.) — typed as int because the library exposes
-// formats as untyped int constants.
-func ParsePlist(raw []byte) (map[string]any, int, error) {
-	var out map[string]any
-	format, err := plist.Unmarshal(raw, &out)
-	if err != nil {
-		return nil, 0, fmt.Errorf("parsing plist: %w", err)
-	}
-	return out, format, nil
-}
-
-// MarshalPlist serialises a plist dict back to XML form. Used by the input
-// builder when re-emitting a payload after identifier injection.
-func MarshalPlist(m map[string]any) ([]byte, error) {
-	buf := &bytes.Buffer{}
-	enc := plist.NewEncoderForFormat(buf, plist.XMLFormat)
-	enc.Indent("\t")
-	if err := enc.Encode(m); err != nil {
-		return nil, fmt.Errorf("encoding plist: %w", err)
-	}
-	return buf.Bytes(), nil
-}
-
-// CanonicalisePlistXML parses a mobileconfig plist and re-emits it as
-// tab-indented XML. Used on the state-builder side to normalise Jamf's
-// compact single-line wire form into the same shape user-authored
-// payloads typically take (Apple's standard pretty-printed mobileconfig).
-// When state and plan share formatting, Terraform's diff narrows from a
-// whole-payload swap to the specific keys that changed.
-//
-// Falls back to returning the input unchanged if the plist fails to
-// parse — the caller still has a usable string, and the legibility
-// improvement is a UX nicety, not a correctness gate.
-func CanonicalisePlistXML(raw []byte) []byte {
-	parsed, _, err := ParsePlist(raw)
-	if err != nil {
-		return raw
-	}
-	out, err := MarshalPlist(parsed)
-	if err != nil {
-		return raw
-	}
-	return out
-}
-
 // MaskPayload returns a deep-cloned representation of the input plist with
 // every server-controlled key dropped and every string value trimmed. The
 // result is suitable for equality comparison against another masked payload
@@ -142,7 +97,7 @@ func CanonicalisePlistXML(raw []byte) []byte {
 // See STYLE_GUIDE.md §Configuration profile payload diff suppression for
 // the diff-class catalogue this mask is designed to neutralise.
 func MaskPayload(raw []byte) (map[string]any, error) {
-	parsed, _, err := ParsePlist(raw)
+	parsed, _, err := plisthelpers.ParsePlist(raw)
 	if err != nil {
 		return nil, err
 	}
@@ -307,13 +262,13 @@ func PayloadsSemanticallyEqual(a, b []byte) (bool, error) {
 // LenientEqualPlist compares two parsed-and-masked plist trees with
 // intersection semantics: dict keys present on only one side are ignored;
 // shared keys must compare equal. Arrays compare positionally. Scalars
-// compare via numericEqual for ints (howett.net/plist returns int64 or
+// compare via plisthelpers.NumericEqual for ints (howett.net/plist returns int64 or
 // uint64 depending on sign).
 //
 // Exception: PayloadContent[i] entries whose PayloadType is in
 // mcxLikePayloadTypes (e.g. com.apple.ManagedClient.preferences — Jamf
 // Pro's "Application & Custom Settings") get their inner `.PayloadContent`
-// child strict-compared via strictEqual. That subtree is opaque
+// child strict-compared via plisthelpers.Equal. That subtree is opaque
 // user-authored vendor preference data; admin-UI key add/remove inside it
 // is real drift and must surface on the next plan. Remaining keys at the
 // MCX entry depth still use intersection so per-payload metadata defaults
@@ -340,7 +295,7 @@ func LenientEqualPlist(a, b any) bool {
 				if aHas != bHas {
 					return false
 				}
-				if aHas && !strictEqual(ai, bi) {
+				if aHas && !plisthelpers.Equal(ai, bi) {
 					return false
 				}
 				for k, va := range av {
@@ -376,70 +331,13 @@ func LenientEqualPlist(a, b any) bool {
 		}
 		return true
 	case uint64:
-		return numericEqual(int64(av), b)
+		return plisthelpers.NumericEqual(int64(av), b)
 	case int64:
-		return numericEqual(av, b)
+		return plisthelpers.NumericEqual(av, b)
 	case int:
-		return numericEqual(int64(av), b)
+		return plisthelpers.NumericEqual(int64(av), b)
 	default:
 		return a == b
-	}
-}
-
-// strictEqual is a structural-equality compare for the trimmed plist tree.
-// Unlike LenientEqualPlist, asymmetric keysets fail. Used for opaque
-// user-content subtrees (see mcxLikePayloadTypes) where every key is
-// author-controlled — admin-UI key add/remove inside the subtree is real
-// drift, not Jamf-side metadata injection.
-func strictEqual(a, b any) bool {
-	if a == nil || b == nil {
-		return a == nil && b == nil
-	}
-	switch av := a.(type) {
-	case map[string]any:
-		bv, ok := b.(map[string]any)
-		if !ok || len(av) != len(bv) {
-			return false
-		}
-		for k, va := range av {
-			vb, exists := bv[k]
-			if !exists || !strictEqual(va, vb) {
-				return false
-			}
-		}
-		return true
-	case []any:
-		bv, ok := b.([]any)
-		if !ok || len(av) != len(bv) {
-			return false
-		}
-		for i := range av {
-			if !strictEqual(av[i], bv[i]) {
-				return false
-			}
-		}
-		return true
-	case uint64:
-		return numericEqual(int64(av), b)
-	case int64:
-		return numericEqual(av, b)
-	case int:
-		return numericEqual(int64(av), b)
-	default:
-		return a == b
-	}
-}
-
-func numericEqual(a int64, b any) bool {
-	switch bv := b.(type) {
-	case uint64:
-		return a >= 0 && uint64(a) == bv
-	case int64:
-		return a == bv
-	case int:
-		return a == int64(bv)
-	default:
-		return false
 	}
 }
 
@@ -455,7 +353,7 @@ func InjectTopLevelIdentifierValues(newPayload []byte, uuid, identifier string) 
 	if uuid == "" && identifier == "" {
 		return newPayload, nil
 	}
-	next, format, err := ParsePlist(newPayload)
+	next, format, err := plisthelpers.ParsePlist(newPayload)
 	if err != nil {
 		return nil, fmt.Errorf("parsing new payload for identifier injection: %w", err)
 	}
@@ -481,7 +379,7 @@ func InjectTopLevelIdentifiers(newPayload, existingPayload []byte) ([]byte, erro
 	if len(existingPayload) == 0 {
 		return newPayload, nil
 	}
-	exist, _, err := ParsePlist(existingPayload)
+	exist, _, err := plisthelpers.ParsePlist(existingPayload)
 	if err != nil {
 		return newPayload, nil //nolint:nilerr // best-effort
 	}

--- a/internal/resources/pro/configuration_profiles/payloadhelpers/helpers_test.go
+++ b/internal/resources/pro/configuration_profiles/payloadhelpers/helpers_test.go
@@ -6,6 +6,8 @@ package payloadhelpers
 import (
 	"strings"
 	"testing"
+
+	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/common/plisthelpers"
 )
 
 const minimalPlist = `<?xml version="1.0" encoding="UTF-8"?>
@@ -30,41 +32,6 @@ const minimalWireXML = `<?xml version="1.0" encoding="UTF-8"?>
 &lt;key&gt;PayloadDisplayName&lt;/key&gt;&lt;string&gt;Test Profile&lt;/string&gt;
 &lt;key&gt;PayloadContent&lt;/key&gt;&lt;array/&gt;
 &lt;/dict&gt;&lt;/plist&gt;</payloads></general></configuration_profile>`
-
-func TestParsePlist_BasicRoundTrip(t *testing.T) {
-	m, _, err := ParsePlist([]byte(minimalPlist))
-	if err != nil {
-		t.Fatalf("parse: %v", err)
-	}
-	if m["PayloadType"] != "Configuration" {
-		t.Fatalf("PayloadType: got %v", m["PayloadType"])
-	}
-}
-
-func TestParsePlist_InvalidInput(t *testing.T) {
-	_, _, err := ParsePlist([]byte("not a plist"))
-	if err == nil {
-		t.Fatal("expected error on invalid input")
-	}
-}
-
-func TestMarshalPlist_RoundTrip(t *testing.T) {
-	parsed, _, err := ParsePlist([]byte(minimalPlist))
-	if err != nil {
-		t.Fatalf("parse: %v", err)
-	}
-	out, err := MarshalPlist(parsed)
-	if err != nil {
-		t.Fatalf("marshal: %v", err)
-	}
-	reparsed, _, err := ParsePlist(out)
-	if err != nil {
-		t.Fatalf("reparse: %v", err)
-	}
-	if reparsed["PayloadType"] != parsed["PayloadType"] {
-		t.Errorf("PayloadType: got=%v want=%v", reparsed["PayloadType"], parsed["PayloadType"])
-	}
-}
 
 func TestPayloadsSemanticallyEqual_Identical(t *testing.T) {
 	eq, err := PayloadsSemanticallyEqual([]byte(minimalPlist), []byte(minimalPlist))
@@ -121,7 +88,7 @@ func TestInjectTopLevelIdentifierValues_ReplacesUUIDs(t *testing.T) {
 	if err != nil {
 		t.Fatalf("inject: %v", err)
 	}
-	check, _, err := ParsePlist(out)
+	check, _, err := plisthelpers.ParsePlist(out)
 	if err != nil {
 		t.Fatalf("parse output: %v", err)
 	}
@@ -170,7 +137,7 @@ func TestExtractServerPayloadFromGeneral_DecodesEntities(t *testing.T) {
 	if err != nil {
 		t.Fatalf("extract: %v", err)
 	}
-	if _, _, err := ParsePlist(payload); err != nil {
+	if _, _, err := plisthelpers.ParsePlist(payload); err != nil {
 		t.Fatalf("extracted bytes not valid plist: %v", err)
 	}
 }

--- a/internal/resources/pro/configuration_profiles/payloadhelpers/threeway.go
+++ b/internal/resources/pro/configuration_profiles/payloadhelpers/threeway.go
@@ -7,6 +7,8 @@ import (
 	"fmt"
 	"maps"
 	"slices"
+
+	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/common/plisthelpers"
 )
 
 // ThreeWayDecision is the outcome of comparing a plan's payload to two
@@ -140,11 +142,11 @@ func structuralEqual(a, b any) bool {
 		}
 		return slices.EqualFunc(av, bv, structuralEqual)
 	case uint64:
-		return numericEqual(int64(av), b)
+		return plisthelpers.NumericEqual(int64(av), b)
 	case int64:
-		return numericEqual(av, b)
+		return plisthelpers.NumericEqual(av, b)
 	case int:
-		return numericEqual(int64(av), b)
+		return plisthelpers.NumericEqual(int64(av), b)
 	default:
 		return a == b
 	}


### PR DESCRIPTION
Follow-ups to #170, surfaced during live use of `jamfplatform_pro_mobile_device_app`.

## Fixes (all wire-probed against a live tenant)
- **`app_configuration.preferences`** — the server strips the trailing newline on round-trip (we send it; confirmed via SDK marshal + GET). Now compared by **semantic plist equality**, which erases whitespace, indentation, line endings, trailing newline, and key order; string fallback (CRLF/trailing-newline) for non-plist content. Fixes "inconsistent result after apply" on heredoc-authored preferences.
- **Top-level Optional+Computed churn** — `after_install_button_text` is returned absent when unset, so its null prior under `UseNonNullStateForUnknown` forced "(known after apply)" every update. Top-level helpers now use `UseStateForUnknown` (copies null; identical for non-null); nested SetNested elements keep `UseNonNullStateForUnknown` via new `*InList` helpers.
- **`os_type`** — no longer unconditionally Required; it's only needed for in-house apps. Now Optional+Computed (OneOf iOS/tvOS).
- **Schema descriptions** — stripped API/wire mechanics per STYLE_GUIDE "User-facing descriptions are UI-aligned"; docs regenerated.

## Refactor
- Extracted the resource-agnostic plist primitives (`ParsePlist`, `MarshalPlist`, `CanonicalisePlistXML`, `Equal`, `NumericEqual`, `SemanticallyEqual`) into **`internal/common/plisthelpers`**. `payloadhelpers` keeps its mobileconfig-specific masking/lenient-compare and consumes the new package; config-profile resources call it directly (no wrappers). **Pure move — config-profile behaviour unchanged** (their unit tests stay green).

## Testing
- `make fix fmt lint test` + `make generate` clean; new `plisthelpers` tests + `preferencesEqual` cases.
- Acceptance suite (resource + both config-profile packages) green against a live tenant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)