### PR TITLE
docs: delete-semantics taxonomy + retry-is-consumer-concern + acc-fixture conventions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -101,7 +101,7 @@ Save all bodies under `local-testing/<endpoint>/` (gitignored). Sanitise PII and
 | `update {id}` omitting a field entirely | Omitted-tag preservation. |
 | `create` with a bogus referenced name | Whether the server validates references (409) or silently accepts. |
 | `create` toggling a known interacting field (e.g. `use_generic` for printers, `is_smart` for groups) | Server-side overrides of sibling fields — drift pure GETs won't show. |
-| `delete {id} --yes` | Cleanup. `--yes` required under `--no-input`; or set `JAMF_CLI_ARGS='--yes'`. |
+| `delete {id} --yes -vvv` then `get {id}` over time | **Delete behaviour**, not just cleanup: response status (some classic deletes return a *misleading* `400`/`409` on an accepted delete), whether removal is synchronous, and — for async deletes — whether *polling itself interferes* (re-`GET` every few seconds vs a single quiet `GET`). Picks the delete handler per [STYLE_GUIDE §Delete semantics](STYLE_GUIDE.md#delete-semantics-not-found-async-and-propagation-blocked). `--yes` required under `--no-input` (or set `JAMF_CLI_ARGS='--yes'`). |
 
 Name saved artifacts after the probe that produced them (`get-id-69-minimal.xml`, `put-merge-clear-category.xml`). Delete agent-created throwaway resources before declaring the audit complete; the maintainer-seeded objects stay.
 

--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -816,22 +816,32 @@ When a resource references a **server-managed catalog** object — one the user 
 
 Reference: `jamfplatform_pro_app_installer.app_title_name` → Computed `app_title_id`.
 
-### Pro error/retry helpers (planned extension)
+### Delete semantics: not-found, async, and propagation-blocked
 
-Existing `internal/common/helpers/helpers.go` provides `IsNotFoundError` and `IsServerError`. Pro APIs add cases the existing helpers don't cover:
+The SDK transport does **not** retry 4xx and does **not** treat `DELETE→404` as success — both are consumer concerns (an eventual-consistency retry needs context the transport lacks; see [§Pro error/retry helpers](#pro-errorretry-helpers)). So **every `Delete` must branch on `helpers.IsNotFoundError`** to treat an already-absent record as success — never assume the SDK swallows the 404.
 
-- **429 Too Many Requests** — Pro endpoints rate-limit aggressively under load.
-- **423 Locked** — Pro async operations (deploy, sync, redeploy) return `423` while another operation is in flight.
-- **409 Conflict** — Pro PATCH/PUT on stale state.
+Beyond not-found, **wire-probe the delete** during the in-design phase — the response status, whether removal is synchronous, and (for async deletes) whether *polling itself interferes*. Probe: create a throwaway object, issue a single `DELETE` (capture status + body via `jamf-cli ... delete <id> -vvv`), then `GET`-by-id over time. Four patterns, each a distinct handler:
 
-When **3 or more** Pro resources need retry handling for these cases, extract into `internal/common/helpers`:
+| Wire behaviour | Handler | Reference |
+|---|---|---|
+| Clean synchronous (`200`/`204`, `GET`→404 immediately) | Plain delete + `IsNotFoundError` not-found-as-success branch | `mac_app_store_app` (`/macapplications`) |
+| Accepted behind a **misleading** status (e.g. `400` with an `<id>` body), removal prompt and **not** GET-sensitive | Poll `GET`-until-not-found via `helpers.ConfirmAsyncDelete`; error only on timeout | `mobile_device_app` (`/mobiledeviceapplications`) |
+| Accepted behind a misleading status, slow **and GET-sensitive** — polling to confirm *delays* the server-side removal | **Fire-and-trust**: issue `DELETE` once, **never GET**, `helpers.IsClientError`→`AddWarning` (drop from state), surface 5xx/transport as errors. Destroy-time verification is impossible → acc `CheckDestroy` is a documented no-op | `ebook` (`/ebooks`) |
+| Blocked by a still-propagating dependency (`406`/`409` while a dependent resource's own deletion catches up — Platform Services) | **Re-issue** the `DELETE` on `406`/`409` until it clears, the object is gone, or the timeout fires (`jamfplatform.PollUntil`). Re-issuing is *correct* here, unlike the accepted-async case | `device_group` |
 
-- `IsRateLimitError(err error) bool` — 429
-- `IsLockedError(err error) bool` — 423
-- `IsConflictError(err error) bool` — 409
-- `RetryWithBackoff(ctx, op, isRetriable, maxAttempts) error` — generic retry helper that respects context deadlines.
+The two misleading-status patterns look identical on the wire (same `400`) but diverge on GET-sensitivity — **probe it, do not assume** (`/ebooks` and `/mobiledeviceapplications` return the same misleading `400` yet behave oppositely under polling). Likewise never generalise one classic delete's behaviour to a sibling: `/macapplications` is clean-sync while the other two are misleading-async.
 
-Until the trigger fires, retry logic lives in-resource. Same deferred-abstraction discipline as shared schemas.
+### Pro error/retry helpers
+
+Eventual-consistency and retry are **consumer concerns**, not transport concerns — the SDK client cannot tell a permanent `409` ("Problem with site ID") from a transient one, so it does **not** retry 4xx. The transport retries only **`429`/`Retry-After`** (an unambiguous, server-instructed throttle) and applies a configurable **inter-request delay** (`WithMinRequestInterval`, default 100ms; surfaced as the provider `min_request_interval_ms` attribute / `JAMFPLATFORM_MIN_REQUEST_INTERVAL_MS` env var) that paces all outbound calls. Everything else surfaces to the resource, which owns any eventual-consistency handling (poll, re-issue, or fire-and-trust — see [§Delete semantics](#delete-semantics-not-found-async-and-propagation-blocked) and the per-resource `crud.go` annotation blocks).
+
+`internal/common/helpers/helpers.go` provides the classifiers:
+
+- `IsNotFoundError(err)` — `404` (and the classic `400 INVALID_ID`); use in every `Read`/`Delete`.
+- `IsClientError(err)` — any `4xx`; distinguishes an accepted-but-misleading `4xx` (treat as success-with-warning on a fire-and-trust delete) from a `5xx`/transport failure that must surface.
+- `IsServerError(err)` — `5xx`.
+
+For genuinely transient Pro states (`429`, `423 Locked` on in-flight async ops, `409` on stale `PATCH`/`PUT`), keep retry logic in-resource until **3 or more** resources need it, then extract a shared `RetryWithBackoff(ctx, op, isRetriable, maxAttempts)` (same deferred-abstraction discipline as shared schemas). `device_group`'s propagation-delete retry is the current in-resource precedent.
 
 ### Provider overall minimum Jamf Pro version (advisory warning)
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -179,6 +179,19 @@ Pro resources use the same `*jamfplatform.Client` and the same `JAMFPLATFORM_*` 
 
 **Acceptance test files MUST declare `//go:build acceptance` on line 1** or they leak into the unit run.
 
+### Tenant-prerequisite fixtures (server-state gates)
+
+Some Pro features can only be created when the tenant is in a prerequisite state — e.g. an enrollment-customization **SSO pane** requires SAML configured (`403 [INVALID_STATE] : SAML must be configured`), and a `DIRECTORY_SERVICE_ATTRIBUTE_MAPPING` extension attribute requires LDAP configured (`400 [INVALID_CONTENT] ... if LDAP is not configured`). Stand the prerequisite up as an in-config **fixture resource the subject `depends_on`**, so the apply orders the prerequisite first. Two flavours:
+
+- **Dummy fixture, no gating** — when the prerequisite resource doesn't validate live connectivity, build a placeholder. `jamfplatform_pro_ldap_server` does not verify the LDAP connection, so a dummy (`Open Directory`, fake `ldap.acc-anon.example.com:389`, `authentication_type = none`) configures LDAP with no real server and **needs no env var**. Reference: `ceaDSAM`/`mdeaDSAM`.
+- **Real-credential fixture, env-gated** — when the prerequisite needs real external infra (a SAML IdP metadata URL), gate the test on an env var and **skip** when unset (`t.Skipf`). Reference: the enrollment-customization SSO-pane tests gate on `JAMFPLATFORM_ACC_SSO_IDP_URL`; the `sso_settings` suite owns the same var.
+
+Two cautions: (1) prefer a fixture that **mutates the tenant minimally and reversibly** — e.g. SSO uses `OIDC_WITH_SAML`, not pure SAML, so Jamf ID admin login keeps working. (2) Many prerequisite singletons (`sso_settings`, `computer_inventory_collection_settings`) have **state-only deletes**, so teardown leaves the tenant in the fixture's state — idempotent on re-run, but document it and don't let other suites assume a clean SSO/inventory baseline.
+
+### Do not `ImportStateVerify` async server-computed values
+
+A `Computed` attribute that the server populates **asynchronously** (e.g. `computer_prestage_enrollment.profile_uuid` — the "information out of date" window) can read empty on a plain `GET` even on a settled object, so it does not reliably round-trip on import. Add it to `ImportStateVerifyIgnore` (alongside `timeouts` and WriteOnly secrets). It is server-generated, not user-settable, so verifying it on import adds no coverage. **Do not** try to force it to populate inside `Read` (e.g. a readiness poll) — for a GET-sensitive value that can make refresh worse (a transient empty becomes a hard timeout error).
+
 ### Profile-corpus regression test (opt-in build tag)
 
 `internal/resources/pro/configuration_profiles/macos_configuration_profile/helpers_corpus_test.go` is gated by `//go:build profile_corpus`. It iterates a 200-profile mobileconfig corpus under `testing/profile_roundtrip/` (gitignored, developer-machine-only) and asserts the mask-and-compare diff suppression is stable. Run with:


### PR DESCRIPTION
Follow-up to #193 — lifts the durable findings from the SDK 4xx-retry removal and the ebook build into the guides, so the next Pro resource can be built without re-deriving them. Docs-only.

## STYLE_GUIDE.md
- **New §Delete semantics: not-found, async, and propagation-blocked** — the four wire-probed delete patterns and which handler each gets:

  | Wire behaviour | Handler | Ref |
  |---|---|---|
  | clean sync (200/204, immediate 404) | plain delete + `IsNotFoundError` | mac_app |
  | misleading status, prompt, GET-safe | poll via `ConfirmAsyncDelete` | mobile_device_app |
  | misleading status, slow + GET-sensitive | fire-and-trust (delete once, no GET, warn) | ebook |
  | propagation-blocked 406/409 | re-issue DELETE until clear | device_group |

  Plus the rule that every Delete must treat `DELETE→404` as success itself (the transport no longer swallows it).
- **§Pro error/retry helpers** rewritten from "planned" → shipped: eventual-consistency/retry is a consumer concern; the transport does only `429`/`Retry-After` + a configurable inter-request delay (`min_request_interval_ms`); documents `IsClientError`.

## TESTING.md
- **Tenant-prerequisite fixtures** — dummy-no-gate (e.g. dummy LDAP for DSAM EAs) vs real-credential env-gated (e.g. `JAMFPLATFORM_ACC_SSO_IDP_URL` for SSO panes); prefer minimal/reversible tenant mutation; flag state-only-delete singletons.
- **Don't `ImportStateVerify` async server-computed values** (the `profile_uuid` lesson).

## CONTRIBUTING.md
- The Pro-resource wire-probe gate now probes **delete behaviour** (status, sync/async, GET-sensitivity), not just cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)