### PR TITLE
fix(device_group): model criteria as ordered list, not set

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -110,7 +110,7 @@ Optional split-outs for complex resources:
 
 - Schemas should be inline and as flat as possible.
 - Favor nested attributes (set/single/list) instead of blocks wherever possible.
-- **Sets vs Lists**: Use sets for user-supplied unordered collections where deduplication and order-independent comparison matter (e.g. `members`, `device_groups` scope, `criteria`, `raw_component`, component configuration sets). Use lists for computed API results that are read-only — sets require element hashing which adds CPU overhead with no benefit when the user doesn't control the values. Data source attributes returning API data should always use lists.
+- **Sets vs Lists**: Use sets for user-supplied unordered collections where deduplication and order-independent comparison matter (e.g. `members`, `device_groups` scope, `raw_component`, component configuration sets). Use lists for ordered user-supplied collections whose position is semantically meaningful (e.g. smart-group `criteria`, where evaluation order, parentheses, and `and_or` joins are positional) and for computed API results that are read-only — sets require element hashing which adds CPU overhead with no benefit when the user doesn't control the values. Data source attributes returning API data should always use lists.
 
 ## Environment Variables
 

--- a/docs/resources/device_group.md
+++ b/docs/resources/device_group.md
@@ -68,7 +68,7 @@ resource "jamfplatform_device_group" "example_smart_computer_group" {
 
 ### Optional
 
-- `criteria` (Attributes Set) Smart-group criteria evaluated by the Jamf inventory service. (see [below for nested schema](#nestedatt--criteria))
+- `criteria` (Attributes List) Smart-group criteria evaluated by the Jamf inventory service. Ordered: criteria are evaluated and rendered in the order listed. (see [below for nested schema](#nestedatt--criteria))
 - `description` (String) Optional Description for the device group.
 - `members` (Set of String) Optional device IDs to manage for static groups. When omitted, the provider leaves membership unchanged. Ignored for smart groups.
 - `timeouts` (Attributes) (see [below for nested schema](#nestedatt--timeouts))

--- a/internal/resources/device_group/resource.go
+++ b/internal/resources/device_group/resource.go
@@ -119,8 +119,8 @@ func (r *DeviceGroupResource) Schema(ctx context.Context, req resource.SchemaReq
 				MarkdownDescription: "Total members reported by the API.",
 				Computed:            true,
 			},
-			"criteria": schema.SetNestedAttribute{
-				MarkdownDescription: "Smart-group criteria evaluated by the Jamf inventory service.",
+			"criteria": schema.ListNestedAttribute{
+				MarkdownDescription: "Smart-group criteria evaluated by the Jamf inventory service. Ordered: criteria are evaluated and rendered in the order listed.",
 				Optional:            true,
 				NestedObject: schema.NestedAttributeObject{
 					Attributes: map[string]schema.Attribute{

--- a/internal/resources/device_group/schema_test.go
+++ b/internal/resources/device_group/schema_test.go
@@ -89,9 +89,9 @@ func TestDeviceGroupResource_SchemaAttributes(t *testing.T) {
 		t.Fatal("missing criteria attribute")
 	}
 
-	nested, ok := criteria.(resourceschema.SetNestedAttribute)
+	nested, ok := criteria.(resourceschema.ListNestedAttribute)
 	if !ok {
-		t.Fatal("criteria should be a SetNestedAttribute")
+		t.Fatal("criteria should be a ListNestedAttribute")
 	}
 
 	expectedCriteriaAttrs := []string{"order", "criteria", "operator", "value", "and_or", "has_opening_parenthesis", "has_closing_parenthesis"}


### PR DESCRIPTION
Closes #175

## Problem

`jamfplatform_device_group.criteria` was a `SetNestedAttribute`, but smart-group criteria are inherently **ordered** — the `order` field, parentheses, and `and_or` joins are all positional. Sets are unordered, producing two distinct failures:

1. **Wrong evaluation order in Jamf.** Terraform hands set elements to the provider in arbitrary hash order; `expandDeviceGroupCriteria` then stamped `Order = idx` from that scrambled iteration. Criteria written `26.0 / 15.0 / 16.0` landed in Jamf as `16.0 / 26.0 / 15.0`.

2. **`planned set element … does not correlate with any element in actual`.** Set correlation is by *value*. The positional reconcile in `flattenDeviceGroupCriteria` (`prev = current[i]`) paired each server element with an unrelated hash-ordered prior-state element, emitting garbage `order`/parenthesis values that matched no planned element — even though Jamf stored the group correctly.

## Fix

Switch `criteria` to `ListNestedAttribute`. The **data source already models the identical shape as a list** — this aligns the resource with it. Lists correlate positionally, so `prev[i]` lines up with `server[i]`, and the null-preserving `Reconcile*` helpers keep user-omitted `order`/parenthesis fields null (no inconsistent-result error). Sets-vs-Lists guidance in `CLAUDE.md` updated to match.

## No state upgrader needed

Set and list both serialise to a plain JSON array in Terraform state — there's no set-vs-list type tag to migrate from, so stored state decodes cleanly into the new type.

⚠️ **Known one-time upgrade plan (not a regression):** upgrading *in place* (rather than taint/recreate) shows a single self-healing reorder diff — e.g. `has_closing_parenthesis = false -> null` at one position and `+ true` at another — as state is realigned from the old hash order to config order. It applies cleanly and the next plan is empty. An upgrader can't avoid it (the Set never stored order). Recreating the resource sidesteps it entirely.

## Testing

- `go build ./internal/...`, `go vet`, `gofmt` clean.
- Unit tests pass (`go test ./internal/resources/device_group/...`); schema test updated to assert `ListNestedAttribute`.
- Verified empirically against a live tenant: clean-create now applies criteria in the correct order, and re-plan is idempotent.

## Note

This change is independent of the `jamf_pro_id` bridging work on `feat/pro-expansion` — zero overlap. The branch's `STYLE_GUIDE.md:158` still lists `criteria` as a set; that's a separate branch-side doc follow-up (the branch's rewritten CLAUDE.md will supersede this PR's CLAUDE.md edit on merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)