### PR TITLE
refactor(policy): align top-level blocks with the admin UI

### DIFF
--- a/docs/resources/pro_policy.md
+++ b/docs/resources/pro_policy.md
@@ -3,12 +3,12 @@
 page_title: "jamfplatform_pro_policy Resource - terraform-provider-jamfplatform"
 subcategory: ""
 description: |-
-  Manages a Jamf Pro policy. Supports the full 13-section policy payload (general, scope, self_service, package_configuration, scripts, printers, dock_items, account_maintenance, reboot, maintenance, files_processes, user_interaction, disk_encryption). Scope targets are flat sets of Jamf Pro IDs — interpolate jamfplatform_device_group.x.jamf_pro_id to bridge from Platform Services. Attribute names mirror the Jamf Pro admin UI labels. The legacy software-update policy block is intentionally not modelled: driving software updates via policy is an obsolete delivery path superseded by MDM-driven app installs / OS update scheduling and the Jamf Pro patch-management surface. If you need to drive OS or app updates from Terraform, reach for the patch / DDM resources instead.
+  Manages a Jamf Pro policy. Top-level blocks mirror the admin UI's tabs and Options sidebar: general, scope, self_service, user_interaction, and the Options payloads packages, scripts, printers, disk_encryption, dock_items, local_accounts, management_account, directory_bindings, efi_password, restart_options, maintenance, files_and_processes. Scope targets are flat sets of Jamf Pro IDs — interpolate jamfplatform_device_group.x.jamf_pro_id to bridge from Platform Services. The four account-maintenance payloads (local_accounts, management_account, directory_bindings, efi_password) are flattened peers of the UI sections; on the classic wire they share a single account_maintenance object. The legacy Software Update and Conditional Access policy sections are intentionally not modelled — both are obsolete in Jamf Pro, superseded by MDM-driven app installs / OS update scheduling and the patch-management surface. If you need to drive OS or app updates from Terraform, reach for the patch / DDM resources instead.
 ---
 
 # jamfplatform_pro_policy (Resource)
 
-Manages a Jamf Pro policy. Supports the full 13-section policy payload (general, scope, self_service, package_configuration, scripts, printers, dock_items, account_maintenance, reboot, maintenance, files_processes, user_interaction, disk_encryption). Scope targets are flat sets of Jamf Pro IDs — interpolate `jamfplatform_device_group.x.jamf_pro_id` to bridge from Platform Services. Attribute names mirror the Jamf Pro admin UI labels. The legacy software-update policy block is **intentionally not modelled**: driving software updates via policy is an obsolete delivery path superseded by MDM-driven app installs / OS update scheduling and the Jamf Pro patch-management surface. If you need to drive OS or app updates from Terraform, reach for the patch / DDM resources instead.
+Manages a Jamf Pro policy. Top-level blocks mirror the admin UI's tabs and Options sidebar: `general`, `scope`, `self_service`, `user_interaction`, and the Options payloads `packages`, `scripts`, `printers`, `disk_encryption`, `dock_items`, `local_accounts`, `management_account`, `directory_bindings`, `efi_password`, `restart_options`, `maintenance`, `files_and_processes`. Scope targets are flat sets of Jamf Pro IDs — interpolate `jamfplatform_device_group.x.jamf_pro_id` to bridge from Platform Services. The four account-maintenance payloads (`local_accounts`, `management_account`, `directory_bindings`, `efi_password`) are flattened peers of the UI sections; on the classic wire they share a single `account_maintenance` object. The legacy Software Update and Conditional Access policy sections are **intentionally not modelled** — both are obsolete in Jamf Pro, superseded by MDM-driven app installs / OS update scheduling and the patch-management surface. If you need to drive OS or app updates from Terraform, reach for the patch / DDM resources instead.
 
 ## Example Usage
 
@@ -77,6 +77,69 @@ resource "jamfplatform_pro_policy" "universal" {
     }
   }
 }
