### PR TITLE
refactor(policy): model self_service categories as a repeating set

### DIFF
--- a/docs/resources/pro_policy.md
+++ b/docs/resources/pro_policy.md
@@ -62,6 +62,21 @@ resource "jamfplatform_pro_policy" "scoped" {
     notification_location     = "Self Service"
     notification_subject      = "tf-acc"
     notification_message      = "Demo policy now available."
+
+    # A policy can appear in multiple Self Service categories, each with its
+    # own "Display in" / "Feature in" flags.
+    categories = [
+      {
+        id         = "1"
+        display_in = true
+        feature_in = true
+      },
+      {
+        id         = "2"
+        display_in = true
+        feature_in = false
+      },
+    ]
   }
 }
 
@@ -318,7 +333,7 @@ Optional:
 
 Optional:
 
-- `action` (String) Account action. Valid values: `Create`, `Reset`, `Delete`, `DisableFileVault` (the admin UI labels the last action "Disable FileVault" — supply `DisableFileVault` here, with no trailing `2`).
+- `action` (String) Account action. Valid values: `Create`, `Reset`, `Delete`, `DisableFileVault` (the admin UI labels the last action "Disable FileVault" — supply `DisableFileVault` here, with no trailing `2`). **Note:** the Jamf Pro classic `/policies` API silently strips `DisableFileVault` account entries on both create and update — they do not round-trip and the policy will report no such account afterwards (confirmed against the live API regardless of username existence, sibling accounts, or extra fields). Only the Jamf Pro web UI can persist this action. Avoid `DisableFileVault` in Terraform-managed policies; it will produce a perpetual diff.
 - `admin` (Boolean) Whether the account is an admin.
 - `archive_home_directory_to` (String) Destination for the archived home directory. Only meaningful when `permanently_delete_home_directory = false`.
 - `filevault_enabled` (Boolean) Whether FileVault 2 is enabled for the account.
@@ -509,7 +524,7 @@ Optional:
 
 Optional:
 