+
+# The Options sidebar payloads map to top-level blocks that mirror the admin
+# UI section names. `account_maintenance` is flattened into four peer blocks:
+# `local_accounts`, `management_account`, `directory_bindings`, `efi_password`.
+resource "jamfplatform_pro_policy" "options" {
+  general = {
+    name      = "tf-acc-options-policy"
+    enabled   = true
+    frequency = "Once per computer"
+  }
+
+  packages = {
+    distribution_point = "Cloud Distribution Point"
+    packages = [
+      { id = "100", action = "Install" },
+    ]
+  }
+
+  # Options ▸ Local Accounts. `password` is WriteOnly — rotate it by bumping
+  # `password_wo_version`.
+  local_accounts = [
+    {
+      action              = "Create"
+      username            = "tf-admin"
+      realname            = "TF Admin"
+      password            = "Sup3rS3cret!"
+      password_wo_version = 1
+      admin               = true
+    },
+  ]
+
+  # Options ▸ Management Accounts.
+  management_account = {
+    action                      = "rotate"
+    managed_password_length     = 16
+    managed_password_wo_version = 1
+  }
+
+  # Options ▸ Directory Bindings.
+  directory_bindings = [
+    { id = "1" },
+  ]
+
+  # Options ▸ EFI Password.
+  efi_password = {
+    of_mode                = "command"
+    of_password            = "EFI-pw-1!"
+    of_password_wo_version = 1
+  }
+
+  # Options ▸ Restart Options.
+  restart_options = {
+    no_user_logged_in = "Restart immediately"
+    user_logged_in    = "Restart if a package or update requires it"
+  }
+
+  # Options ▸ Files and Processes.
+  files_and_processes = {
+    search_by_path       = "/tmp/sentinel"
+    delete_file_if_found = true
+    execute_command      = "/usr/local/bin/post-flight.sh"
+  }
+}
 ```
 
 <!-- schema generated by tfplugindocs -->
@@ -88,14 +151,17 @@ resource "jamfplatform_pro_policy" "universal" {
 
 ### Optional
 
-- `account_maintenance` (Attributes) Account maintenance actions. Account secrets (`accounts[].password`, `management_account.managed_password`, `open_firmware_efi_password.of_password`) are Terraform `WriteOnly` attributes — sent to Jamf Pro on writes but never persisted in Terraform state. Each carries a `*_wo_version` Int64 companion: bump the integer to force the current plaintext to be re-sent on the next apply. (see [below for nested schema](#nestedatt--account_maintenance))
+- `directory_bindings` (Attributes Set) Directory binding assignments (admin UI: Options ▸ Directory Bindings). (see [below for nested schema](#nestedatt--directory_bindings))
 - `disk_encryption` (Attributes) Disk encryption configuration to apply. (see [below for nested schema](#nestedatt--disk_encryption))
 - `dock_items` (Attributes) Dock items to add or remove. (see [below for nested schema](#nestedatt--dock_items))
-- `files_processes` (Attributes) File and process operations. Attribute names mirror the Jamf Pro admin UI labels. (see [below for nested schema](#nestedatt--files_processes))
+- `efi_password` (Attributes) Open Firmware / EFI password configuration (admin UI: Options ▸ EFI Password). (see [below for nested schema](#nestedatt--efi_password))
+- `files_and_processes` (Attributes) File and process operations (admin UI: Options ▸ Files and Processes). Attribute names mirror the Jamf Pro admin UI labels. (see [below for nested schema](#nestedatt--files_and_processes))
+- `local_accounts` (Attributes List) Local account operations (admin UI: Options ▸ Local Accounts). Each `password` is a Terraform `WriteOnly` attribute — sent to Jamf Pro on writes but never persisted in state; pair it with `password_wo_version` to rotate. Modelled as a List (rather than a Set) so the `WriteOnly` attribute is permitted inside each element; Jamf Pro matches accounts by `username` server-side and the order has no semantic effect. (see [below for nested schema](#nestedatt--local_accounts))
 - `maintenance` (Attributes) Maintenance tasks to run as part of the policy. Attribute names mirror the Jamf Pro admin UI checkbox labels. (see [below for nested schema](#nestedatt--maintenance))
-- `package_configuration` (Attributes) Packages to install / cache / remove. (see [below for nested schema](#nestedatt--package_configuration))
+- `management_account` (Attributes) Management account configuration (admin UI: Options ▸ Management Accounts). (see [below for nested schema](#nestedatt--management_account))
+- `packages` (Attributes) Packages to install / cache / remove. Mirrors the admin UI's Options ▸ Packages section. (see [below for nested schema](#nestedatt--packages))
 - `printers` (Attributes) Printers to install or remove. (see [below for nested schema](#nestedatt--printers))
-- `reboot` (Attributes) Reboot configuration after the policy completes. (see [below for nested schema](#nestedatt--reboot))
+- `restart_options` (Attributes) Reboot configuration after the policy completes. Mirrors the admin UI's Options ▸ Restart Options section. (see [below for nested schema](#nestedatt--restart_options))
 - `scope` (Attributes) Policy scope. Targets are flat sets of Jamf Pro IDs; interpolate `jamfplatform_device_group.<x>.jamf_pro_id` to bridge from Platform Services UUIDs. Setting `all_computers = true` forbids `computer_ids`, `computer_group_ids`, `building_ids`, `department_ids`. Setting `all_jss_users = true` forbids `user_ids` and `user_group_ids`. `user_ids` / `user_group_ids` map to the admin UI's "Users" / "User Groups" lists. (see [below for nested schema](#nestedatt--scope))
 - `scripts` (Attributes) Scripts to run as part of the policy. (see [below for nested schema](#nestedatt--scripts))
 - `self_service` (Attributes) Self Service integration. Pair `display_notifications` with `notification_location` to control whether and where Self Service surfaces a notification when the policy becomes available. (see [below for nested schema](#nestedatt--self_service))
@@ -177,38 +243,8 @@ Optional:
 
 
 
-<a id="nestedatt--account_maintenance"></a>
-### Nested Schema for `account_maintenance`
-
-Optional:
-
-- `accounts` (Attributes List) Ordered list of local account operations. Modelled as a List (rather than a Set) so the `password` `WriteOnly` attribute is permitted inside each element; Jamf Pro matches accounts by `username` server-side and the order has no semantic effect. (see [below for nested schema](#nestedatt--account_maintenance--accounts))
-- `directory_bindings` (Attributes Set) Set of directory binding assignments. (see [below for nested schema](#nestedatt--account_maintenance--directory_bindings))
-- `management_account` (Attributes) Management account configuration. (see [below for nested schema](#nestedatt--account_maintenance--management_account))
-- `open_firmware_efi_password` (Attributes) Open Firmware / EFI password configuration. (see [below for nested schema](#nestedatt--account_maintenance--open_firmware_efi_password))
-
-<a id="nestedatt--account_maintenance--accounts"></a>
-### Nested Schema for `account_maintenance.accounts`
-
-Optional:
-
-- `action` (String) Account action. Valid values: `Create`, `Reset`, `Delete`, `DisableFileVault` (the admin UI labels the last action "Disable FileVault" — supply `DisableFileVault` here, with no trailing `2`).
-- `admin` (Boolean) Whether the account is an admin.
-- `archive_home_directory_to` (String) Destination for the archived home directory. Only meaningful when `permanently_delete_home_directory = false`.
-- `filevault_enabled` (Boolean) Whether FileVault 2 is enabled for the account.
-- `hint` (String) Password hint.
-- `home` (String) Home directory path.
-- `password` (String, Sensitive, [Write-only](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments)) Plaintext password used by `Create` and `Reset` actions. `WriteOnly` — sent to Jamf Pro on writes but **never persisted in Terraform state**. Pair with `password_wo_version` to rotate the stored password. `accounts` is a List, so bumping `password_wo_version` surfaces in `terraform plan` as an in-place change to the list element at the matching index (Jamf matches accounts by `username` server-side).
-- `password_wo_version` (Number) Rotation trigger for the `WriteOnly` `password`. Bump this integer (any change) to force a new apply that re-sends `password` to Jamf Pro for this account. Initial Create should set `password_wo_version = 1`. Leaving it unset or unchanged signals "leave the stored password alone" — the provider omits the password from the next update so Jamf Pro retains the existing value.
-- `permanently_delete_home_directory` (Boolean) Permanently delete the home directory when `action = "Delete"`. When true, the home is removed; when false (or unset), the home is archived to `archive_home_directory_to`. Mirrors the admin UI checkbox "Permanently delete home directory".
-- `picture` (String) Account picture path.
-- `realname` (String) Account real (full) name.
-- `secure_token_allowed` (Boolean) Whether the account is allowed to hold a Secure Token.
-- `username` (String) Account username.
-
-
-<a id="nestedatt--account_maintenance--directory_bindings"></a>
-### Nested Schema for `account_maintenance.directory_bindings`
+<a id="nestedatt--directory_bindings"></a>
+### Nested Schema for `directory_bindings`
 
 Required:
 
@@ -217,28 +253,6 @@ Required:
 Optional:
 
 - `name` (String) Directory binding display name. Returned by Jamf Pro.
-
-
-<a id="nestedatt--account_maintenance--management_account"></a>
-### Nested Schema for `account_maintenance.management_account`
-
-Optional:
-
-- `action` (String) Management account action (e.g. `doNotChange`, `rotate`).
-- `managed_password` (String, Sensitive, [Write-only](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments)) Plaintext managed password. `WriteOnly` — sent to Jamf Pro on writes but **never persisted in Terraform state**. Pair with `managed_password_wo_version` to rotate the stored password.
-- `managed_password_length` (Number) Length used when randomly generating the managed password.
-- `managed_password_wo_version` (Number) Rotation trigger for the `WriteOnly` `managed_password`. Bump this integer (any change) to force a new apply that re-sends `managed_password` to Jamf Pro. Initial Create should set `managed_password_wo_version = 1`. Leaving it unset or unchanged signals "leave the stored password alone" — the provider omits the password from the next update so Jamf Pro retains the existing value.
-
-
-<a id="nestedatt--account_maintenance--open_firmware_efi_password"></a>
-### Nested Schema for `account_maintenance.open_firmware_efi_password`
-
-Optional:
-
-- `of_mode` (String) Open Firmware mode (`command` or `full`).
-- `of_password` (String, Sensitive, [Write-only](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments)) Plaintext Open Firmware / EFI password. `WriteOnly` — sent to Jamf Pro on writes but **never persisted in Terraform state**. Pair with `of_password_wo_version` to rotate the stored password.
-- `of_password_wo_version` (Number) Rotation trigger for the `WriteOnly` `of_password`. Bump this integer (any change) to force a new apply that re-sends `of_password` to Jamf Pro. Initial Create should set `of_password_wo_version = 1`. Leaving it unset or unchanged signals "leave the stored password alone" — the provider omits the password from the next update so Jamf Pro retains the existing value.
-
 
 
 <a id="nestedatt--disk_encryption"></a>
@@ -274,8 +288,18 @@ Optional:
 
 
 
-<a id="nestedatt--files_processes"></a>
-### Nested Schema for `files_processes`
+<a id="nestedatt--efi_password"></a>
+### Nested Schema for `efi_password`
+
+Optional:
+
+- `of_mode` (String) Open Firmware mode (`command` or `full`).
+- `of_password` (String, Sensitive, [Write-only](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments)) Plaintext Open Firmware / EFI password. `WriteOnly` — sent to Jamf Pro on writes but **never persisted in Terraform state**. Pair with `of_password_wo_version` to rotate the stored password.
+- `of_password_wo_version` (Number) Rotation trigger for the `WriteOnly` `of_password`. Bump this integer (any change) to force a new apply that re-sends `of_password` to Jamf Pro. Initial Create should set `of_password_wo_version = 1`. Leaving it unset or unchanged signals "leave the stored password alone" — the provider omits the password from the next update so Jamf Pro retains the existing value.
+
+
+<a id="nestedatt--files_and_processes"></a>
+### Nested Schema for `files_and_processes`
 
 Optional:
 
@@ -287,6 +311,26 @@ Optional:
 - `search_by_spotlight` (String) Spotlight query. Mirrors the admin UI "Search for File Using Spotlight" input.
 - `search_for_process` (String) Process name to search for.
 - `update_locate_database` (Boolean) Update the locate database before searching.
+
+
+<a id="nestedatt--local_accounts"></a>
+### Nested Schema for `local_accounts`
+
+Optional:
+
+- `action` (String) Account action. Valid values: `Create`, `Reset`, `Delete`, `DisableFileVault` (the admin UI labels the last action "Disable FileVault" — supply `DisableFileVault` here, with no trailing `2`).
+- `admin` (Boolean) Whether the account is an admin.
+- `archive_home_directory_to` (String) Destination for the archived home directory. Only meaningful when `permanently_delete_home_directory = false`.
+- `filevault_enabled` (Boolean) Whether FileVault 2 is enabled for the account.
+- `hint` (String) Password hint.
+- `home` (String) Home directory path.
+- `password` (String, Sensitive, [Write-only](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments)) Plaintext password used by `Create` and `Reset` actions. `WriteOnly` — sent to Jamf Pro on writes but **never persisted in Terraform state**. Pair with `password_wo_version` to rotate the stored password. `local_accounts` is a List, so bumping `password_wo_version` surfaces in `terraform plan` as an in-place change to the list element at the matching index (Jamf matches accounts by `username` server-side).
+- `password_wo_version` (Number) Rotation trigger for the `WriteOnly` `password`. Bump this integer (any change) to force a new apply that re-sends `password` to Jamf Pro for this account. Initial Create should set `password_wo_version = 1`. Leaving it unset or unchanged signals "leave the stored password alone" — the provider omits the password from the next update so Jamf Pro retains the existing value.
+- `permanently_delete_home_directory` (Boolean) Permanently delete the home directory when `action = "Delete"`. When true, the home is removed; when false (or unset), the home is archived to `archive_home_directory_to`. Mirrors the admin UI checkbox "Permanently delete home directory".
+- `picture` (String) Account picture path.
+- `realname` (String) Account real (full) name.
+- `secure_token_allowed` (Boolean) Whether the account is allowed to hold a Secure Token.
+- `username` (String) Account username.
 
 
 <a id="nestedatt--maintenance"></a>
@@ -304,16 +348,27 @@ Optional:
 - `verify_startup_disk` (Boolean) Verify startup disk.
 
 
-<a id="nestedatt--package_configuration"></a>
-### Nested Schema for `package_configuration`
+<a id="nestedatt--management_account"></a>
+### Nested Schema for `management_account`
+
+Optional:
+
+- `action` (String) Management account action (e.g. `doNotChange`, `rotate`).
+- `managed_password` (String, Sensitive, [Write-only](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments)) Plaintext managed password. `WriteOnly` — sent to Jamf Pro on writes but **never persisted in Terraform state**. Pair with `managed_password_wo_version` to rotate the stored password.
+- `managed_password_length` (Number) Length used when randomly generating the managed password.
+- `managed_password_wo_version` (Number) Rotation trigger for the `WriteOnly` `managed_password`. Bump this integer (any change) to force a new apply that re-sends `managed_password` to Jamf Pro. Initial Create should set `managed_password_wo_version = 1`. Leaving it unset or unchanged signals "leave the stored password alone" — the provider omits the password from the next update so Jamf Pro retains the existing value.
+
+
+<a id="nestedatt--packages"></a>
+### Nested Schema for `packages`
 
 Optional:
 
 - `distribution_point` (String) Name of the file share distribution point used for the policy. Omit to inherit the tenant default.
-- `packages` (Attributes Set) Set of package assignments. Each item identifies the package by ID; `name` is returned by Jamf Pro. `action` is one of `Install`, `Cache`, `Install Cached`, `Uninstall`. (see [below for nested schema](#nestedatt--package_configuration--packages))
+- `packages` (Attributes Set) Set of package assignments. Each item identifies the package by ID; `name` is returned by Jamf Pro. `action` is one of `Install`, `Cache`, `Install Cached`, `Uninstall`. (see [below for nested schema](#nestedatt--packages--packages))
 
-<a id="nestedatt--package_configuration--packages"></a>
-### Nested Schema for `package_configuration.packages`
+<a id="nestedatt--packages--packages"></a>
+### Nested Schema for `packages.packages`
 
 Required:
 
@@ -352,8 +407,8 @@ Optional:
 
 
 
-<a id="nestedatt--reboot"></a>
-### Nested Schema for `reboot`
+<a id="nestedatt--restart_options"></a>
+### Nested Schema for `restart_options`
 
 Optional:
 

--- a/examples/resources/jamfplatform_pro_policy/resource.tf
+++ b/examples/resources/jamfplatform_pro_policy/resource.tf
@@ -62,3 +62,66 @@ resource "jamfplatform_pro_policy" "universal" {
     }
   }
 }
+
+# The Options sidebar payloads map to top-level blocks that mirror the admin
+# UI section names. `account_maintenance` is flattened into four peer blocks:
+# `local_accounts`, `management_account`, `directory_bindings`, `efi_password`.
+resource "jamfplatform_pro_policy" "options" {
+  general = {
+    name      = "tf-acc-options-policy"
+    enabled   = true
+    frequency = "Once per computer"
+  }
+
+  packages = {
+    distribution_point = "Cloud Distribution Point"
+    packages = [
+      { id = "100", action = "Install" },
+    ]
+  }
+
+  # Options ▸ Local Accounts. `password` is WriteOnly — rotate it by bumping
+  # `password_wo_version`.
+  local_accounts = [
+    {
+      action              = "Create"
+      username            = "tf-admin"
+      realname            = "TF Admin"
+      password            = "Sup3rS3cret!"
+      password_wo_version = 1
+      admin               = true
+    },
+  ]
+
+  # Options ▸ Management Accounts.
+  management_account = {
+    action                      = "rotate"
+    managed_password_length     = 16
+    managed_password_wo_version = 1
+  }
+
+  # Options ▸ Directory Bindings.
+  directory_bindings = [
+    { id = "1" },
+  ]
+
+  # Options ▸ EFI Password.
+  efi_password = {
+    of_mode                = "command"
+    of_password            = "EFI-pw-1!"
+    of_password_wo_version = 1
+  }
+
+  # Options ▸ Restart Options.
+  restart_options = {
+    no_user_logged_in = "Restart immediately"
+    user_logged_in    = "Restart if a package or update requires it"
+  }
+
+  # Options ▸ Files and Processes.
+  files_and_processes = {
+    search_by_path       = "/tmp/sentinel"
+    delete_file_if_found = true
+    execute_command      = "/usr/local/bin/post-flight.sh"
+  }
+}

--- a/internal/resources/pro/policies/policy/helpers.go
+++ b/internal/resources/pro/policies/policy/helpers.go
@@ -161,20 +161,20 @@ func stringIDPtr(value types.String) *int {
 // the corresponding XML element.
 func accountMaintenanceSecretsForCreate(cfg *PolicyResourceModel) *policyAccountMaintenanceSecrets {
 	out := &policyAccountMaintenanceSecrets{accountPasswords: map[string]*string{}}
-	if cfg == nil || cfg.AccountMaintenance == nil {
+	if cfg == nil {
 		return out
 	}
-	for _, a := range cfg.AccountMaintenance.Accounts {
+	for _, a := range cfg.LocalAccounts {
 		if a.Username.IsNull() || a.Username.IsUnknown() {
 			continue
 		}
 		out.accountPasswords[a.Username.ValueString()] = helpers.OptionalStringPointer(a.Password)
 	}
-	if cfg.AccountMaintenance.ManagementAccount != nil {
-		out.managedPassword = helpers.OptionalStringPointer(cfg.AccountMaintenance.ManagementAccount.ManagedPassword)
+	if cfg.ManagementAccount != nil {
+		out.managedPassword = helpers.OptionalStringPointer(cfg.ManagementAccount.ManagedPassword)
 	}
-	if cfg.AccountMaintenance.OpenFirmwareEfiPassword != nil {
-		out.ofPassword = helpers.OptionalStringPointer(cfg.AccountMaintenance.OpenFirmwareEfiPassword.OfPassword)
+	if cfg.EfiPassword != nil {
+		out.ofPassword = helpers.OptionalStringPointer(cfg.EfiPassword.OfPassword)
 	}
 	return out
 }

--- a/internal/resources/pro/policies/policy/input_builders.go
+++ b/internal/resources/pro/policies/policy/input_builders.go
@@ -68,8 +68,8 @@ func buildPolicyInput(ctx context.Context, plan PolicyResourceModel, secrets *po
 		out.SelfService = buildPolicySelfService(plan.SelfService)
 	}
 
-	if plan.PackageConfiguration != nil {
-		out.PackageConfiguration = buildPolicyPackageConfiguration(plan.PackageConfiguration)
+	if plan.Packages != nil {
+		out.PackageConfiguration = buildPolicyPackageConfiguration(plan.Packages)
 	}
 
 	if plan.Scripts != nil {
@@ -84,20 +84,22 @@ func buildPolicyInput(ctx context.Context, plan PolicyResourceModel, secrets *po
 		out.DockItems = buildPolicyDockItems(plan.DockItems)
 	}
 
-	if plan.AccountMaintenance != nil {
-		out.AccountMaintenance = buildPolicyAccountMaintenance(plan.AccountMaintenance, secrets)
-	}
+	// The four flattened account-maintenance blocks join back into a single
+	// wire <account_maintenance> object. buildPolicyAccountMaintenance
+	// self-guards: it returns nil when all four are absent, preserving the
+	// "omit the wire object entirely" behaviour.
+	out.AccountMaintenance = buildPolicyAccountMaintenance(plan, secrets)
 
-	if plan.Reboot != nil {
-		out.Reboot = buildPolicyReboot(plan.Reboot)
+	if plan.RestartOptions != nil {
+		out.Reboot = buildPolicyReboot(plan.RestartOptions)
 	}
 
 	if plan.Maintenance != nil {
 		out.Maintenance = buildPolicyMaintenance(plan.Maintenance)
 	}
 
-	if plan.FilesProcesses != nil {
-		out.FilesProcesses = buildPolicyFilesProcesses(plan.FilesProcesses)
+	if plan.FilesAndProcesses != nil {
+		out.FilesProcesses = buildPolicyFilesProcesses(plan.FilesAndProcesses)
 	}
 
 	if plan.UserInteraction != nil {
@@ -467,7 +469,7 @@ func buildPolicySelfService(m *PolicySelfServiceModel) *proclassic.PolicyPostSel
 	return ss
 }
 
-func buildPolicyPackageConfiguration(m *PolicyPackageConfigurationModel) *proclassic.PolicyPostPackageConfiguration {
+func buildPolicyPackageConfiguration(m *PolicyPackagesModel) *proclassic.PolicyPostPackageConfiguration {
 	dp := helpers.OptionalStringPointer(m.DistributionPoint)
 	if len(m.Packages) == 0 && dp == nil {
 		return nil
@@ -576,12 +578,17 @@ func buildPolicyDockItems(m *PolicyDockItemsModel) *proclassic.PolicyPostDockIte
 	return &proclassic.PolicyPostDockItems{DockItem: &items}
 }
 
-func buildPolicyAccountMaintenance(m *PolicyAccountMaintenanceModel, secrets *policyAccountMaintenanceSecrets) *proclassic.PolicyPostAccountMaintenance {
+// buildPolicyAccountMaintenance joins the four flattened account-maintenance
+// blocks (local_accounts, management_account, directory_bindings,
+// efi_password) back into the single classic wire <account_maintenance>
+// object. It self-guards: when all four blocks are absent it returns nil so
+// the wire omits the object entirely.
+func buildPolicyAccountMaintenance(plan PolicyResourceModel, secrets *policyAccountMaintenanceSecrets) *proclassic.PolicyPostAccountMaintenance {
 	am := &proclassic.PolicyPostAccountMaintenance{}
 
-	if len(m.Accounts) > 0 {
-		items := make([]proclassic.PolicyAccountMaintenanceAccountsAccountItem, 0, len(m.Accounts))
-		for _, a := range m.Accounts {
+	if len(plan.LocalAccounts) > 0 {
+		items := make([]proclassic.PolicyAccountMaintenanceAccountsAccountItem, 0, len(plan.LocalAccounts))
+		for _, a := range plan.LocalAccounts {
 			var password *string
 			if !a.Username.IsNull() && !a.Username.IsUnknown() {
 				if p, ok := secrets.accountPasswords[a.Username.ValueString()]; ok {
@@ -606,9 +613,9 @@ func buildPolicyAccountMaintenance(m *PolicyAccountMaintenanceModel, secrets *po
 		am.Accounts = &proclassic.PolicyAccountMaintenanceAccounts{Account: &items}
 	}
 
-	if len(m.DirectoryBindings) > 0 {
-		items := make([]proclassic.IDName, 0, len(m.DirectoryBindings))
-		for _, b := range m.DirectoryBindings {
+	if len(plan.DirectoryBindings) > 0 {
+		items := make([]proclassic.IDName, 0, len(plan.DirectoryBindings))
+		for _, b := range plan.DirectoryBindings {
 			items = append(items, proclassic.IDName{
 				ID:   stringIDPtr(b.ID),
 				Name: helpers.OptionalStringPointer(b.Name),
@@ -617,17 +624,17 @@ func buildPolicyAccountMaintenance(m *PolicyAccountMaintenanceModel, secrets *po
 		am.DirectoryBindings = &proclassic.PolicyAccountMaintenanceDirectoryBindings{Binding: &items}
 	}
 
-	if m.ManagementAccount != nil {
+	if plan.ManagementAccount != nil {
 		am.ManagementAccount = &proclassic.PolicyAccountMaintenanceManagementAccount{
-			Action:                helpers.OptionalStringPointer(m.ManagementAccount.Action),
+			Action:                helpers.OptionalStringPointer(plan.ManagementAccount.Action),
 			ManagedPassword:       secrets.managedPassword,
-			ManagedPasswordLength: optionalInt64ToInt(m.ManagementAccount.ManagedPasswordLength),
+			ManagedPasswordLength: optionalInt64ToInt(plan.ManagementAccount.ManagedPasswordLength),
 		}
 	}
 
-	if m.OpenFirmwareEfiPassword != nil {
+	if plan.EfiPassword != nil {
 		am.OpenFirmwareEfiPassword = &proclassic.PolicyAccountMaintenanceOpenFirmwareEfiPassword{
-			OfMode:     helpers.OptionalStringPointer(m.OpenFirmwareEfiPassword.OfMode),
+			OfMode:     helpers.OptionalStringPointer(plan.EfiPassword.OfMode),
 			OfPassword: secrets.ofPassword,
 		}
 	}
@@ -638,7 +645,7 @@ func buildPolicyAccountMaintenance(m *PolicyAccountMaintenanceModel, secrets *po
 	return am
 }
 
-func buildPolicyReboot(m *PolicyRebootModel) *proclassic.PolicyPostReboot {
+func buildPolicyReboot(m *PolicyRestartOptionsModel) *proclassic.PolicyPostReboot {
 	return &proclassic.PolicyPostReboot{
 		Message:                     helpers.OptionalStringPointer(m.Message),
 		StartupDisk:                 helpers.OptionalStringPointer(m.StartupDisk),
@@ -664,7 +671,7 @@ func buildPolicyMaintenance(m *PolicyMaintenanceModel) *proclassic.PolicyPostMai
 	}
 }
 
-func buildPolicyFilesProcesses(m *PolicyFilesProcessesModel) *proclassic.PolicyPostFilesProcesses {
+func buildPolicyFilesProcesses(m *PolicyFilesAndProcessesModel) *proclassic.PolicyPostFilesProcesses {
 	return &proclassic.PolicyPostFilesProcesses{
 		SearchByPath:         helpers.OptionalStringPointer(m.SearchByPath),
 		DeleteFile:           optionalBoolPointer(m.DeleteFileIfFound),

--- a/internal/resources/pro/policies/policy/input_builders_test.go
+++ b/internal/resources/pro/policies/policy/input_builders_test.go
@@ -161,7 +161,7 @@ func TestBuildPolicyInput_PackagesAndScripts(t *testing.T) {
 	t.Parallel()
 	plan := PolicyResourceModel{
 		General: &PolicyGeneralModel{Name: types.StringValue("tf-acc-pkg")},
-		PackageConfiguration: &PolicyPackageConfigurationModel{
+		Packages: &PolicyPackagesModel{
 			DistributionPoint: types.StringValue("Dummy DP"),
 			Packages: []PolicyPackageItemModel{
 				{ID: types.StringValue("100"), Action: types.StringValue("Install")},
@@ -190,7 +190,7 @@ func TestBuildPolicyInput_PackagesAndScripts(t *testing.T) {
 
 func TestBuildPolicyPackageConfiguration_DistributionPointOnly(t *testing.T) {
 	t.Parallel()
-	m := &PolicyPackageConfigurationModel{
+	m := &PolicyPackagesModel{
 		DistributionPoint: types.StringValue("Dummy DP"),
 	}
 	got := buildPolicyPackageConfiguration(m)
@@ -207,7 +207,7 @@ func TestBuildPolicyPackageConfiguration_DistributionPointOnly(t *testing.T) {
 
 func TestBuildPolicyPackageConfiguration_EmptyReturnsNil(t *testing.T) {
 	t.Parallel()
-	m := &PolicyPackageConfigurationModel{}
+	m := &PolicyPackagesModel{}
 	if got := buildPolicyPackageConfiguration(m); got != nil {
 		t.Fatalf("expected nil for empty package_configuration, got %+v", got)
 	}

--- a/internal/resources/pro/policies/policy/model_types.go
+++ b/internal/resources/pro/policies/policy/model_types.go
@@ -19,8 +19,8 @@ import (
 //   - self_service.display_notifications / notification_location are two TF
 //     attributes that round-trip through a single proclassic.NotificationValue
 //     (the wire emits two <notification> elements per policy).
-//   - Plaintext secrets (accounts[].password, management_account.managed_password,
-//     open_firmware_efi_password.of_password) are `WriteOnly` attributes: sent
+//   - Plaintext secrets (local_accounts[].password, management_account.managed_password,
+//     efi_password.of_password) are `WriteOnly` attributes: sent
 //     on writes from req.Config, never persisted in state. Each carries a
 //     `*_wo_version` Int64 Optional companion as rotation trigger. The
 //     SHA-256 response twins (password_sha256, of_password_sha256) are no
@@ -34,21 +34,29 @@ import (
 //     underlying wrapper-shape defect on the SDK type for any future
 //     non-policy consumer.
 type PolicyResourceModel struct {
-	ID                   types.String                     `tfsdk:"id"`
-	General              *PolicyGeneralModel              `tfsdk:"general"`
-	Scope                *scope.ComputerScopeModel        `tfsdk:"scope"`
-	SelfService          *PolicySelfServiceModel          `tfsdk:"self_service"`
-	PackageConfiguration *PolicyPackageConfigurationModel `tfsdk:"package_configuration"`
-	Scripts              *PolicyScriptsModel              `tfsdk:"scripts"`
-	Printers             *PolicyPrintersModel             `tfsdk:"printers"`
-	DockItems            *PolicyDockItemsModel            `tfsdk:"dock_items"`
-	AccountMaintenance   *PolicyAccountMaintenanceModel   `tfsdk:"account_maintenance"`
-	Reboot               *PolicyRebootModel               `tfsdk:"reboot"`
-	Maintenance          *PolicyMaintenanceModel          `tfsdk:"maintenance"`
-	FilesProcesses       *PolicyFilesProcessesModel       `tfsdk:"files_processes"`
-	UserInteraction      *PolicyUserInteractionModel      `tfsdk:"user_interaction"`
-	DiskEncryption       *PolicyDiskEncryptionModel       `tfsdk:"disk_encryption"`
-	Timeouts             resourceTimeouts.Value           `tfsdk:"timeouts"`
+	ID          types.String              `tfsdk:"id"`
+	General     *PolicyGeneralModel       `tfsdk:"general"`
+	Scope       *scope.ComputerScopeModel `tfsdk:"scope"`
+	SelfService *PolicySelfServiceModel   `tfsdk:"self_service"`
+	Packages    *PolicyPackagesModel      `tfsdk:"packages"`
+	Scripts     *PolicyScriptsModel       `tfsdk:"scripts"`
+	Printers    *PolicyPrintersModel      `tfsdk:"printers"`
+	DockItems   *PolicyDockItemsModel     `tfsdk:"dock_items"`
+	// account_maintenance is flattened into four UI-aligned peer blocks
+	// (Local Accounts / Management Accounts / Directory Bindings / EFI
+	// Password in the admin UI). The classic wire still carries them under a
+	// single <account_maintenance> object — the input/state builders join and
+	// split across these four fields.
+	LocalAccounts     []PolicyAccountItemModel            `tfsdk:"local_accounts"`
+	DirectoryBindings []PolicyDirectoryBindingItemModel   `tfsdk:"directory_bindings"`
+	ManagementAccount *PolicyManagementAccountModel       `tfsdk:"management_account"`
+	EfiPassword       *PolicyOpenFirmwareEfiPasswordModel `tfsdk:"efi_password"`
+	RestartOptions    *PolicyRestartOptionsModel          `tfsdk:"restart_options"`
+	Maintenance       *PolicyMaintenanceModel             `tfsdk:"maintenance"`
+	FilesAndProcesses *PolicyFilesAndProcessesModel       `tfsdk:"files_and_processes"`
+	UserInteraction   *PolicyUserInteractionModel         `tfsdk:"user_interaction"`
+	DiskEncryption    *PolicyDiskEncryptionModel          `tfsdk:"disk_encryption"`
+	Timeouts          resourceTimeouts.Value              `tfsdk:"timeouts"`
 }
 
 // PolicyGeneralModel models <policy><general>.
@@ -139,8 +147,9 @@ type PolicySelfServiceCategoryModel struct {
 	FeatureIn types.Bool   `tfsdk:"feature_in"`
 }
 
-// PolicyPackageConfigurationModel models <policy><package_configuration>.
-type PolicyPackageConfigurationModel struct {
+// PolicyPackagesModel models <policy><package_configuration> (admin UI:
+// Options ▸ Packages).
+type PolicyPackagesModel struct {
 	DistributionPoint types.String             `tfsdk:"distribution_point"`
 	Packages          []PolicyPackageItemModel `tfsdk:"packages"`
 }
@@ -203,14 +212,6 @@ type PolicyDockItemModel struct {
 	Action types.String `tfsdk:"action"`
 }
 
-// PolicyAccountMaintenanceModel models <policy><account_maintenance>.
-type PolicyAccountMaintenanceModel struct {
-	Accounts                []PolicyAccountItemModel            `tfsdk:"accounts"`
-	DirectoryBindings       []PolicyDirectoryBindingItemModel   `tfsdk:"directory_bindings"`
-	ManagementAccount       *PolicyManagementAccountModel       `tfsdk:"management_account"`
-	OpenFirmwareEfiPassword *PolicyOpenFirmwareEfiPasswordModel `tfsdk:"open_firmware_efi_password"`
-}
-
 // PolicyAccountItemModel models a single <account>. `Password` is
 // `WriteOnly` (never persisted in state); `PasswordWoVersion` is the
 // rotation trigger companion.
@@ -253,8 +254,9 @@ type PolicyOpenFirmwareEfiPasswordModel struct {
 	OfPasswordWoVersion types.Int64  `tfsdk:"of_password_wo_version"`
 }
 
-// PolicyRebootModel models <policy><reboot>.
-type PolicyRebootModel struct {
+// PolicyRestartOptionsModel models <policy><reboot> (admin UI: Options ▸
+// Restart Options).
+type PolicyRestartOptionsModel struct {
 	Message                     types.String `tfsdk:"message"`
 	StartupDisk                 types.String `tfsdk:"startup_disk"`
 	SpecifyStartup              types.String `tfsdk:"specify_startup"`
@@ -278,9 +280,10 @@ type PolicyMaintenanceModel struct {
 	VerifyStartupDisk     types.Bool `tfsdk:"verify_startup_disk"`     // wire: <verify>
 }
 
-// PolicyFilesProcessesModel models <policy><files_processes>. Attribute names
-// mirror the Jamf Pro admin UI labels; wire element names are noted below.
-type PolicyFilesProcessesModel struct {
+// PolicyFilesAndProcessesModel models <policy><files_processes> (admin UI:
+// Options ▸ Files and Processes). Attribute names mirror the Jamf Pro admin
+// UI labels; wire element names are noted below.
+type PolicyFilesAndProcessesModel struct {
 	SearchByPath         types.String `tfsdk:"search_by_path"`
 	DeleteFileIfFound    types.Bool   `tfsdk:"delete_file_if_found"` // wire: <delete_file>
 	SearchByFilename     types.String `tfsdk:"search_by_filename"`   // wire: <locate_file>

--- a/internal/resources/pro/policies/policy/resource.go
+++ b/internal/resources/pro/policies/policy/resource.go
@@ -86,7 +86,7 @@ func (r *PolicyResource) IdentitySchema(ctx context.Context, req resource.Identi
 // element names are noted in attribute descriptions where they differ.
 func (r *PolicyResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = schema.Schema{
-		MarkdownDescription: "Manages a Jamf Pro policy. Supports the full 13-section policy payload (general, scope, self_service, package_configuration, scripts, printers, dock_items, account_maintenance, reboot, maintenance, files_processes, user_interaction, disk_encryption). Scope targets are flat sets of Jamf Pro IDs — interpolate `jamfplatform_device_group.x.jamf_pro_id` to bridge from Platform Services. Attribute names mirror the Jamf Pro admin UI labels. The legacy software-update policy block is **intentionally not modelled**: driving software updates via policy is an obsolete delivery path superseded by MDM-driven app installs / OS update scheduling and the Jamf Pro patch-management surface. If you need to drive OS or app updates from Terraform, reach for the patch / DDM resources instead.",
+		MarkdownDescription: "Manages a Jamf Pro policy. Top-level blocks mirror the admin UI's tabs and Options sidebar: `general`, `scope`, `self_service`, `user_interaction`, and the Options payloads `packages`, `scripts`, `printers`, `disk_encryption`, `dock_items`, `local_accounts`, `management_account`, `directory_bindings`, `efi_password`, `restart_options`, `maintenance`, `files_and_processes`. Scope targets are flat sets of Jamf Pro IDs — interpolate `jamfplatform_device_group.x.jamf_pro_id` to bridge from Platform Services. The four account-maintenance payloads (`local_accounts`, `management_account`, `directory_bindings`, `efi_password`) are flattened peers of the UI sections; on the classic wire they share a single `account_maintenance` object. The legacy Software Update and Conditional Access policy sections are **intentionally not modelled** — both are obsolete in Jamf Pro, superseded by MDM-driven app installs / OS update scheduling and the patch-management surface. If you need to drive OS or app updates from Terraform, reach for the patch / DDM resources instead.",
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
 				MarkdownDescription: "Policy ID assigned by Jamf Pro.",
@@ -277,8 +277,8 @@ func (r *PolicyResource) Schema(ctx context.Context, req resource.SchemaRequest,
 					},
 				},
 			},
-			"package_configuration": schema.SingleNestedAttribute{
-				MarkdownDescription: "Packages to install / cache / remove.",
+			"packages": schema.SingleNestedAttribute{
+				MarkdownDescription: "Packages to install / cache / remove. Mirrors the admin UI's Options ▸ Packages section.",
 				Optional:            true,
 				Attributes: map[string]schema.Attribute{
 					"distribution_point": schema.StringAttribute{
@@ -374,96 +374,96 @@ func (r *PolicyResource) Schema(ctx context.Context, req resource.SchemaRequest,
 					},
 				},
 			},
-			"account_maintenance": schema.SingleNestedAttribute{
-				MarkdownDescription: "Account maintenance actions. Account secrets (`accounts[].password`, `management_account.managed_password`, `open_firmware_efi_password.of_password`) are Terraform `WriteOnly` attributes — sent to Jamf Pro on writes but never persisted in Terraform state. Each carries a `*_wo_version` Int64 companion: bump the integer to force the current plaintext to be re-sent on the next apply.",
+			// account_maintenance is flattened into four UI-aligned peer blocks
+			// to mirror the admin UI's Options sidebar (Local Accounts /
+			// Management Accounts / Directory Bindings / EFI Password). The
+			// classic wire still nests all four under a single
+			// <account_maintenance> object — the input/state builders join
+			// these four fields on write and split them on read.
+			"local_accounts": schema.ListNestedAttribute{
+				MarkdownDescription: "Local account operations (admin UI: Options ▸ Local Accounts). Each `password` is a Terraform `WriteOnly` attribute — sent to Jamf Pro on writes but never persisted in state; pair it with `password_wo_version` to rotate. Modelled as a List (rather than a Set) so the `WriteOnly` attribute is permitted inside each element; Jamf Pro matches accounts by `username` server-side and the order has no semantic effect.",
 				Optional:            true,
-				Attributes: map[string]schema.Attribute{
-					"accounts": schema.ListNestedAttribute{
-						MarkdownDescription: "Ordered list of local account operations. Modelled as a List (rather than a Set) so the `password` `WriteOnly` attribute is permitted inside each element; Jamf Pro matches accounts by `username` server-side and the order has no semantic effect.",
-						Optional:            true,
-						NestedObject: schema.NestedAttributeObject{
-							Attributes: map[string]schema.Attribute{
-								"action": schema.StringAttribute{
-									MarkdownDescription: "Account action. Valid values: `Create`, `Reset`, `Delete`, `DisableFileVault` (the admin UI labels the last action \"Disable FileVault\" — supply `DisableFileVault` here, with no trailing `2`).",
-									Optional:            true,
-									Computed:            true,
-									PlanModifiers:       []planmodifier.String{stringplanmodifier.UseNonNullStateForUnknown()},
-									Validators: []validator.String{
-										stringvalidator.OneOf("Create", "Reset", "Delete", "DisableFileVault"),
-									},
-								},
-								"username": optComputedString("Account username."),
-								"realname": optComputedString("Account real (full) name."),
-								"password": schema.StringAttribute{
-									MarkdownDescription: "Plaintext password used by `Create` and `Reset` actions. `WriteOnly` — sent to Jamf Pro on writes but **never persisted in Terraform state**. Pair with `password_wo_version` to rotate the stored password. `accounts` is a List, so bumping `password_wo_version` surfaces in `terraform plan` as an in-place change to the list element at the matching index (Jamf matches accounts by `username` server-side).",
-									Optional:            true,
-									Sensitive:           true,
-									WriteOnly:           true,
-								},
-								"password_wo_version": schema.Int64Attribute{
-									MarkdownDescription: "Rotation trigger for the `WriteOnly` `password`. Bump this integer (any change) to force a new apply that re-sends `password` to Jamf Pro for this account. Initial Create should set `password_wo_version = 1`. Leaving it unset or unchanged signals \"leave the stored password alone\" — the provider omits the password from the next update so Jamf Pro retains the existing value.",
-									Optional:            true,
-								},
-								"permanently_delete_home_directory": optComputedBool("Permanently delete the home directory when `action = \"Delete\"`. When true, the home is removed; when false (or unset), the home is archived to `archive_home_directory_to`. Mirrors the admin UI checkbox \"Permanently delete home directory\"."),
-								"archive_home_directory_to":         optComputedString("Destination for the archived home directory. Only meaningful when `permanently_delete_home_directory = false`."),
-								"home":                              optComputedString("Home directory path."),
-								"hint":                              optComputedString("Password hint."),
-								"picture":                           optComputedString("Account picture path."),
-								"admin":                             optComputedBool("Whether the account is an admin."),
-								"filevault_enabled":                 optComputedBool("Whether FileVault 2 is enabled for the account."),
-								"secure_token_allowed":              optComputedBool("Whether the account is allowed to hold a Secure Token."),
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"action": schema.StringAttribute{
+							MarkdownDescription: "Account action. Valid values: `Create`, `Reset`, `Delete`, `DisableFileVault` (the admin UI labels the last action \"Disable FileVault\" — supply `DisableFileVault` here, with no trailing `2`).",
+							Optional:            true,
+							Computed:            true,
+							PlanModifiers:       []planmodifier.String{stringplanmodifier.UseNonNullStateForUnknown()},
+							Validators: []validator.String{
+								stringvalidator.OneOf("Create", "Reset", "Delete", "DisableFileVault"),
 							},
 						},
-					},
-					"directory_bindings": schema.SetNestedAttribute{
-						MarkdownDescription: "Set of directory binding assignments.",
-						Optional:            true,
-						NestedObject: schema.NestedAttributeObject{
-							Attributes: map[string]schema.Attribute{
-								"id":   schema.StringAttribute{MarkdownDescription: "Directory binding ID.", Required: true},
-								"name": optComputedString("Directory binding display name. Returned by Jamf Pro."),
-							},
+						"username": optComputedString("Account username."),
+						"realname": optComputedString("Account real (full) name."),
+						"password": schema.StringAttribute{
+							MarkdownDescription: "Plaintext password used by `Create` and `Reset` actions. `WriteOnly` — sent to Jamf Pro on writes but **never persisted in Terraform state**. Pair with `password_wo_version` to rotate the stored password. `local_accounts` is a List, so bumping `password_wo_version` surfaces in `terraform plan` as an in-place change to the list element at the matching index (Jamf matches accounts by `username` server-side).",
+							Optional:            true,
+							Sensitive:           true,
+							WriteOnly:           true,
 						},
-					},
-					"management_account": schema.SingleNestedAttribute{
-						MarkdownDescription: "Management account configuration.",
-						Optional:            true,
-						Attributes: map[string]schema.Attribute{
-							"action": optComputedString("Management account action (e.g. `doNotChange`, `rotate`)."),
-							"managed_password": schema.StringAttribute{
-								MarkdownDescription: "Plaintext managed password. `WriteOnly` — sent to Jamf Pro on writes but **never persisted in Terraform state**. Pair with `managed_password_wo_version` to rotate the stored password.",
-								Optional:            true,
-								Sensitive:           true,
-								WriteOnly:           true,
-							},
-							"managed_password_wo_version": schema.Int64Attribute{
-								MarkdownDescription: "Rotation trigger for the `WriteOnly` `managed_password`. Bump this integer (any change) to force a new apply that re-sends `managed_password` to Jamf Pro. Initial Create should set `managed_password_wo_version = 1`. Leaving it unset or unchanged signals \"leave the stored password alone\" — the provider omits the password from the next update so Jamf Pro retains the existing value.",
-								Optional:            true,
-							},
-							"managed_password_length": optComputedInt("Length used when randomly generating the managed password."),
+						"password_wo_version": schema.Int64Attribute{
+							MarkdownDescription: "Rotation trigger for the `WriteOnly` `password`. Bump this integer (any change) to force a new apply that re-sends `password` to Jamf Pro for this account. Initial Create should set `password_wo_version = 1`. Leaving it unset or unchanged signals \"leave the stored password alone\" — the provider omits the password from the next update so Jamf Pro retains the existing value.",
+							Optional:            true,
 						},
-					},
-					"open_firmware_efi_password": schema.SingleNestedAttribute{
-						MarkdownDescription: "Open Firmware / EFI password configuration.",
-						Optional:            true,
-						Attributes: map[string]schema.Attribute{
-							"of_mode": optComputedString("Open Firmware mode (`command` or `full`)."),
-							"of_password": schema.StringAttribute{
-								MarkdownDescription: "Plaintext Open Firmware / EFI password. `WriteOnly` — sent to Jamf Pro on writes but **never persisted in Terraform state**. Pair with `of_password_wo_version` to rotate the stored password.",
-								Optional:            true,
-								Sensitive:           true,
-								WriteOnly:           true,
-							},
-							"of_password_wo_version": schema.Int64Attribute{
-								MarkdownDescription: "Rotation trigger for the `WriteOnly` `of_password`. Bump this integer (any change) to force a new apply that re-sends `of_password` to Jamf Pro. Initial Create should set `of_password_wo_version = 1`. Leaving it unset or unchanged signals \"leave the stored password alone\" — the provider omits the password from the next update so Jamf Pro retains the existing value.",
-								Optional:            true,
-							},
-						},
+						"permanently_delete_home_directory": optComputedBool("Permanently delete the home directory when `action = \"Delete\"`. When true, the home is removed; when false (or unset), the home is archived to `archive_home_directory_to`. Mirrors the admin UI checkbox \"Permanently delete home directory\"."),
+						"archive_home_directory_to":         optComputedString("Destination for the archived home directory. Only meaningful when `permanently_delete_home_directory = false`."),
+						"home":                              optComputedString("Home directory path."),
+						"hint":                              optComputedString("Password hint."),
+						"picture":                           optComputedString("Account picture path."),
+						"admin":                             optComputedBool("Whether the account is an admin."),
+						"filevault_enabled":                 optComputedBool("Whether FileVault 2 is enabled for the account."),
+						"secure_token_allowed":              optComputedBool("Whether the account is allowed to hold a Secure Token."),
 					},
 				},
 			},