-- `category` (Attributes) Self Service category under which the policy appears. Only one category may be set. (see [below for nested schema](#nestedatt--self_service--category))
+- `categories` (Attributes Set) Self Service categories under which the policy appears. Each entry carries its own `display_in` / `feature_in` flags, mirroring the admin UI's parallel "Display in" / "Feature in" columns. A policy may appear in multiple categories. (see [below for nested schema](#nestedatt--self_service--categories))
 - `display_notifications` (Boolean) Whether Self Service surfaces a notification when the policy becomes available. Pair with `notification_location` to set the delivery target.
 - `ensure_users_view_description` (Boolean) Force users to view the description before installing.
 - `include_in_featured_category` (Boolean) Feature the policy on the Self Service main page.
@@ -523,15 +538,21 @@ Optional:
 - `self_service_icon` (Attributes) Self Service icon. The icon binary is uploaded out-of-band; the provider surfaces the resolved id, URI, and filename. Uploading the icon bytes inline is not currently supported — open an issue if you need it. (see [below for nested schema](#nestedatt--self_service--self_service_icon))
 - `use_for_self_service` (Boolean) Expose the policy in Self Service.
 
-<a id="nestedatt--self_service--category"></a>
-### Nested Schema for `self_service.category`
+<a id="nestedatt--self_service--categories"></a>
+### Nested Schema for `self_service.categories`
+
+Required:
+
+- `id` (String) Category ID.
 
 Optional:
 
 - `display_in` (Boolean) Display the policy in this category.
 - `feature_in` (Boolean) Feature the policy in this category.
-- `id` (String) Category ID.
-- `name` (String) Category display name.
+
+Read-Only:
+
+- `name` (String) Category display name. Returned by Jamf Pro.
 
 
 <a id="nestedatt--self_service--self_service_icon"></a>

--- a/examples/resources/jamfplatform_pro_policy/resource.tf
+++ b/examples/resources/jamfplatform_pro_policy/resource.tf
@@ -47,6 +47,21 @@ resource "jamfplatform_pro_policy" "scoped" {
     notification_location     = "Self Service"
     notification_subject      = "tf-acc"
     notification_message      = "Demo policy now available."
+
+    # A policy can appear in multiple Self Service categories, each with its
+    # own "Display in" / "Feature in" flags.
+    categories = [
+      {
+        id         = "1"
+        display_in = true
+        feature_in = true
+      },
+      {
+        id         = "2"
+        display_in = true
+        feature_in = false
+      },
+    ]
   }
 }
 

--- a/internal/resources/pro/policies/policy/input_builders.go
+++ b/internal/resources/pro/policies/policy/input_builders.go
@@ -453,17 +453,17 @@ func buildPolicySelfService(m *PolicySelfServiceModel) *proclassic.PolicyPostSel
 		}
 	}
 
-	if m.Category != nil {
-		cat := proclassic.PolicySelfServiceSelfServiceCategoriesCategoryItem{
-			ID:        stringIDPtr(m.Category.ID),
-			Name:      helpers.OptionalStringPointer(m.Category.Name),
-			DisplayIn: optionalBoolPointer(m.Category.DisplayIn),
-			FeatureIn: optionalBoolPointer(m.Category.FeatureIn),
+	if len(m.Categories) > 0 {
+		cats := make([]proclassic.PolicySelfServiceSelfServiceCategoriesCategoryItem, 0, len(m.Categories))
+		for _, c := range m.Categories {
+			cats = append(cats, proclassic.PolicySelfServiceSelfServiceCategoriesCategoryItem{
+				ID:        stringIDPtr(c.ID),
+				Name:      helpers.OptionalStringPointer(c.Name),
+				DisplayIn: optionalBoolPointer(c.DisplayIn),
+				FeatureIn: optionalBoolPointer(c.FeatureIn),
+			})
 		}
-		if cat.ID != nil || cat.Name != nil || cat.DisplayIn != nil || cat.FeatureIn != nil {
-			cats := []proclassic.PolicySelfServiceSelfServiceCategoriesCategoryItem{cat}
-			ss.SelfServiceCategories = &proclassic.PolicySelfServiceSelfServiceCategories{Category: &cats}
-		}
+		ss.SelfServiceCategories = &proclassic.PolicySelfServiceSelfServiceCategories{Category: &cats}
 	}
 
 	return ss

--- a/internal/resources/pro/policies/policy/model_types.go
+++ b/internal/resources/pro/policies/policy/model_types.go
@@ -116,19 +116,19 @@ type PolicyGeneralOverrideDefaultsModel struct {
 // and NotificationLocation project into a single proclassic.NotificationValue
 // — see helpers.go for the split/join logic.
 type PolicySelfServiceModel struct {
-	UseForSelfService          types.Bool                      `tfsdk:"use_for_self_service"`
-	SelfServiceDisplayName     types.String                    `tfsdk:"self_service_display_name"`
-	InstallButtonText          types.String                    `tfsdk:"install_button_text"`
-	ReinstallButtonText        types.String                    `tfsdk:"reinstall_button_text"`
-	SelfServiceDescription     types.String                    `tfsdk:"self_service_description"`
-	EnsureUsersViewDescription types.Bool                      `tfsdk:"ensure_users_view_description"`
-	IncludeInFeaturedCategory  types.Bool                      `tfsdk:"include_in_featured_category"`
-	DisplayNotifications       types.Bool                      `tfsdk:"display_notifications"`
-	NotificationLocation       types.String                    `tfsdk:"notification_location"`
-	NotificationSubject        types.String                    `tfsdk:"notification_subject"`
-	NotificationMessage        types.String                    `tfsdk:"notification_message"`
-	SelfServiceIcon            *PolicySelfServiceIconModel     `tfsdk:"self_service_icon"`
-	Category                   *PolicySelfServiceCategoryModel `tfsdk:"category"`
+	UseForSelfService          types.Bool                           `tfsdk:"use_for_self_service"`
+	SelfServiceDisplayName     types.String                         `tfsdk:"self_service_display_name"`
+	InstallButtonText          types.String                         `tfsdk:"install_button_text"`
+	ReinstallButtonText        types.String                         `tfsdk:"reinstall_button_text"`
+	SelfServiceDescription     types.String                         `tfsdk:"self_service_description"`
+	EnsureUsersViewDescription types.Bool                           `tfsdk:"ensure_users_view_description"`
+	IncludeInFeaturedCategory  types.Bool                           `tfsdk:"include_in_featured_category"`
+	DisplayNotifications       types.Bool                           `tfsdk:"display_notifications"`
+	NotificationLocation       types.String                         `tfsdk:"notification_location"`
+	NotificationSubject        types.String                         `tfsdk:"notification_subject"`
+	NotificationMessage        types.String                         `tfsdk:"notification_message"`
+	SelfServiceIcon            *PolicySelfServiceIconModel          `tfsdk:"self_service_icon"`
+	Categories                 []PolicySelfServiceCategoryItemModel `tfsdk:"categories"`
 }
 
 // PolicySelfServiceIconModel models <self_service><self_service_icon>.
@@ -138,9 +138,11 @@ type PolicySelfServiceIconModel struct {
 	Filename types.String `tfsdk:"filename"`
 }
 
-// PolicySelfServiceCategoryModel models <self_service><self_service_categories><category>.
-// SDK collapses the wrapper into a single child — schema follows.
-type PolicySelfServiceCategoryModel struct {
+// PolicySelfServiceCategoryItemModel models a single
+// <self_service><self_service_categories><category>. The wire carries a
+// repeating <category> element — each entry has its own display/feature
+// flags (admin UI: the parallel "Display in" / "Feature in" columns).
+type PolicySelfServiceCategoryItemModel struct {
 	ID        types.String `tfsdk:"id"`
 	Name      types.String `tfsdk:"name"`
 	DisplayIn types.Bool   `tfsdk:"display_in"`

--- a/internal/resources/pro/policies/policy/resource.go
+++ b/internal/resources/pro/policies/policy/resource.go
@@ -265,14 +265,23 @@ func (r *PolicyResource) Schema(ctx context.Context, req resource.SchemaRequest,
 							"filename": optComputedString("Icon filename. Returned by Jamf Pro."),
 						},
 					},
-					"category": schema.SingleNestedAttribute{
-						MarkdownDescription: "Self Service category under which the policy appears. Only one category may be set.",
+					"categories": schema.SetNestedAttribute{
+						MarkdownDescription: "Self Service categories under which the policy appears. Each entry carries its own `display_in` / `feature_in` flags, mirroring the admin UI's parallel \"Display in\" / \"Feature in\" columns. A policy may appear in multiple categories.",
 						Optional:            true,
-						Attributes: map[string]schema.Attribute{
-							"id":         optComputedString("Category ID."),
-							"name":       optComputedString("Category display name."),
-							"display_in": optComputedBool("Display the policy in this category."),
-							"feature_in": optComputedBool("Feature the policy in this category."),
+						NestedObject: schema.NestedAttributeObject{
+							Attributes: map[string]schema.Attribute{
+								"id": schema.StringAttribute{MarkdownDescription: "Category ID.", Required: true},
+								// `name` is server-derived from the (mutable) `id`. It MUST be
+								// plain Computed — NOT Optional+Computed+UseNonNullStateForUnknown.
+								// In a Set, flipping a sibling element's flag changes that
+								// element's hash, so the framework can't pair it to prior state;
+								// a USFU-carried known `name` then mis-correlates and trips
+								// "produced an inconsistent result after apply … does not correlate".
+								// Leaving `name` Unknown at plan defers Set correlation cleanly.
+								"name":       schema.StringAttribute{MarkdownDescription: "Category display name. Returned by Jamf Pro.", Computed: true},
+								"display_in": optComputedBool("Display the policy in this category."),
+								"feature_in": optComputedBool("Feature the policy in this category."),
+							},
 						},
 					},
 				},
@@ -386,7 +395,7 @@ func (r *PolicyResource) Schema(ctx context.Context, req resource.SchemaRequest,
 				NestedObject: schema.NestedAttributeObject{
 					Attributes: map[string]schema.Attribute{
 						"action": schema.StringAttribute{
-							MarkdownDescription: "Account action. Valid values: `Create`, `Reset`, `Delete`, `DisableFileVault` (the admin UI labels the last action \"Disable FileVault\" — supply `DisableFileVault` here, with no trailing `2`).",
+							MarkdownDescription: "Account action. Valid values: `Create`, `Reset`, `Delete`, `DisableFileVault` (the admin UI labels the last action \"Disable FileVault\" — supply `DisableFileVault` here, with no trailing `2`). **Note:** the Jamf Pro classic `/policies` API silently strips `DisableFileVault` account entries on both create and update — they do not round-trip and the policy will report no such account afterwards (confirmed against the live API regardless of username existence, sibling accounts, or extra fields). Only the Jamf Pro web UI can persist this action. Avoid `DisableFileVault` in Terraform-managed policies; it will produce a perpetual diff.",
 							Optional:            true,
 							Computed:            true,
 							PlanModifiers:       []planmodifier.String{stringplanmodifier.UseNonNullStateForUnknown()},

--- a/internal/resources/pro/policies/policy/resource_acceptance_test.go
+++ b/internal/resources/pro/policies/policy/resource_acceptance_test.go
@@ -175,6 +175,48 @@ resource "jamfplatform_pro_policy" "test" {
 `, name, name)
 }
 
+// policyConfigSelfServiceCategories builds a policy in TWO Self Service
+// categories with distinct per-entry flags (firstFeatureIn controls the
+// first category's feature_in; the second is always feature_in=false). Two
+// category fixtures supply the referenced IDs. This is the lossy case the
+// pre-migration [0]-only read silently collapsed to a single category.
+func policyConfigSelfServiceCategories(name string, firstFeatureIn bool) string {
+	return fmt.Sprintf(`
+resource "jamfplatform_pro_category" "a" {
+  name     = %q
+  priority = 9
+}
+
+resource "jamfplatform_pro_category" "b" {
+  name     = %q
+  priority = 9
+}
+
+resource "jamfplatform_pro_policy" "test" {
+  general = {
+    name    = %q
+    enabled = true
+  }
+  self_service = {
+    use_for_self_service      = true
+    self_service_display_name = %q
+    categories = [
+      {
+        id         = jamfplatform_pro_category.a.id
+        display_in = true
+        feature_in = %t
+      },
+      {
+        id         = jamfplatform_pro_category.b.id
+        display_in = true
+        feature_in = false
+      },
+    ]
+  }
+}
+`, name+"-a", name+"-b", name, name, firstFeatureIn)
+}
+
 func policyConfigAllComputers(name string) string {
 	return fmt.Sprintf(`
 resource "jamfplatform_pro_policy" "test" {
@@ -357,6 +399,73 @@ func TestAccPolicyResource_SelfServiceNotificationSplit(t *testing.T) {
 						"jamfplatform_pro_policy.test",
 						tfjsonpath.New("self_service").AtMapKey("notification_location"),
 						knownvalue.StringExact("Self Service"),
+					),
+				},
+			},
+		},
+	})
+}
+
+// TestAccPolicyResource_SelfServiceMultiCategory is the regression test for the
+// self_service.categories migration (SingleNested → SetNested). The classic
+// /policies wire carries a repeating <category> element; the pre-migration
+// model read only index [0], silently dropping every category after the first
+// along with its independent display_in/feature_in flags. Step 1 declares two
+// categories with distinct feature_in values — a green size-2 set, with one
+// element feature_in=true and one feature_in=false, IS the assertion that both
+// survive the round-trip. Step 2 flips the first category's feature_in in place
+// to exercise per-element flag mutation idempotency.
+func TestAccPolicyResource_SelfServiceMultiCategory(t *testing.T) {
+	testhelpers.AccPreCheck(t)
+	suffix := testhelpers.RunSuffix()
+	name := "tf-acc-policy-sscat-" + suffix
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testhelpers.AccTestProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckPolicyDestroy(t),
+		Steps: []resource.TestStep{
+			{
+				Config: policyConfigSelfServiceCategories(name, true),
+				ConfigStateChecks: []statecheck.StateCheck{
+					// Both categories survive the round-trip — the
+					// pre-migration [0]-only read would collapse this to 1.
+					statecheck.ExpectKnownValue(
+						"jamfplatform_pro_policy.test",
+						tfjsonpath.New("self_service").AtMapKey("categories"),
+						knownvalue.SetSizeExact(2),
+					),
+					// …and the two entries carry DISTINCT feature_in flags
+					// (SetPartial consumes each match, so this requires two
+					// separate elements). ObjectPartial matches only
+					// feature_in, sidestepping the Computed name/id.
+					statecheck.ExpectKnownValue(
+						"jamfplatform_pro_policy.test",
+						tfjsonpath.New("self_service").AtMapKey("categories"),
+						knownvalue.SetPartial([]knownvalue.Check{
+							knownvalue.ObjectPartial(map[string]knownvalue.Check{"feature_in": knownvalue.Bool(true)}),
+							knownvalue.ObjectPartial(map[string]knownvalue.Check{"feature_in": knownvalue.Bool(false)}),
+						}),
+					),
+				},
+			},
+			{
+				// Flip the first category's feature_in true→false in place;
+				// both categories must still round-trip, both now feature_in
+				// =false, and the apply must converge cleanly.
+				Config: policyConfigSelfServiceCategories(name, false),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"jamfplatform_pro_policy.test",
+						tfjsonpath.New("self_service").AtMapKey("categories"),
+						knownvalue.SetSizeExact(2),
+					),
+					statecheck.ExpectKnownValue(
+						"jamfplatform_pro_policy.test",
+						tfjsonpath.New("self_service").AtMapKey("categories"),
+						knownvalue.SetPartial([]knownvalue.Check{
+							knownvalue.ObjectPartial(map[string]knownvalue.Check{"feature_in": knownvalue.Bool(false)}),
+							knownvalue.ObjectPartial(map[string]knownvalue.Check{"feature_in": knownvalue.Bool(false)}),
+						}),
 					),
 				},
 			},

--- a/internal/resources/pro/policies/policy/state_builders.go
+++ b/internal/resources/pro/policies/policy/state_builders.go
@@ -393,12 +393,27 @@ func flattenPolicySelfService(ss *proclassic.PolicySelfService, state *PolicySel
 		state.SelfServiceIcon.Filename = preferCurrentStringPointer(ss.SelfServiceIcon.Filename, state.SelfServiceIcon.Filename)
 	}
 
-	if state.Category != nil && ss.SelfServiceCategories != nil && ss.SelfServiceCategories.Category != nil && len(*ss.SelfServiceCategories.Category) > 0 {
-		c := (*ss.SelfServiceCategories.Category)[0]
-		state.Category.ID = preferCurrentStringPointer(stringFromIntPtr(c.ID), state.Category.ID)
-		state.Category.Name = preferCurrentStringPointer(c.Name, state.Category.Name)
-		state.Category.DisplayIn = preferCurrentBoolPointer(c.DisplayIn, state.Category.DisplayIn)
-		state.Category.FeatureIn = preferCurrentBoolPointer(c.FeatureIn, state.Category.FeatureIn)
+	// Self Service categories are an unordered Set; rebuild the slice
+	// directly from the wire. The classic /policies endpoint always echoes
+	// id/name/display_in/feature_in for each surviving category, so the
+	// Optional+Computed flags never come back null (no preferCurrent
+	// needed). Refresh only when the caller manages the block.
+	if state.Categories != nil {
+		if ss.SelfServiceCategories != nil && ss.SelfServiceCategories.Category != nil {
+			items := *ss.SelfServiceCategories.Category
+			out := make([]PolicySelfServiceCategoryItemModel, 0, len(items))
+			for _, c := range items {
+				out = append(out, PolicySelfServiceCategoryItemModel{
+					ID:        helpers.StringValueFromIntPtr(c.ID),
+					Name:      helpers.StringPointerValueOrNull(c.Name),
+					DisplayIn: helpers.BoolPointerValueOrNull(c.DisplayIn),
+					FeatureIn: helpers.BoolPointerValueOrNull(c.FeatureIn),
+				})
+			}
+			state.Categories = out
+		} else {
+			state.Categories = []PolicySelfServiceCategoryItemModel{}
+		}
 	}
 }
 


### PR DESCRIPTION
## What

Migrates `jamfplatform_pro_policy.self_service.category` (SingleNested) → `self_service.categories` (SetNested), and documents a wire-proven `DisableFileVault` limitation. Closes two Phase 2.6 follow-ups (Project #2).

## Why — the bug

The classic `/policies` wire carries a **repeating** `<category>` element under `<self_service_categories>`, each with its own `display_in` / `feature_in` flags (the admin UI's parallel "Display in" / "Feature in" columns). The provider modelled it as a single `category` block, so the read path took only index `[0]` — **silently dropping every category after the first** along with its independent flags. Wire baseline (policy 6791, two categories with distinct `feature_in`) confirmed the loss.

## Changes

- **Schema:** `self_service.category` SingleNested → `self_service.categories` SetNested. Breaking rename + reshape (provider unshipped → no state upgrader).
  - Set, not List: categories are unordered membership, the endpoint doesn't preserve order on round-trip, and there's no WriteOnly field forcing a List.
  - `id` now **Required**, matching the sibling package/script/printer/dock collections.
  - `name` is **plain Computed** (not Optional+Computed+USFU). It's server-derived from the mutable `id`; in a Set, a USFU-carried known `name` mis-correlates when a sibling element's flag changes, tripping *"produced an inconsistent result after apply … does not correlate"*. Leaving it Unknown at plan defers Set correlation cleanly.
- **Builders:** input builder iterates the slice; state builder rebuilds it directly from the wire (no `preferCurrent` — the endpoint always echoes the flags).
- **DisableFileVault doc note:** wire-probed against the live classic API — `<account><action>DisableFileVault</action>` is **silently stripped on both create and update**, regardless of username existence, sibling accounts, or extra fields (control: `Create` survives the same XML shape). Only the Jamf Pro web UI persists it. Documented on the `local_accounts.action` attribute as a perpetual-diff warning; no survival acc test (impossible).
- Example + regenerated docs.

## Tests

`TestAccPolicyResource_SelfServiceMultiCategory` (passing): two categories with distinct `feature_in`; step 2 flips a flag in place. `SetSizeExact(2)` is the load-bearing regression assertion (the pre-migration `[0]`-read collapsed it to 1); `SetPartial`+`ObjectPartial` proves distinct flags on a path-robust statecheck. Step 2 is what surfaced and validates the `name` correlation fix above.

`make fmt lint test` green; `make generate` clean.

## Not in scope

Device Compliance category probe (#13) remains blocked — needs an Intune-enabled tenant with the checkbox definitively ON to capture the wire shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)