-			"reboot": schema.SingleNestedAttribute{
-				MarkdownDescription: "Reboot configuration after the policy completes.",
+			"management_account": schema.SingleNestedAttribute{
+				MarkdownDescription: "Management account configuration (admin UI: Options ▸ Management Accounts).",
+				Optional:            true,
+				Attributes: map[string]schema.Attribute{
+					"action": optComputedString("Management account action (e.g. `doNotChange`, `rotate`)."),
+					"managed_password": schema.StringAttribute{
+						MarkdownDescription: "Plaintext managed password. `WriteOnly` — sent to Jamf Pro on writes but **never persisted in Terraform state**. Pair with `managed_password_wo_version` to rotate the stored password.",
+						Optional:            true,
+						Sensitive:           true,
+						WriteOnly:           true,
+					},
+					"managed_password_wo_version": schema.Int64Attribute{
+						MarkdownDescription: "Rotation trigger for the `WriteOnly` `managed_password`. Bump this integer (any change) to force a new apply that re-sends `managed_password` to Jamf Pro. Initial Create should set `managed_password_wo_version = 1`. Leaving it unset or unchanged signals \"leave the stored password alone\" — the provider omits the password from the next update so Jamf Pro retains the existing value.",
+						Optional:            true,
+					},
+					"managed_password_length": optComputedInt("Length used when randomly generating the managed password."),
+				},
+			},
+			"directory_bindings": schema.SetNestedAttribute{
+				MarkdownDescription: "Directory binding assignments (admin UI: Options ▸ Directory Bindings).",
+				Optional:            true,
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"id":   schema.StringAttribute{MarkdownDescription: "Directory binding ID.", Required: true},
+						"name": optComputedString("Directory binding display name. Returned by Jamf Pro."),
+					},
+				},
+			},
+			"efi_password": schema.SingleNestedAttribute{
+				MarkdownDescription: "Open Firmware / EFI password configuration (admin UI: Options ▸ EFI Password).",
+				Optional:            true,
+				Attributes: map[string]schema.Attribute{
+					"of_mode": optComputedString("Open Firmware mode (`command` or `full`)."),
+					"of_password": schema.StringAttribute{
+						MarkdownDescription: "Plaintext Open Firmware / EFI password. `WriteOnly` — sent to Jamf Pro on writes but **never persisted in Terraform state**. Pair with `of_password_wo_version` to rotate the stored password.",
+						Optional:            true,
+						Sensitive:           true,
+						WriteOnly:           true,
+					},
+					"of_password_wo_version": schema.Int64Attribute{
+						MarkdownDescription: "Rotation trigger for the `WriteOnly` `of_password`. Bump this integer (any change) to force a new apply that re-sends `of_password` to Jamf Pro. Initial Create should set `of_password_wo_version = 1`. Leaving it unset or unchanged signals \"leave the stored password alone\" — the provider omits the password from the next update so Jamf Pro retains the existing value.",
+						Optional:            true,
+					},
+				},
+			},
+			"restart_options": schema.SingleNestedAttribute{
+				MarkdownDescription: "Reboot configuration after the policy completes. Mirrors the admin UI's Options ▸ Restart Options section.",
 				Optional:            true,
 				Attributes: map[string]schema.Attribute{
 					"message":      optComputedString("Reboot prompt message."),
@@ -498,8 +498,8 @@ func (r *PolicyResource) Schema(ctx context.Context, req resource.SchemaRequest,
 					"verify_startup_disk":     optComputedBool("Verify startup disk."),
 				},
 			},
-			"files_processes": schema.SingleNestedAttribute{
-				MarkdownDescription: "File and process operations. Attribute names mirror the Jamf Pro admin UI labels.",
+			"files_and_processes": schema.SingleNestedAttribute{
+				MarkdownDescription: "File and process operations (admin UI: Options ▸ Files and Processes). Attribute names mirror the Jamf Pro admin UI labels.",
 				Optional:            true,
 				Attributes: map[string]schema.Attribute{
 					"search_by_path":         optComputedString("Path to search for. Mirrors the admin UI \"Search for File by Path\" input."),

--- a/internal/resources/pro/policies/policy/resource_acceptance_test.go
+++ b/internal/resources/pro/policies/policy/resource_acceptance_test.go
@@ -585,7 +585,7 @@ resource "jamfplatform_pro_policy" "test" {
   general = {
     name = %q
   }
-  reboot = {
+  restart_options = {
     message                        = "tf-acc reboot message"
     startup_disk                   = "Current Startup Disk"
     specify_startup                = %q
@@ -613,7 +613,7 @@ resource "jamfplatform_pro_policy" "test" {
   general = {
     name = %q
   }
-  package_configuration = {
+  packages = {
     distribution_point = %q
   }
 }
@@ -643,7 +643,7 @@ func TestAccPolicyResource_PackageConfigurationDistributionPoint(t *testing.T) {
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(
 						"jamfplatform_pro_policy.test",
-						tfjsonpath.New("package_configuration").AtMapKey("distribution_point"),
+						tfjsonpath.New("packages").AtMapKey("distribution_point"),
 						knownvalue.StringExact("Dummy DP"),
 					),
 				},
@@ -665,7 +665,7 @@ resource "jamfplatform_pro_policy" "test" {
   general = {
     name = %q
   }
-  package_configuration = {
+  packages = {
     distribution_point = "Dummy DP"
     packages = [
       {
@@ -679,7 +679,7 @@ resource "jamfplatform_pro_policy" "test" {
 }
 
 // TestAccPolicyResource_PackageConfigurationPackages exercises the
-// `package_configuration.packages` set together with the top-level
+// `packages.packages` set together with the top-level
 // distribution_point. A jamfplatform_pro_package resource uploads the
 // committed jamf-cli .pkg fixture (shared with the inventory/package acc
 // suite) so the policy can reference a real package ID. Step 2 swaps the
@@ -705,17 +705,17 @@ func TestAccPolicyResource_PackageConfigurationPackages(t *testing.T) {
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(
 						"jamfplatform_pro_policy.test",
-						tfjsonpath.New("package_configuration").AtMapKey("distribution_point"),
+						tfjsonpath.New("packages").AtMapKey("distribution_point"),
 						knownvalue.StringExact("Dummy DP"),
 					),
 					statecheck.ExpectKnownValue(
 						"jamfplatform_pro_policy.test",
-						tfjsonpath.New("package_configuration").AtMapKey("packages"),
+						tfjsonpath.New("packages").AtMapKey("packages"),
 						knownvalue.SetSizeExact(1),
 					),
 					statecheck.ExpectKnownValue(
 						"jamfplatform_pro_policy.test",
-						tfjsonpath.New("package_configuration").AtMapKey("packages").AtSliceIndex(0).AtMapKey("action"),
+						tfjsonpath.New("packages").AtMapKey("packages").AtSliceIndex(0).AtMapKey("action"),
 						knownvalue.StringExact("Install"),
 					),
 				},
@@ -725,7 +725,7 @@ func TestAccPolicyResource_PackageConfigurationPackages(t *testing.T) {
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(
 						"jamfplatform_pro_policy.test",
-						tfjsonpath.New("package_configuration").AtMapKey("packages").AtSliceIndex(0).AtMapKey("action"),
+						tfjsonpath.New("packages").AtMapKey("packages").AtSliceIndex(0).AtMapKey("action"),
 						knownvalue.StringExact("Cache"),
 					),
 				},
@@ -748,27 +748,27 @@ func TestAccPolicyResource_RebootFullCoverage(t *testing.T) {
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(
 						"jamfplatform_pro_policy.test",
-						tfjsonpath.New("reboot").AtMapKey("specify_startup"),
+						tfjsonpath.New("restart_options").AtMapKey("specify_startup"),
 						knownvalue.StringExact(""),
 					),
 					statecheck.ExpectKnownValue(
 						"jamfplatform_pro_policy.test",
-						tfjsonpath.New("reboot").AtMapKey("message"),
+						tfjsonpath.New("restart_options").AtMapKey("message"),
 						knownvalue.StringExact("tf-acc reboot message"),
 					),
 					statecheck.ExpectKnownValue(
 						"jamfplatform_pro_policy.test",
-						tfjsonpath.New("reboot").AtMapKey("delay_minutes"),
+						tfjsonpath.New("restart_options").AtMapKey("delay_minutes"),
 						knownvalue.Int64Exact(10),
 					),
 					statecheck.ExpectKnownValue(
 						"jamfplatform_pro_policy.test",
-						tfjsonpath.New("reboot").AtMapKey("start_reboot_timer_immediately"),
+						tfjsonpath.New("restart_options").AtMapKey("start_reboot_timer_immediately"),
 						knownvalue.Bool(true),
 					),
 					statecheck.ExpectKnownValue(
 						"jamfplatform_pro_policy.test",
-						tfjsonpath.New("reboot").AtMapKey("no_user_logged_in"),
+						tfjsonpath.New("restart_options").AtMapKey("no_user_logged_in"),
 						knownvalue.StringExact("Restart immediately"),
 					),
 				},
@@ -778,7 +778,7 @@ func TestAccPolicyResource_RebootFullCoverage(t *testing.T) {
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(
 						"jamfplatform_pro_policy.test",
-						tfjsonpath.New("reboot").AtMapKey("specify_startup"),
+						tfjsonpath.New("restart_options").AtMapKey("specify_startup"),
 						knownvalue.StringExact("Standard Restart"),
 					),
 				},
@@ -788,7 +788,7 @@ func TestAccPolicyResource_RebootFullCoverage(t *testing.T) {
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(
 						"jamfplatform_pro_policy.test",
-						tfjsonpath.New("reboot").AtMapKey("specify_startup"),
+						tfjsonpath.New("restart_options").AtMapKey("specify_startup"),
 						knownvalue.StringExact("MDM Restart with Kernel Cache Rebuild"),
 					),
 				},
@@ -1107,7 +1107,7 @@ resource "jamfplatform_pro_policy" "test" {
   general = {
     name = %q
   }
-  files_processes = {
+  files_and_processes = {
     search_by_path         = %q
     delete_file_if_found   = true
     search_by_filename     = "tf-acc-search-filename"
@@ -1122,7 +1122,7 @@ resource "jamfplatform_pro_policy" "test" {
 }
 
 // TestAccPolicyResource_FilesProcessesFullCoverage exercises every
-// files_processes attribute. Step 2 perturbs two scalar string fields to
+// files_and_processes attribute. Step 2 perturbs two scalar string fields to
 // exercise the Update path.
 func TestAccPolicyResource_FilesProcessesFullCoverage(t *testing.T) {
 	testhelpers.AccPreCheck(t)
@@ -1138,27 +1138,27 @@ func TestAccPolicyResource_FilesProcessesFullCoverage(t *testing.T) {
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(
 						"jamfplatform_pro_policy.test",
-						tfjsonpath.New("files_processes").AtMapKey("search_by_path"),
+						tfjsonpath.New("files_and_processes").AtMapKey("search_by_path"),
 						knownvalue.StringExact("/tmp/tf-acc-search"),
 					),
 					statecheck.ExpectKnownValue(
 						"jamfplatform_pro_policy.test",
-						tfjsonpath.New("files_processes").AtMapKey("delete_file_if_found"),
+						tfjsonpath.New("files_and_processes").AtMapKey("delete_file_if_found"),
 						knownvalue.Bool(true),
 					),
 					statecheck.ExpectKnownValue(
 						"jamfplatform_pro_policy.test",
-						tfjsonpath.New("files_processes").AtMapKey("search_by_filename"),
+						tfjsonpath.New("files_and_processes").AtMapKey("search_by_filename"),
 						knownvalue.StringExact("tf-acc-search-filename"),
 					),
 					statecheck.ExpectKnownValue(
 						"jamfplatform_pro_policy.test",
-						tfjsonpath.New("files_processes").AtMapKey("kill_process_if_found"),
+						tfjsonpath.New("files_and_processes").AtMapKey("kill_process_if_found"),
 						knownvalue.Bool(true),
 					),
 					statecheck.ExpectKnownValue(
 						"jamfplatform_pro_policy.test",
-						tfjsonpath.New("files_processes").AtMapKey("execute_command"),
+						tfjsonpath.New("files_and_processes").AtMapKey("execute_command"),
 						knownvalue.StringExact("echo tf-acc-initial"),
 					),
 				},
@@ -1168,12 +1168,12 @@ func TestAccPolicyResource_FilesProcessesFullCoverage(t *testing.T) {
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(
 						"jamfplatform_pro_policy.test",
-						tfjsonpath.New("files_processes").AtMapKey("search_by_path"),
+						tfjsonpath.New("files_and_processes").AtMapKey("search_by_path"),
 						knownvalue.StringExact("/tmp/tf-acc-search-updated"),
 					),
 					statecheck.ExpectKnownValue(
 						"jamfplatform_pro_policy.test",
-						tfjsonpath.New("files_processes").AtMapKey("execute_command"),
+						tfjsonpath.New("files_and_processes").AtMapKey("execute_command"),
 						knownvalue.StringExact("echo tf-acc-updated"),
 					),
 				},
@@ -1881,33 +1881,31 @@ resource "jamfplatform_pro_policy" "test" {
   general = {
     name = %q
   }
-  account_maintenance = {
-    accounts = [
-      {
-        action               = "Create"
-        username             = "tf-acc-create"
-        realname             = "tf-acc create"
-        password             = "Sup3rS3cret!"
-        password_wo_version  = 1
-        home                 = "/Users/tf-acc-create"
-        hint                 = "tf-acc hint"
-        admin                = true
-        filevault_enabled    = false
-        secure_token_allowed = true
-      },
-      {
-        action              = "Reset"
-        username            = "tf-acc-reset"
-        password            = "Resetting123!"
-        password_wo_version = 1
-      },
-      {
-        action                            = "Delete"
-        username                          = "tf-acc-delete"
-        permanently_delete_home_directory = true
-      },
-    ]
-  }
+  local_accounts = [
+    {
+      action               = "Create"
+      username             = "tf-acc-create"
+      realname             = "tf-acc create"
+      password             = "Sup3rS3cret!"
+      password_wo_version  = 1
+      home                 = "/Users/tf-acc-create"
+      hint                 = "tf-acc hint"
+      admin                = true
+      filevault_enabled    = false
+      secure_token_allowed = true
+    },
+    {
+      action              = "Reset"
+      username            = "tf-acc-reset"
+      password            = "Resetting123!"
+      password_wo_version = 1
+    },
+    {
+      action                            = "Delete"
+      username                          = "tf-acc-delete"
+      permanently_delete_home_directory = true
+    },
+  ]
 }
 `, name)
 }
@@ -1922,38 +1920,36 @@ resource "jamfplatform_pro_policy" "test" {
   general = {
     name = %q
   }
-  account_maintenance = {
-    accounts = [
-      {
-        action               = "Create"
-        username             = "tf-acc-create"
-        realname             = "tf-acc create"
-        password             = "Rotated-pw-1!"
-        password_wo_version  = 2
-        home                 = "/Users/tf-acc-create"
-        hint                 = "tf-acc hint"
-        admin                = true
-        filevault_enabled    = false
-        secure_token_allowed = true
-      },
-      {
-        action              = "Reset"
-        username            = "tf-acc-reset"
-        password            = "Resetting123!"
-        password_wo_version = 1
-      },
-      {
-        action                            = "Delete"
-        username                          = "tf-acc-delete"
-        permanently_delete_home_directory = true
-      },
-      {
-        action                            = "Delete"
-        username                          = "tf-acc-fourth-delete"
-        permanently_delete_home_directory = true
-      },
-    ]
-  }
+  local_accounts = [
+    {
+      action               = "Create"
+      username             = "tf-acc-create"
+      realname             = "tf-acc create"
+      password             = "Rotated-pw-1!"
+      password_wo_version  = 2
+      home                 = "/Users/tf-acc-create"
+      hint                 = "tf-acc hint"
+      admin                = true
+      filevault_enabled    = false
+      secure_token_allowed = true
+    },
+    {
+      action              = "Reset"
+      username            = "tf-acc-reset"
+      password            = "Resetting123!"
+      password_wo_version = 1
+    },
+    {
+      action                            = "Delete"
+      username                          = "tf-acc-delete"
+      permanently_delete_home_directory = true
+    },
+    {
+      action                            = "Delete"
+      username                          = "tf-acc-fourth-delete"
+      permanently_delete_home_directory = true
+    },
+  ]
 }
 `, name)
 }
@@ -1969,33 +1965,31 @@ resource "jamfplatform_pro_policy" "test" {
   general = {
     name = %q
   }
-  account_maintenance = {
-    accounts = [
-      {
-        action               = "Create"
-        username             = "tf-acc-create"
-        realname             = "tf-acc create"
-        password             = "Rotated-pw-1!"
-        password_wo_version  = 2
-        home                 = "/Users/tf-acc-create"
-        hint                 = "tf-acc hint"
-        admin                = true
-        filevault_enabled    = false
-        secure_token_allowed = true
-      },
-      {
-        action              = "Reset"
-        username            = "tf-acc-reset"
-        password            = "Resetting123!"
-        password_wo_version = 1
-      },
-      {
-        action                            = "Delete"
-        username                          = "tf-acc-delete"
-        permanently_delete_home_directory = true
-      },
-    ]
-  }
+  local_accounts = [
+    {
+      action               = "Create"
+      username             = "tf-acc-create"
+      realname             = "tf-acc create"
+      password             = "Rotated-pw-1!"
+      password_wo_version  = 2
+      home                 = "/Users/tf-acc-create"
+      hint                 = "tf-acc hint"
+      admin                = true
+      filevault_enabled    = false
+      secure_token_allowed = true
+    },
+    {
+      action              = "Reset"
+      username            = "tf-acc-reset"
+      password            = "Resetting123!"
+      password_wo_version = 1
+    },
+    {
+      action                            = "Delete"
+      username                          = "tf-acc-delete"
+      permanently_delete_home_directory = true
+    },
+  ]
 }
 `, name)
 }
@@ -2042,28 +2036,28 @@ func TestAccPolicyResource_AccountMaintenanceAccountsFullCoverage(t *testing.T) 
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(
 						"jamfplatform_pro_policy.test",
-						tfjsonpath.New("account_maintenance").AtMapKey("accounts"),
+						tfjsonpath.New("local_accounts"),
 						knownvalue.ListSizeExact(3),
 					),
 					// Positional identity: List indices map to the HCL order.
 					statecheck.ExpectKnownValue(
 						"jamfplatform_pro_policy.test",
-						tfjsonpath.New("account_maintenance").AtMapKey("accounts").AtSliceIndex(0).AtMapKey("username"),
+						tfjsonpath.New("local_accounts").AtSliceIndex(0).AtMapKey("username"),
 						knownvalue.StringExact("tf-acc-create"),
 					),
 					statecheck.ExpectKnownValue(
 						"jamfplatform_pro_policy.test",
-						tfjsonpath.New("account_maintenance").AtMapKey("accounts").AtSliceIndex(1).AtMapKey("username"),
+						tfjsonpath.New("local_accounts").AtSliceIndex(1).AtMapKey("username"),
 						knownvalue.StringExact("tf-acc-reset"),
 					),
 					statecheck.ExpectKnownValue(
 						"jamfplatform_pro_policy.test",
-						tfjsonpath.New("account_maintenance").AtMapKey("accounts").AtSliceIndex(2).AtMapKey("username"),
+						tfjsonpath.New("local_accounts").AtSliceIndex(2).AtMapKey("username"),
 						knownvalue.StringExact("tf-acc-delete"),
 					),
 					statecheck.ExpectKnownValue(
 						"jamfplatform_pro_policy.test",
-						tfjsonpath.New("account_maintenance").AtMapKey("accounts").AtSliceIndex(0).AtMapKey("password_wo_version"),
+						tfjsonpath.New("local_accounts").AtSliceIndex(0).AtMapKey("password_wo_version"),
 						knownvalue.Int64Exact(1),
 					),
 				},
@@ -2076,22 +2070,22 @@ func TestAccPolicyResource_AccountMaintenanceAccountsFullCoverage(t *testing.T) 
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(
 						"jamfplatform_pro_policy.test",
-						tfjsonpath.New("account_maintenance").AtMapKey("accounts"),
+						tfjsonpath.New("local_accounts"),
 						knownvalue.ListSizeExact(3),
 					),
 					statecheck.ExpectKnownValue(
 						"jamfplatform_pro_policy.test",
-						tfjsonpath.New("account_maintenance").AtMapKey("accounts").AtSliceIndex(0).AtMapKey("password_wo_version"),
+						tfjsonpath.New("local_accounts").AtSliceIndex(0).AtMapKey("password_wo_version"),
 						knownvalue.Int64Exact(2),
 					),
 					statecheck.ExpectKnownValue(
 						"jamfplatform_pro_policy.test",
-						tfjsonpath.New("account_maintenance").AtMapKey("accounts").AtSliceIndex(1).AtMapKey("password_wo_version"),
+						tfjsonpath.New("local_accounts").AtSliceIndex(1).AtMapKey("password_wo_version"),
 						knownvalue.Int64Exact(1),
 					),
 					statecheck.ExpectKnownValue(
 						"jamfplatform_pro_policy.test",
-						tfjsonpath.New("account_maintenance").AtMapKey("accounts").AtSliceIndex(0).AtMapKey("username"),
+						tfjsonpath.New("local_accounts").AtSliceIndex(0).AtMapKey("username"),
 						knownvalue.StringExact("tf-acc-create"),
 					),
 				},
@@ -2104,37 +2098,37 @@ func TestAccPolicyResource_AccountMaintenanceAccountsFullCoverage(t *testing.T) 
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(
 						"jamfplatform_pro_policy.test",
-						tfjsonpath.New("account_maintenance").AtMapKey("accounts"),
+						tfjsonpath.New("local_accounts"),
 						knownvalue.ListSizeExact(4),
 					),
 					statecheck.ExpectKnownValue(
 						"jamfplatform_pro_policy.test",
-						tfjsonpath.New("account_maintenance").AtMapKey("accounts").AtSliceIndex(0).AtMapKey("username"),
+						tfjsonpath.New("local_accounts").AtSliceIndex(0).AtMapKey("username"),
 						knownvalue.StringExact("tf-acc-create"),
 					),
 					statecheck.ExpectKnownValue(
 						"jamfplatform_pro_policy.test",
-						tfjsonpath.New("account_maintenance").AtMapKey("accounts").AtSliceIndex(1).AtMapKey("username"),
+						tfjsonpath.New("local_accounts").AtSliceIndex(1).AtMapKey("username"),
 						knownvalue.StringExact("tf-acc-reset"),
 					),
 					statecheck.ExpectKnownValue(
 						"jamfplatform_pro_policy.test",
-						tfjsonpath.New("account_maintenance").AtMapKey("accounts").AtSliceIndex(2).AtMapKey("username"),
+						tfjsonpath.New("local_accounts").AtSliceIndex(2).AtMapKey("username"),
 						knownvalue.StringExact("tf-acc-delete"),
 					),
 					statecheck.ExpectKnownValue(
 						"jamfplatform_pro_policy.test",
-						tfjsonpath.New("account_maintenance").AtMapKey("accounts").AtSliceIndex(3).AtMapKey("username"),
+						tfjsonpath.New("local_accounts").AtSliceIndex(3).AtMapKey("username"),
 						knownvalue.StringExact("tf-acc-fourth-delete"),
 					),
 					statecheck.ExpectKnownValue(
 						"jamfplatform_pro_policy.test",
-						tfjsonpath.New("account_maintenance").AtMapKey("accounts").AtSliceIndex(0).AtMapKey("password_wo_version"),
+						tfjsonpath.New("local_accounts").AtSliceIndex(0).AtMapKey("password_wo_version"),
 						knownvalue.Int64Exact(2),
 					),
 					statecheck.ExpectKnownValue(
 						"jamfplatform_pro_policy.test",
-						tfjsonpath.New("account_maintenance").AtMapKey("accounts").AtSliceIndex(1).AtMapKey("password_wo_version"),
+						tfjsonpath.New("local_accounts").AtSliceIndex(1).AtMapKey("password_wo_version"),
 						knownvalue.Int64Exact(1),
 					),
 				},
@@ -2165,20 +2159,18 @@ resource "jamfplatform_pro_policy" "test" {
   general = {
     name = %q
   }
-  account_maintenance = {
-    directory_bindings = [
-      {
-        id = jamfplatform_pro_directory_binding.fixture.id
-      },
-    ]
-  }
+  directory_bindings = [
+    {
+      id = jamfplatform_pro_directory_binding.fixture.id
+    },
+  ]
 }
 `, dbName, dbUsername, dbPassword, policyName)
 }
 
 // TestAccPolicyResource_AccountMaintenanceDirectoryBindingsFullCoverage
 // creates a jamfplatform_pro_directory_binding fixture and references it
-// from policy.account_maintenance.directory_bindings, asserting the set
+// from policy.directory_bindings, asserting the set
 // round-trips through the policy resource. The fixture uses the Open
 // Directory binding type which has the minimal required-field footprint.
 func TestAccPolicyResource_AccountMaintenanceDirectoryBindingsFullCoverage(t *testing.T) {
@@ -2196,7 +2188,7 @@ func TestAccPolicyResource_AccountMaintenanceDirectoryBindingsFullCoverage(t *te
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(
 						"jamfplatform_pro_policy.test",
-						tfjsonpath.New("account_maintenance").AtMapKey("directory_bindings"),
+						tfjsonpath.New("directory_bindings"),
 						knownvalue.SetSizeExact(1),
 					),
 				},
@@ -2211,13 +2203,11 @@ resource "jamfplatform_pro_policy" "test" {
   general = {
     name = %q
   }
-  account_maintenance = {
-    management_account = {
-      action                      = %q
-      managed_password            = %q
-      managed_password_wo_version = %d
-      managed_password_length     = %d
-    }
+  management_account = {
+    action                      = %q
+    managed_password            = %q
+    managed_password_wo_version = %d
+    managed_password_length     = %d
   }
 }
 `, name, action, managedPassword, woVersion, length)
@@ -2242,7 +2232,7 @@ func TestAccPolicyResource_AccountMaintenanceManagementAccountFullCoverage(t *te
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(
 						"jamfplatform_pro_policy.test",
-						tfjsonpath.New("account_maintenance").AtMapKey("management_account").AtMapKey("action"),
+						tfjsonpath.New("management_account").AtMapKey("action"),
 						knownvalue.StringExact("rotate"),
 					),
 				},
@@ -2252,7 +2242,7 @@ func TestAccPolicyResource_AccountMaintenanceManagementAccountFullCoverage(t *te
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(
 						"jamfplatform_pro_policy.test",
-						tfjsonpath.New("account_maintenance").AtMapKey("management_account").AtMapKey("managed_password_length"),
+						tfjsonpath.New("management_account").AtMapKey("managed_password_length"),
 						knownvalue.Int64Exact(16),
 					),
 				},
@@ -2267,19 +2257,17 @@ resource "jamfplatform_pro_policy" "test" {
   general = {
     name = %q
   }
-  account_maintenance = {
-    open_firmware_efi_password = {
-      of_mode                = %q
-      of_password            = %q
-      of_password_wo_version = %d
-    }
+  efi_password = {
+    of_mode                = %q
+    of_password            = %q
+    of_password_wo_version = %d
   }
 }
 `, name, ofMode, ofPassword, woVersion)
 }
 
 // TestAccPolicyResource_AccountMaintenanceOpenFirmwareEfiPasswordFullCoverage
-// exercises the open_firmware_efi_password block. The plaintext of_password
+// exercises the efi_password block. The plaintext of_password
 // is `WriteOnly` (sent on writes, never persisted in state); rotation is
 // triggered via `of_password_wo_version`. Step 2 switches of_mode
 // `command` → `full` AND bumps `of_password_wo_version` 1 → 2 to exercise
@@ -2298,7 +2286,7 @@ func TestAccPolicyResource_AccountMaintenanceOpenFirmwareEfiPasswordFullCoverage
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(
 						"jamfplatform_pro_policy.test",
-						tfjsonpath.New("account_maintenance").AtMapKey("open_firmware_efi_password").AtMapKey("of_mode"),
+						tfjsonpath.New("efi_password").AtMapKey("of_mode"),
 						knownvalue.StringExact("command"),
 					),
 				},
@@ -2308,7 +2296,7 @@ func TestAccPolicyResource_AccountMaintenanceOpenFirmwareEfiPasswordFullCoverage
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(
 						"jamfplatform_pro_policy.test",
-						tfjsonpath.New("account_maintenance").AtMapKey("open_firmware_efi_password").AtMapKey("of_mode"),
+						tfjsonpath.New("efi_password").AtMapKey("of_mode"),
 						knownvalue.StringExact("full"),
 					),
 				},

--- a/internal/resources/pro/policies/policy/schema_test.go
+++ b/internal/resources/pro/policies/policy/schema_test.go
@@ -22,9 +22,11 @@ func TestPolicyResource_Schema(t *testing.T) {
 		t.Fatalf("schema returned diagnostics: %v", resp.Diagnostics)
 	}
 	must := []string{
-		"id", "general", "scope", "self_service", "package_configuration",
-		"scripts", "printers", "dock_items", "account_maintenance", "reboot",
-		"maintenance", "files_processes", "user_interaction", "disk_encryption",
+		"id", "general", "scope", "self_service", "packages",
+		"scripts", "printers", "dock_items",
+		"local_accounts", "management_account", "directory_bindings", "efi_password",
+		"restart_options",
+		"maintenance", "files_and_processes", "user_interaction", "disk_encryption",
 		"timeouts",
 	}
 	for _, name := range must {

--- a/internal/resources/pro/policies/policy/state_builders.go
+++ b/internal/resources/pro/policies/policy/state_builders.go
@@ -46,8 +46,8 @@ func assignPolicyResourceModel(ctx context.Context, state *PolicyResourceModel, 
 	if state.SelfService != nil && p.SelfService != nil {
 		flattenPolicySelfService(p.SelfService, state.SelfService)
 	}
-	if state.PackageConfiguration != nil && p.PackageConfiguration != nil {
-		flattenPolicyPackageConfiguration(p.PackageConfiguration, state.PackageConfiguration)
+	if state.Packages != nil && p.PackageConfiguration != nil {
+		flattenPolicyPackageConfiguration(p.PackageConfiguration, state.Packages)
 	}
 	if state.Scripts != nil && p.Scripts != nil {
 		flattenPolicyScripts(p.Scripts, state.Scripts)
@@ -58,17 +58,21 @@ func assignPolicyResourceModel(ctx context.Context, state *PolicyResourceModel, 
 	if state.DockItems != nil && p.DockItems != nil {
 		flattenPolicyDockItems(p.DockItems, state.DockItems)
 	}
-	if state.AccountMaintenance != nil && p.AccountMaintenance != nil {
-		flattenPolicyAccountMaintenance(p.AccountMaintenance, state.AccountMaintenance)
+	// The four flattened account-maintenance blocks all read from the single
+	// wire <account_maintenance> object. Each is refreshed only when the
+	// caller already manages it (per-section gate), mirroring the optional
+	// section discipline above.
+	if p.AccountMaintenance != nil {
+		flattenPolicyAccountMaintenance(p.AccountMaintenance, state)
 	}
-	if state.Reboot != nil && p.Reboot != nil {
-		flattenPolicyReboot(p.Reboot, state.Reboot)
+	if state.RestartOptions != nil && p.Reboot != nil {
+		flattenPolicyReboot(p.Reboot, state.RestartOptions)
 	}
 	if state.Maintenance != nil && p.Maintenance != nil {
 		flattenPolicyMaintenance(p.Maintenance, state.Maintenance)
 	}
-	if state.FilesProcesses != nil && p.FilesProcesses != nil {
-		flattenPolicyFilesProcesses(p.FilesProcesses, state.FilesProcesses)
+	if state.FilesAndProcesses != nil && p.FilesProcesses != nil {
+		flattenPolicyFilesProcesses(p.FilesProcesses, state.FilesAndProcesses)
 	}
 	if state.UserInteraction != nil && p.UserInteraction != nil {
 		flattenPolicyUserInteraction(p.UserInteraction, state.UserInteraction)
@@ -398,7 +402,7 @@ func flattenPolicySelfService(ss *proclassic.PolicySelfService, state *PolicySel
 	}
 }
 
-func flattenPolicyPackageConfiguration(pc *proclassic.PolicyPackageConfiguration, state *PolicyPackageConfigurationModel) {
+func flattenPolicyPackageConfiguration(pc *proclassic.PolicyPackageConfiguration, state *PolicyPackagesModel) {
 	state.DistributionPoint = preferCurrentStringPointer(pc.DistributionPoint, state.DistributionPoint)
 
 	if pc.Packages == nil || pc.Packages.Package == nil {
@@ -501,8 +505,14 @@ func flattenPolicyDockItems(d *proclassic.PolicyDockItems, state *PolicyDockItem
 	state.DockItems = out
 }
 
-func flattenPolicyAccountMaintenance(am *proclassic.PolicyAccountMaintenance, state *PolicyAccountMaintenanceModel) {
-	if am.Accounts != nil && am.Accounts.Account != nil {
+// flattenPolicyAccountMaintenance splits the single wire <account_maintenance>
+// object across the four flattened top-level state blocks. Each block is
+// refreshed only when the caller already manages it (state.LocalAccounts /
+// DirectoryBindings non-nil, ManagementAccount / EfiPassword non-nil) —
+// populating an unmanaged section would violate the framework's "produced
+// inconsistent result after apply" check.
+func flattenPolicyAccountMaintenance(am *proclassic.PolicyAccountMaintenance, state *PolicyResourceModel) {
+	if state.LocalAccounts != nil && am.Accounts != nil && am.Accounts.Account != nil {
 		// Reorder wire accounts to match the plan's declared username
 		// order. The Jamf classic /policies endpoint does not preserve
 		// account order on round-trip — entries can come back in
@@ -512,7 +522,7 @@ func flattenPolicyAccountMaintenance(am *proclassic.PolicyAccountMaintenance, st
 		// index than the plan's accounts[i].password).
 		//
 		// `state` here is actually the plan model (CRUD passes &plan to
-		// assignPolicyResourceModel), so state.Accounts holds the plan
+		// assignPolicyResourceModel), so state.LocalAccounts holds the plan
 		// order at this point. We build a wire-keyed-by-username map and
 		// emit in plan order. Any wire-only entries (server echoed a
 		// username not in plan) append at the end so they remain visible.
@@ -532,8 +542,8 @@ func flattenPolicyAccountMaintenance(am *proclassic.PolicyAccountMaintenance, st
 			wireByUsername[*a.Username] = a
 			wireUsernameOrder = append(wireUsernameOrder, *a.Username)
 		}
-		woByUsername := make(map[string]types.Int64, len(state.Accounts))
-		for _, prev := range state.Accounts {
+		woByUsername := make(map[string]types.Int64, len(state.LocalAccounts))
+		for _, prev := range state.LocalAccounts {
 			if !prev.Username.IsNull() && !prev.Username.IsUnknown() {
 				woByUsername[prev.Username.ValueString()] = prev.PasswordWoVersion
 			}
@@ -563,7 +573,7 @@ func flattenPolicyAccountMaintenance(am *proclassic.PolicyAccountMaintenance, st
 		}
 		consumed := make(map[string]bool, len(wireItems))
 		out := make([]PolicyAccountItemModel, 0, len(wireItems))
-		for _, prev := range state.Accounts {
+		for _, prev := range state.LocalAccounts {
 			if prev.Username.IsNull() || prev.Username.IsUnknown() {
 				continue
 			}
@@ -581,12 +591,12 @@ func flattenPolicyAccountMaintenance(am *proclassic.PolicyAccountMaintenance, st
 			out = append(out, emit(wireByUsername[u]))
 			consumed[u] = true
 		}
-		state.Accounts = out
+		state.LocalAccounts = out
 	} else {
-		state.Accounts = nil
+		state.LocalAccounts = nil
 	}
 
-	if am.DirectoryBindings != nil && am.DirectoryBindings.Binding != nil {
+	if state.DirectoryBindings != nil && am.DirectoryBindings != nil && am.DirectoryBindings.Binding != nil {
 		items := *am.DirectoryBindings.Binding
 		out := make([]PolicyDirectoryBindingItemModel, 0, len(items))
 		for _, b := range items {
@@ -616,8 +626,8 @@ func flattenPolicyAccountMaintenance(am *proclassic.PolicyAccountMaintenance, st
 		state.ManagementAccount.ManagedPasswordLength = preferCurrentInt(am.ManagementAccount.ManagedPasswordLength, state.ManagementAccount.ManagedPasswordLength)
 	}
 
-	if state.OpenFirmwareEfiPassword != nil && am.OpenFirmwareEfiPassword != nil {
-		state.OpenFirmwareEfiPassword.OfMode = preferCurrentStringPointer(am.OpenFirmwareEfiPassword.OfMode, state.OpenFirmwareEfiPassword.OfMode)
+	if state.EfiPassword != nil && am.OpenFirmwareEfiPassword != nil {
+		state.EfiPassword.OfMode = preferCurrentStringPointer(am.OpenFirmwareEfiPassword.OfMode, state.EfiPassword.OfMode)
 		// of_password is WriteOnly — framework strips from state.
 		// of_password_wo_version round-trips as a regular Optional Int64;
 		// the API never echoes it, so the prior state value passes through
@@ -625,7 +635,7 @@ func flattenPolicyAccountMaintenance(am *proclassic.PolicyAccountMaintenance, st
 	}
 }
 
-func flattenPolicyReboot(r *proclassic.PolicyReboot, state *PolicyRebootModel) {
+func flattenPolicyReboot(r *proclassic.PolicyReboot, state *PolicyRestartOptionsModel) {
 	state.Message = preferCurrentStringPointer(r.Message, state.Message)
 	state.StartupDisk = preferCurrentStringPointer(r.StartupDisk, state.StartupDisk)
 	state.SpecifyStartup = preferCurrentStringPointer(r.SpecifyStartup, state.SpecifyStartup)
@@ -647,7 +657,7 @@ func flattenPolicyMaintenance(m *proclassic.PolicyMaintenance, state *PolicyMain
 	state.VerifyStartupDisk = preferCurrentBoolPointer(m.Verify, state.VerifyStartupDisk)
 }
 
-func flattenPolicyFilesProcesses(fp *proclassic.PolicyFilesProcesses, state *PolicyFilesProcessesModel) {
+func flattenPolicyFilesProcesses(fp *proclassic.PolicyFilesProcesses, state *PolicyFilesAndProcessesModel) {
 	state.SearchByPath = preferCurrentStringPointer(fp.SearchByPath, state.SearchByPath)
 	state.DeleteFileIfFound = preferCurrentBoolPointer(fp.DeleteFile, state.DeleteFileIfFound)
 	state.SearchByFilename = preferCurrentStringPointer(fp.LocateFile, state.SearchByFilename)

--- a/internal/resources/pro/policies/policy/state_builders_test.go
+++ b/internal/resources/pro/policies/policy/state_builders_test.go
@@ -114,8 +114,8 @@ func TestAssignPolicyResourceModel_RoundTripNotification(t *testing.T) {
 func TestAssignPolicyResourceModel_PackageConfigurationDistributionPoint(t *testing.T) {
 	t.Parallel()
 	state := &PolicyResourceModel{
-		General:              &PolicyGeneralModel{Name: types.StringValue("tf-acc")},
-		PackageConfiguration: &PolicyPackageConfigurationModel{},
+		General:  &PolicyGeneralModel{Name: types.StringValue("tf-acc")},
+		Packages: &PolicyPackagesModel{},
 	}
 	src := &proclassic.Policy{
 		General: &proclassic.PolicyGeneral{Name: new("tf-acc")},
@@ -127,11 +127,11 @@ func TestAssignPolicyResourceModel_PackageConfigurationDistributionPoint(t *test
 	if diags.HasError() {
 		t.Fatalf("unexpected diagnostics: %v", diags)
 	}
-	if state.PackageConfiguration.DistributionPoint.ValueString() != "Dummy DP" {
-		t.Fatalf("expected distribution_point=Dummy DP, got %q", state.PackageConfiguration.DistributionPoint.ValueString())
+	if state.Packages.DistributionPoint.ValueString() != "Dummy DP" {
+		t.Fatalf("expected distribution_point=Dummy DP, got %q", state.Packages.DistributionPoint.ValueString())
 	}
-	if state.PackageConfiguration.Packages != nil {
-		t.Fatalf("expected packages nil when server returned none, got %+v", state.PackageConfiguration.Packages)
+	if state.Packages.Packages != nil {
+		t.Fatalf("expected packages nil when server returned none, got %+v", state.Packages.Packages)
 	}
 }
 
@@ -139,7 +139,7 @@ func TestAssignPolicyResourceModel_PackageConfigurationConfiguredWins(t *testing
 	t.Parallel()
 	state := &PolicyResourceModel{
 		General: &PolicyGeneralModel{Name: types.StringValue("tf-acc")},
-		PackageConfiguration: &PolicyPackageConfigurationModel{
+		Packages: &PolicyPackagesModel{
 			DistributionPoint: types.StringValue("Configured DP"),
 		},
 	}
@@ -153,7 +153,7 @@ func TestAssignPolicyResourceModel_PackageConfigurationConfiguredWins(t *testing
 	if diags.HasError() {
 		t.Fatalf("unexpected diagnostics: %v", diags)
 	}
-	if got := state.PackageConfiguration.DistributionPoint.ValueString(); got != "Configured DP" {
+	if got := state.Packages.DistributionPoint.ValueString(); got != "Configured DP" {
 		t.Fatalf("preferCurrentStringPointer should keep configured value, got %q", got)
 	}
 }


### PR DESCRIPTION
## What

Refactors the `jamfplatform_pro_policy` top-level schema so block names mirror the Jamf Pro admin UI's Options sidebar and tabs, and flattens the wire-shaped `account_maintenance` wrapper into four UI-aligned peer blocks.

### Renames (UI-aligned)
| Before | After | UI section |
|---|---|---|
| `package_configuration` | `packages` | Options ▸ Packages |
| `reboot` | `restart_options` | Options ▸ Restart Options |
| `files_processes` | `files_and_processes` | Options ▸ Files and Processes |

### Flattened `account_maintenance` → 4 peer blocks
`local_accounts` (list), `management_account`, `directory_bindings` (set), `efi_password` — mirroring the UI's Local Accounts / Management Accounts / Directory Bindings / EFI Password sections.

The classic wire still nests all four under a single `<account_maintenance>` object; the input builder **joins** them on write and the state builder **splits** them on read (one `p.AccountMaintenance != nil` call, four per-section `state.X != nil` gates).

### Intentionally out of scope
Software Update and Conditional Access — both obsolete in Jamf Pro, superseded by MDM-driven app installs / OS update scheduling and the patch-management surface.

## Correctness notes
- **WriteOnly secrets** (`local_accounts[].password`, `management_account.managed_password`, `efi_password.of_password`) read struct fields, so they moved with the renames — no silent password drop.
- **Omit guard** preserved: `buildPolicyAccountMaintenance` returns `nil` when all four blocks are absent, so the wire still omits the object.
- **State gating** split from one shared gate into four independent per-section gates.

## Breaking change
This renames public schema attributes. The provider is unshipped, so per repo convention no state upgrader is added.

## Testing
- `make fmt lint test` — green
- `go vet -tags acceptance ./internal/resources/pro/policies/policy/` — green (compiles acc file + printf analyzer over restructured `fmt.Sprintf` configs)
- Acceptance suite — green (run locally by author)
- `make generate` — docs + example regenerated

🤖 Generated with [Claude Code](https://claude.com/claude-code)