### PR TITLE
feat(criteria): directory-service group criteria (name↔base64) across 5 resources

### DIFF
--- a/docs/resources/device_group.md
+++ b/docs/resources/device_group.md
@@ -56,6 +56,25 @@ resource "jamfplatform_device_group" "example_smart_computer_group" {
   ]
 }
 
+# Directory-service (LDAP / cloud-IdP) group criteria. Write the group by NAME and
+# the provider resolves it to the base64 {uuid,serverId} value the API stores
+# (and back again on read, so state keeps the readable name). A raw base64 value
+# is also accepted verbatim — useful to disambiguate a name that exists on more
+# than one directory server, or to paste a value straight from the API/UI.
+resource "jamfplatform_device_group" "example_directory_service_group" {
+  name        = "Example Directory Service Smart Group"
+  group_type  = "smart"
+  device_type = "computer"
+  description = "Members of a directory-service group"
+  criteria = [
+    {
+      criteria = "Username directory service group"
+      operator = "member of"
+      value    = "MyDirectoryGroupName" # resolved to base64 on apply
+    },
+  ]
+}
+
 # The Computed `jamf_pro_id` attribute exposes the numeric Jamf Pro classic ID
 # for the group. Reference it from classic-API scope blocks (policies,
 # configuration profiles, restricted software). The value is null when the

--- a/examples/resources/jamfplatform_device_group/resource.tf
+++ b/examples/resources/jamfplatform_device_group/resource.tf
@@ -41,6 +41,25 @@ resource "jamfplatform_device_group" "example_smart_computer_group" {
   ]
 }
 
+# Directory-service (LDAP / cloud-IdP) group criteria. Write the group by NAME and
+# the provider resolves it to the base64 {uuid,serverId} value the API stores
+# (and back again on read, so state keeps the readable name). A raw base64 value
+# is also accepted verbatim — useful to disambiguate a name that exists on more
+# than one directory server, or to paste a value straight from the API/UI.
+resource "jamfplatform_device_group" "example_directory_service_group" {
+  name        = "Example Directory Service Smart Group"
+  group_type  = "smart"
+  device_type = "computer"
+  description = "Members of a directory-service group"
+  criteria = [
+    {
+      criteria = "Username directory service group"
+      operator = "member of"
+      value    = "MyDirectoryGroupName" # resolved to base64 on apply
+    },
+  ]
+}
+
 # The Computed `jamf_pro_id` attribute exposes the numeric Jamf Pro classic ID
 # for the group. Reference it from classic-API scope blocks (policies,
 # configuration profiles, restricted software). The value is null when the

--- a/internal/common/criteria/dsgroup.go
+++ b/internal/common/criteria/dsgroup.go
@@ -1,0 +1,514 @@
+// Copyright Jamf Software LLC 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package criteria
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+
+	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/common/ldapgroups"
+)
+
+// Directory-service group criteria (Jamf Pro 11.29+) carry a base64-encoded JSON
+// object — {"uuid":"…","serverId":"…"} — as their criterion VALUE, not a group
+// name. This file maps a human-friendly group name <-> that wire blob so a user
+// can write a directory group by name (and the provider resolves + encodes it),
+// while a power user may still paste the raw base64 verbatim. See
+// spike/DIRECTORY_SERVICE_GROUP_CRITERIA_SPIKE.md for the wire-probe results.
+//
+// Two questions are kept distinct (the "set A / set B" split):
+//   - set A — "is this a directory-service group criterion at all?" Membership
+//     triggers value encoding. Class-agnostic: the five canonical names below.
+//   - set B — the per-object-class allowlist of names the corresponding Jamf API
+//     surface actually accepts (computer 5 / mobile 4 / user 1). A name in A but
+//     not in B's class is rejected at plan (fail-closed) with a clear message,
+//     rather than shipping a literal group name the server would 409/400 on.
+//
+// The criterion names are the server-canonical TITLE-CASE forms enumerated by
+// live probe (re-probed 2026-06-17 against platform-nmartin). Every surface —
+// Platform device-groups AND the classic/Pro searches — is CASE-SENSITIVE on the
+// whole string: the lowercase doc form ("Assigned user…") and an all-caps "MDM"
+// are both rejected (400 INVALID_FIELD / 409 "Problem with criteria"). The MDM
+// criterion's canonical token is "Mdm" (title-case), not "MDM" — an earlier
+// spike probed it as "MDM", got rejected everywhere, and wrongly excluded it. It
+// IS accepted (as "Mdm") on computer + mobile. The Jamf 11.29 doc table is NOT
+// authoritative on casing.
+
+// ObjectType is the inventory object class a criteria-bearing resource targets.
+// It dispatches the per-class directory-service group allowlist (set B).
+type ObjectType int
+
+const (
+	// ObjectTypeComputer covers device_group (computer) + advanced_computer_search.
+	ObjectTypeComputer ObjectType = iota
+	// ObjectTypeMobile covers device_group (mobile) + advanced_mobile_device_search.
+	ObjectTypeMobile
+	// ObjectTypeUser covers user_group + advanced_user_search.
+	ObjectTypeUser
+)
+
+// Server-canonical directory-service group criterion names (exact, case-sensitive).
+// Note "Mdm" is title-case, not "MDM" — the server rejects the all-caps form.
+const (
+	dsAssignedUser    = "Assigned User directory service group"
+	dsUsername        = "Username directory service group"
+	dsULLIComputer    = "User last logged in - Computer directory service group"
+	dsULLISelfService = "User last logged in - Self Service directory service group"
+	dsULLIMdm         = "User last logged in - Mdm directory service group"
+)
+
+// dsGroupNamesAll (set A) is every directory-service group criterion name across
+// all object classes. Membership means "the value must be encoded".
+var dsGroupNamesAll = map[string]bool{
+	dsAssignedUser:    true,
+	dsUsername:        true,
+	dsULLIComputer:    true,
+	dsULLISelfService: true,
+	dsULLIMdm:         true,
+}
+
+// dsGroupAllowlist (set B) is the per-object-class set of accepted names, from
+// the empirical matrix (re-probed 2026-06-17). Computer accepts all five; mobile
+// accepts all but the Computer criterion (400 INVALID_FIELD); the user surfaces
+// accept only Username (everything else 409 "Problem with criteria").
+// advanced_computer_search ≡ device_group COMPUTER; advanced_mobile_device_search
+// ≡ device_group MOBILE; advanced_user_search ≡ user_group.
+var dsGroupAllowlist = map[ObjectType]map[string]bool{
+	ObjectTypeComputer: {
+		dsAssignedUser:    true,
+		dsUsername:        true,
+		dsULLIComputer:    true,
+		dsULLISelfService: true,
+		dsULLIMdm:         true,
+	},
+	ObjectTypeMobile: {
+		dsAssignedUser:    true,
+		dsUsername:        true,
+		dsULLISelfService: true,
+		dsULLIMdm:         true,
+	},
+	ObjectTypeUser: {
+		dsUsername: true,
+	},
+}
+
+// uuidPattern matches the canonical 8-4-4-4-12 hex UUID form. Case-insensitive:
+// validation must not reject a valid-but-lowercase uuid (the wire is uppercase,
+// but a pasted blob is preserved verbatim — see ResolveValue).
+var uuidPattern = regexp.MustCompile(`^[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}$`)
+
+// ErrNoUUID is returned when a directory group resolves but carries no uuid (the
+// Okta default-mappings trap — Jamf rejects saving a smart group whose group has
+// no uuid, so the provider must fail loudly rather than encode an empty uuid).
+var ErrNoUUID = errors.New("directory group has no uuid mapping")
+
+// dsGroupRef is the decoded criterion value: {"uuid":"…","serverId":"…"}. Field
+// order matters: json.Marshal emits in declaration order, matching the UI's
+// {"uuid","serverId"} byte layout so a resolved value round-trips byte-stable.
+type dsGroupRef struct {
+	UUID     string `json:"uuid"`
+	ServerID string `json:"serverId"`
+}
+
+// IsDSGroupCriterion reports whether attributeName is a directory-service group
+// criterion (set A) — i.e. its value must be encoded/decoded. Class-agnostic.
+func IsDSGroupCriterion(attributeName string) bool {
+	return dsGroupNamesAll[attributeName]
+}
+
+// isAllowedDSGroupCriterion reports whether attributeName is accepted on the
+// given object class (set B).
+func isAllowedDSGroupCriterion(ot ObjectType, attributeName string) bool {
+	return dsGroupAllowlist[ot][attributeName]
+}
+
+// supportedDSGroupNames returns the accepted names for an object class, for use
+// in the fail-closed error message.
+func supportedDSGroupNames(ot ObjectType) []string {
+	set := dsGroupAllowlist[ot]
+	// Stable, canonical order matching the const declarations.
+	ordered := []string{dsAssignedUser, dsUsername, dsULLIComputer, dsULLISelfService, dsULLIMdm}
+	out := make([]string, 0, len(set))
+	for _, n := range ordered {
+		if set[n] {
+			out = append(out, n)
+		}
+	}
+	return out
+}
+
+// encodeDSGroupValue marshals a ref to its base64 wire form.
+func encodeDSGroupValue(ref dsGroupRef) string {
+	b, _ := json.Marshal(ref) // struct with string fields never fails to marshal
+	return base64.StdEncoding.EncodeToString(b)
+}
+
+// EncodeDSGroupValue returns the base64 {uuid,serverId} wire value for a resolved
+// directory-service group, matching exactly what ResolveValue produces from a
+// name. Exposed as a deterministic, offline escape hatch (and for tests) so a
+// caller holding a uuid + server id can build the raw value the API stores.
+func EncodeDSGroupValue(uuid, serverID string) string {
+	return encodeDSGroupValue(dsGroupRef{UUID: uuid, ServerID: serverID})
+}
+
+// ParseEncodedValue base64-decodes + JSON-parses value and validates the shape.
+//
+//   - ok=false, err=nil → "not an encoded value" → the caller treats value as a
+//     group NAME (the §1a discriminator: a real group name does not base64-decode
+//     to a {uuid,serverId} object).
+//   - ok=true, err=nil → value is a valid pre-encoded blob → pass through verbatim.
+//   - err!=nil → value LOOKED encoded (decoded to a JSON object carrying a uuid or
+//     serverId key) but is malformed (empty/short field, bad uuid) → fail-closed.
+//
+// Offline (no API call).
+func ParseEncodedValue(value string) (dsGroupRef, bool, error) {
+	decoded, err := base64.StdEncoding.DecodeString(value)
+	if err != nil {
+		return dsGroupRef{}, false, nil // not base64 → a name
+	}
+	// Must decode to a JSON object; otherwise it is not our shape → a name.
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(decoded, &raw); err != nil {
+		return dsGroupRef{}, false, nil
+	}
+	_, hasUUID := raw["uuid"]
+	_, hasServer := raw["serverId"]
+	if !hasUUID && !hasServer {
+		return dsGroupRef{}, false, nil // a JSON object, but not a DS-group ref → a name
+	}
+	// It looked encoded — validate strictly, error on any defect.
+	var ref dsGroupRef
+	if err := json.Unmarshal(decoded, &ref); err != nil {
+		return dsGroupRef{}, false, fmt.Errorf("value decodes to base64 but is not a valid directory-service group reference: %w", err)
+	}
+	if ref.UUID == "" {
+		return dsGroupRef{}, false, fmt.Errorf("encoded directory-service group value has an empty uuid (the directory lookup returned no uuid mapping — e.g. Okta with default mappings)")
+	}
+	if !uuidPattern.MatchString(ref.UUID) {
+		return dsGroupRef{}, false, fmt.Errorf("encoded directory-service group value has a malformed uuid %q", ref.UUID)
+	}
+	if ref.ServerID == "" {
+		return dsGroupRef{}, false, fmt.Errorf("encoded directory-service group value has an empty serverId")
+	}
+	return ref, true, nil
+}
+
+// ResolveValue is the write-path entry point for a directory-service group
+// criterion value. If value is already a valid encoded blob it is returned
+// verbatim (pass-through). Otherwise value is treated as a group NAME, resolved
+// across all configured LDAP servers, and encoded.
+//
+// Hard errors (the config is wrong and must be fixed before apply succeeds):
+// malformed base64 blob, group not found, ambiguous name (matches >1 server),
+// or a resolved group with no uuid (ErrNoUUID).
+func ResolveValue(ctx context.Context, resolver ldapgroups.Searcher, value string) (string, error) {
+	_, ok, err := ParseEncodedValue(value)
+	if err != nil {
+		return "", err // looked encoded but malformed → fail-closed
+	}
+	if ok {
+		return value, nil // already encoded → pass through verbatim
+	}
+
+	groups, err := ldapgroups.ResolveByName(ctx, resolver, value)
+	if err != nil {
+		return "", fmt.Errorf("resolving directory-service group %q: %w", value, err)
+	}
+	switch len(groups) {
+	case 0:
+		return "", fmt.Errorf("%w: %q (no directory group with this exact name on any configured LDAP server)", ldapgroups.ErrGroupNotFound, value)
+	case 1:
+		// ok
+	default:
+		return "", fmt.Errorf("%w: %q matches groups on %d LDAP servers — paste the base64 {uuid,serverId} value to disambiguate", ldapgroups.ErrAmbiguousGroup, value, len(groups))
+	}
+
+	g := groups[0]
+	if g.UUID == "" {
+		return "", fmt.Errorf("%w: %q (Jamf rejects saving a directory-service group criterion without a uuid)", ErrNoUUID, value)
+	}
+	return encodeDSGroupValue(dsGroupRef{UUID: g.UUID, ServerID: strconv.Itoa(g.LdapServerID)}), nil
+}
+
+// ResolveCriterionValue is the per-criterion write-path helper for consumers
+// whose criterion model is NOT CriterionModel (device_group, user_group). It
+// encapsulates the set-A trigger, the set-B fail-closed check, and value
+// resolution:
+//
+//   - non-DS-group criterion → returns value unchanged, isDS=false, no error.
+//   - DS-group criterion not accepted on this object class → isDS=true and a
+//     fail-closed error listing the supported names.
+//   - DS-group criterion accepted → resolves/encodes the value (isDS=true); a
+//     resolution failure (not found / ambiguous / no uuid / malformed) is returned.
+//
+// Callers loop over their own model, set the returned wire value, and record an
+// authored[wire]=originalValue entry when isDS so the read-back can restore the
+// authored form (mirror RestoreAuthoredDSGroupCriteria / ReadValue).
+func ResolveCriterionValue(ctx context.Context, resolver ldapgroups.Searcher, ot ObjectType, name, value string) (string, bool, error) {
+	if !IsDSGroupCriterion(name) {
+		return value, false, nil
+	}
+	if !isAllowedDSGroupCriterion(ot, name) {
+		return value, true, fmt.Errorf("criterion %q is not supported on this resource; supported directory-service group criteria: %s",
+			name, strings.Join(supportedDSGroupNames(ot), ", "))
+	}
+	wire, err := ResolveValue(ctx, resolver, value)
+	if err != nil {
+		return value, true, err
+	}
+	return wire, true, nil
+}
+
+// ReadValue maps a wire base64 value back to the state value, preserving the
+// form the user authored. SOFT: it never propagates a resolution error — a prior
+// name that no longer resolves (group deleted/renamed server-side, or a transient
+// API blip) is surfaced as drift by returning the wire base64, so a single
+// server-side change does not break every subsequent `terraform plan`.
+//
+//   - prior is empty (import / data source) → return wire (base64 is first-class).
+//   - prior is itself an encoded blob → keep it if it equals wire, else wire (drift).
+//   - prior is a NAME → re-resolve; if it re-encodes to wire, keep the name; else
+//     return wire (the group changed → drift).
+func ReadValue(ctx context.Context, resolver ldapgroups.Searcher, wire, prior string) string {
+	if prior == "" {
+		return wire
+	}
+	if _, ok, err := ParseEncodedValue(prior); ok && err == nil {
+		if prior == wire {
+			return prior
+		}
+		return wire // both base64, differ → drift
+	}
+	// prior is a name (or a malformed blob we treat as a name): re-resolve.
+	encoded, err := ResolveValue(ctx, resolver, prior)
+	if err != nil {
+		return wire // soft: surface as drift, never error on read
+	}
+	if encoded == wire {
+		return prior
+	}
+	return wire
+}
+
+// ---- CriterionModel layer (the shared CriterionModel consumers) -------------
+//
+// These three functions wire the primitives above into the []CriterionModel path
+// shared by advanced_computer_search, advanced_user_search,
+// advanced_mobile_device_search and user_group. device_group has its own model
+// and wires the primitives directly.
+
+// ResolveDSGroupCriteria resolves the value of every directory-service group
+// criterion (set A) in models from a group NAME to the base64 wire form
+// (pass-through when already encoded). Non-DS-group criteria are untouched.
+//
+// It returns a COPY of models with resolved values, plus an authored map keyed by
+// the resolved wire value → the original authored value (name or base64). The map
+// lets Create/Update restore the authored form after the read-back flatten without
+// a second API call (RestoreAuthoredDSGroupCriteria), sidestepping any index
+// realignment from the priority sort in BuildCriterionSlice.
+//
+// A name in set A but not accepted on this object class (set B) is rejected
+// (fail-closed, spike §7.3); resolution failures (not found / ambiguous / no uuid
+// / malformed blob) surface as errors. Call in Create/Update before Build*.
+func ResolveDSGroupCriteria(ctx context.Context, resolver ldapgroups.Searcher, ot ObjectType, models []CriterionModel) ([]CriterionModel, map[string]string, diag.Diagnostics) {
+	var diags diag.Diagnostics
+	if len(models) == 0 {
+		return models, nil, diags // preserve nil/empty; never flip nil -> []
+	}
+	authored := map[string]string{}
+	out := make([]CriterionModel, len(models))
+	copy(out, models)
+
+	for i := range out {
+		name := out[i].Name.ValueString()
+		original := out[i].Value.ValueString()
+		wire, isDS, err := ResolveCriterionValue(ctx, resolver, ot, name, original)
+		if !isDS {
+			continue
+		}
+		if err != nil {
+			diags.AddError(
+				"Invalid directory-service group criterion",
+				fmt.Sprintf("Criterion %q: %s", name, err.Error()),
+			)
+			continue
+		}
+		out[i].Value = types.StringValue(wire)
+		authored[wire] = original
+	}
+	return out, authored, diags
+}
+
+// RestoreAuthoredDSGroupCriteria rewrites each directory-service group
+// criterion's value back to the form the user authored, using the map produced by
+// ResolveDSGroupCriteria. Pure (no API call, no error): the wire echoes the value
+// we just wrote byte-stable, so this is a lookup-and-restore. Call in Create/Update
+// after the read-back flatten. Criteria absent from the map (or not DS-group) are
+// left as flattened.
+func RestoreAuthoredDSGroupCriteria(models []CriterionModel, authored map[string]string) []CriterionModel {
+	if len(authored) == 0 {
+		return models
+	}
+	out := make([]CriterionModel, len(models))
+	copy(out, models)
+	for i := range out {
+		if !IsDSGroupCriterion(out[i].Name.ValueString()) {
+			continue
+		}
+		if v, ok := authored[out[i].Value.ValueString()]; ok {
+			out[i].Value = types.StringValue(v)
+		}
+	}
+	return out
+}
+
+// DSGroupValuesEquivalent reports whether two directory-service group criterion
+// values refer to the SAME group — i.e. each resolves to the same wire base64
+// ({uuid,serverId}), where a raw base64 value passes through and a name is
+// resolved. Used at plan time to suppress a no-op base64<->name swap.
+//
+// SOFT and class-agnostic: identical strings short-circuit true with no API call;
+// any resolution failure (not found / ambiguous / transient) returns false so a
+// transient LDAP blip can never block `terraform plan` — it just shows the diff.
+func DSGroupValuesEquivalent(ctx context.Context, resolver ldapgroups.Searcher, a, b string) bool {
+	if a == b {
+		return true
+	}
+	wa, err := ResolveValue(ctx, resolver, a)
+	if err != nil {
+		return false
+	}
+	wb, err := ResolveValue(ctx, resolver, b)
+	if err != nil {
+		return false
+	}
+	if wa == wb {
+		return true
+	}
+	// Fall back to a semantic compare so two encodings of the same group — e.g. a
+	// pasted blob with a lowercase uuid or different JSON key order — still match.
+	ra, oka, _ := ParseEncodedValue(wa)
+	rb, okb, _ := ParseEncodedValue(wb)
+	return oka && okb && strings.EqualFold(ra.UUID, rb.UUID) && ra.ServerID == rb.ServerID
+}
+
+// SuppressEquivalentDSGroupValues returns a copy of planned where each
+// directory-service group criterion whose value is semantically equivalent to the
+// aligned prior value is reset to the prior value — suppressing a no-op
+// base64<->name diff so `terraform plan` shows nothing to change. planned and
+// prior are aligned by index, guarded by a name match (mirrors
+// ReadbackDSGroupCriteria); a reorder simply degrades to "no suppression" (the
+// diff shows, which is safe). Set-B validation is deliberately NOT done here — it
+// stays at apply (ResolveCriterionValue) so a transient resolve failure cannot
+// turn into a hard plan error. Call from a resource's ModifyPlan.
+func SuppressEquivalentDSGroupValues(ctx context.Context, resolver ldapgroups.Searcher, planned, prior []CriterionModel) []CriterionModel {
+	if len(planned) == 0 {
+		return planned // preserve nil/empty
+	}
+	out := make([]CriterionModel, len(planned))
+	copy(out, planned)
+	for i := range out {
+		name := out[i].Name.ValueString()
+		if !IsDSGroupCriterion(name) {
+			continue
+		}
+		if i >= len(prior) || prior[i].Name.ValueString() != name {
+			continue
+		}
+		if DSGroupValuesEquivalent(ctx, resolver, out[i].Value.ValueString(), prior[i].Value.ValueString()) {
+			out[i] = reconcileCriterionToPrior(out[i], prior[i])
+		}
+	}
+	return out
+}
+
+// reconcileCriterionToPrior collapses a criterion whose value is a CONFIRMED
+// representation swap (base64<->name for the same group) back to the prior state
+// element: the value adopts the stored form, and any sibling field the plan left
+// Unknown is filled from prior. The Unknown case is load-bearing — `priority` is
+// Optional+Computed with no default, so core flips it to Unknown the moment the
+// criteria list "changes" (the value swap); without this it would stay Unknown
+// (!= the stored value) and defeat the no-op, leaving a phantom criteria diff.
+// Known fields the user actually changed are preserved, so a real edit made
+// alongside the swap still surfaces a diff.
+func reconcileCriterionToPrior(plan, prior CriterionModel) CriterionModel {
+	plan.Value = prior.Value
+	if plan.Priority.IsUnknown() {
+		plan.Priority = prior.Priority
+	}
+	if plan.Name.IsUnknown() {
+		plan.Name = prior.Name
+	}
+	if plan.SearchType.IsUnknown() {
+		plan.SearchType = prior.SearchType
+	}
+	if plan.AndOr.IsUnknown() {
+		plan.AndOr = prior.AndOr
+	}
+	if plan.HasOpeningParenthesis.IsUnknown() {
+		plan.HasOpeningParenthesis = prior.HasOpeningParenthesis
+	}
+	if plan.HasClosingParenthesis.IsUnknown() {
+		plan.HasClosingParenthesis = prior.HasClosingParenthesis
+	}
+	return plan
+}
+
+// CriteriaModelsEqual reports whether two criterion slices are identical across
+// every modelled field. ModifyPlan suppression uses it to confirm a representation
+// swap left no real criteria change before restoring Computed siblings (e.g.
+// site_name) that core flips to unknown on any planned update.
+func CriteriaModelsEqual(a, b []CriterionModel) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if !a[i].Priority.Equal(b[i].Priority) ||
+			!a[i].Name.Equal(b[i].Name) ||
+			!a[i].SearchType.Equal(b[i].SearchType) ||
+			!a[i].Value.Equal(b[i].Value) ||
+			!a[i].AndOr.Equal(b[i].AndOr) ||
+			!a[i].HasOpeningParenthesis.Equal(b[i].HasOpeningParenthesis) ||
+			!a[i].HasClosingParenthesis.Equal(b[i].HasClosingParenthesis) {
+			return false
+		}
+	}
+	return true
+}
+
+// ReadbackDSGroupCriteria maps each directory-service group criterion's wire
+// value back to the authored form on a pure Read/refresh, using prior state as the
+// form source (SOFT — never errors; see ReadValue). wireModels are the freshly
+// flattened (base64) criteria; priorModels are the existing state criteria. Both
+// are wire-ordered, so they zip by index; the index is guarded by a name match.
+// When there is no aligned prior (import / data source / drift), the wire base64
+// is kept. Call in Read after the flatten.
+func ReadbackDSGroupCriteria(ctx context.Context, resolver ldapgroups.Searcher, ot ObjectType, wireModels, priorModels []CriterionModel) []CriterionModel {
+	if len(wireModels) == 0 {
+		return wireModels // preserve nil/empty; never flip nil -> []
+	}
+	out := make([]CriterionModel, len(wireModels))
+	copy(out, wireModels)
+	for i := range out {
+		name := out[i].Name.ValueString()
+		if !IsDSGroupCriterion(name) {
+			continue
+		}
+		prior := ""
+		if i < len(priorModels) && priorModels[i].Name.ValueString() == name {
+			prior = priorModels[i].Value.ValueString()
+		}
+		out[i].Value = types.StringValue(ReadValue(ctx, resolver, out[i].Value.ValueString(), prior))
+	}
+	return out
+}

--- a/internal/common/criteria/dsgroup_test.go
+++ b/internal/common/criteria/dsgroup_test.go
@@ -1,0 +1,383 @@
+// Copyright Jamf Software LLC 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package criteria
+
+import (
+	"context"
+	"encoding/base64"
+	"errors"
+	"testing"
+
+	"github.com/Jamf-Concepts/jamfplatform-go-sdk/jamfplatform/pro"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+
+	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/common/ldapgroups"
+)
+
+// The verbatim wire blob from the spike (§1): base64 of
+// {"uuid":"E5EFCA3E-892C-4CCE-B2C1-6CA1A32E9153","serverId":"31"}.
+const (
+	wireBlob = "eyJ1dWlkIjoiRTVFRkNBM0UtODkyQy00Q0NFLUIyQzEtNkNBMUEzMkU5MTUzIiwic2VydmVySWQiOiIzMSJ9"
+	wireUUID = "E5EFCA3E-892C-4CCE-B2C1-6CA1A32E9153"
+)
+
+// fakeSearcher returns canned results (or an error) for SearchLdapGroupsV1.
+type fakeSearcher struct {
+	results []pro.LdapGroup
+	err     error
+}
+
+func (f *fakeSearcher) SearchLdapGroupsV1(_ context.Context, _ string) (*pro.LdapGroupSearchResults, error) {
+	if f.err != nil {
+		return nil, f.err
+	}
+	return &pro.LdapGroupSearchResults{Results: f.results, TotalCount: len(f.results)}, nil
+}
+
+func adminGroup() []pro.LdapGroup {
+	return []pro.LdapGroup{{Name: "Admins", ID: "37158", LdapServerID: 31, UUID: wireUUID}}
+}
+
+func TestEncodeDSGroupValue_ByteStableWithUI(t *testing.T) {
+	got := encodeDSGroupValue(dsGroupRef{UUID: wireUUID, ServerID: "31"})
+	if got != wireBlob {
+		t.Fatalf("encodeDSGroupValue = %q, want the UI-canonical blob %q", got, wireBlob)
+	}
+}
+
+func TestParseEncodedValue(t *testing.T) {
+	tests := []struct {
+		name    string
+		value   string
+		wantOK  bool
+		wantErr bool
+	}{
+		{"valid blob", wireBlob, true, false},
+		{"group name with underscore (not base64)", "DataJARLDAPS_JamfPro_Admins", false, false},
+		{"short non-b64 name", "Admins", false, false},
+		// valid base64 of JSON that is not a DS-group ref → treat as a name
+		{"base64 of unrelated json object", b64JSON(`{"foo":"bar"}`), false, false},
+		// looked encoded but malformed → error
+		{"empty uuid (Okta trap)", b64JSON(`{"uuid":"","serverId":"31"}`), false, true},
+		{"malformed uuid", b64JSON(`{"uuid":"not-a-uuid","serverId":"31"}`), false, true},
+		{"empty serverId", b64JSON(`{"uuid":"` + wireUUID + `","serverId":""}`), false, true},
+		{"serverId only, missing uuid", b64JSON(`{"serverId":"31"}`), false, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, ok, err := ParseEncodedValue(tt.value)
+			if ok != tt.wantOK {
+				t.Errorf("ok = %v, want %v", ok, tt.wantOK)
+			}
+			if (err != nil) != tt.wantErr {
+				t.Errorf("err = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestResolveValue_PassThroughEncoded(t *testing.T) {
+	// A searcher that would error if called — proving no resolution happens.
+	f := &fakeSearcher{err: errors.New("should not be called")}
+	got, err := ResolveValue(context.Background(), f, wireBlob)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != wireBlob {
+		t.Errorf("got %q, want verbatim %q", got, wireBlob)
+	}
+}
+
+func TestResolveValue_ResolvesName(t *testing.T) {
+	f := &fakeSearcher{results: adminGroup()}
+	got, err := ResolveValue(context.Background(), f, "Admins")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != wireBlob {
+		t.Errorf("got %q, want %q", got, wireBlob)
+	}
+}
+
+func TestResolveValue_Errors(t *testing.T) {
+	tests := []struct {
+		name    string
+		f       *fakeSearcher
+		value   string
+		wantErr error
+	}{
+		{"not found", &fakeSearcher{results: nil}, "Missing", ldapgroups.ErrGroupNotFound},
+		{"ambiguous", &fakeSearcher{results: []pro.LdapGroup{
+			{Name: "Admins", LdapServerID: 31, UUID: "u1"},
+			{Name: "Admins", LdapServerID: 42, UUID: "u2"},
+		}}, "Admins", ldapgroups.ErrAmbiguousGroup},
+		{"no uuid", &fakeSearcher{results: []pro.LdapGroup{
+			{Name: "Admins", LdapServerID: 31, UUID: ""},
+		}}, "Admins", ErrNoUUID},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := ResolveValue(context.Background(), tt.f, tt.value)
+			if !errors.Is(err, tt.wantErr) {
+				t.Errorf("err = %v, want wrapping %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestResolveValue_MalformedBlobFailsClosed(t *testing.T) {
+	f := &fakeSearcher{err: errors.New("should not be called")}
+	_, err := ResolveValue(context.Background(), f, b64JSON(`{"uuid":"","serverId":"31"}`))
+	if err == nil {
+		t.Fatal("expected fail-closed error for malformed encoded value")
+	}
+}
+
+func TestReadValue(t *testing.T) {
+	otherBlob := encodeDSGroupValue(dsGroupRef{UUID: "FA257BC0-5F97-44D8-898E-2F4A19F4A413", ServerID: "31"})
+
+	tests := []struct {
+		name  string
+		f     *fakeSearcher
+		wire  string
+		prior string
+		want  string
+	}{
+		{"import (no prior) keeps wire", &fakeSearcher{}, wireBlob, "", wireBlob},
+		{"prior base64 equals wire keeps prior", &fakeSearcher{}, wireBlob, wireBlob, wireBlob},
+		{"prior base64 differs from wire → drift", &fakeSearcher{}, wireBlob, otherBlob, wireBlob},
+		{"prior name still resolves to wire keeps name", &fakeSearcher{results: adminGroup()}, wireBlob, "Admins", "Admins"},
+		{"prior name resolves elsewhere → drift", &fakeSearcher{results: adminGroup()}, otherBlob, "Admins", otherBlob},
+		{"prior name no longer found (soft) → wire", &fakeSearcher{results: nil}, wireBlob, "Admins", wireBlob},
+		{"prior name resolution errors (soft) → wire", &fakeSearcher{err: errors.New("boom")}, wireBlob, "Admins", wireBlob},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ReadValue(context.Background(), tt.f, tt.wire, tt.prior)
+			if got != tt.want {
+				t.Errorf("got %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSetMembership(t *testing.T) {
+	if !IsDSGroupCriterion(dsAssignedUser) {
+		t.Error("dsAssignedUser should be in set A")
+	}
+	if IsDSGroupCriterion("Application Title") {
+		t.Error("a normal criterion should not be in set A")
+	}
+	// The MDM criterion's canonical token is title-case "Mdm", not "MDM".
+	if !IsDSGroupCriterion(dsULLIMdm) {
+		t.Error("the Mdm criterion should be in set A")
+	}
+	if IsDSGroupCriterion("User last logged in - MDM directory service group") {
+		t.Error("the all-caps MDM form is not a recognised criterion")
+	}
+	// set B per class.
+	if !isAllowedDSGroupCriterion(ObjectTypeComputer, dsULLIComputer) {
+		t.Error("computer should accept the ULLI-Computer criterion")
+	}
+	if isAllowedDSGroupCriterion(ObjectTypeMobile, dsULLIComputer) {
+		t.Error("mobile must reject the ULLI-Computer criterion")
+	}
+	// Mdm is accepted on computer + mobile, rejected on user.
+	if !isAllowedDSGroupCriterion(ObjectTypeComputer, dsULLIMdm) {
+		t.Error("computer should accept the Mdm criterion")
+	}
+	if !isAllowedDSGroupCriterion(ObjectTypeMobile, dsULLIMdm) {
+		t.Error("mobile should accept the Mdm criterion")
+	}
+	if isAllowedDSGroupCriterion(ObjectTypeUser, dsULLIMdm) {
+		t.Error("user surfaces must reject the Mdm criterion")
+	}
+	if isAllowedDSGroupCriterion(ObjectTypeUser, dsAssignedUser) {
+		t.Error("user surfaces accept only Username, not Assigned User")
+	}
+	if !isAllowedDSGroupCriterion(ObjectTypeUser, dsUsername) {
+		t.Error("user surfaces accept Username")
+	}
+	if got := supportedDSGroupNames(ObjectTypeUser); len(got) != 1 || got[0] != dsUsername {
+		t.Errorf("supportedDSGroupNames(user) = %v, want [Username…]", got)
+	}
+}
+
+func TestResolveDSGroupCriteria(t *testing.T) {
+	f := &fakeSearcher{results: adminGroup()}
+	models := []CriterionModel{
+		{Name: types.StringValue("Application Title"), Value: types.StringValue("Firefox")},
+		{Name: types.StringValue(dsUsername), Value: types.StringValue("Admins")},
+	}
+	out, authored, diags := ResolveDSGroupCriteria(context.Background(), f, ObjectTypeComputer, models)
+	if diags.HasError() {
+		t.Fatalf("unexpected diags: %v", diags)
+	}
+	if out[0].Value.ValueString() != "Firefox" {
+		t.Errorf("non-DS criterion mutated: %q", out[0].Value.ValueString())
+	}
+	if out[1].Value.ValueString() != wireBlob {
+		t.Errorf("DS criterion value = %q, want %q", out[1].Value.ValueString(), wireBlob)
+	}
+	if authored[wireBlob] != "Admins" {
+		t.Errorf("authored map = %v, want %q→Admins", authored, wireBlob)
+	}
+	// input must not be mutated in place.
+	if models[1].Value.ValueString() != "Admins" {
+		t.Errorf("input slice was mutated: %q", models[1].Value.ValueString())
+	}
+}
+
+func TestResolveDSGroupCriteria_FailClosedCrossClass(t *testing.T) {
+	f := &fakeSearcher{results: adminGroup()}
+	// Assigned User is set A but NOT accepted on the user class (set B).
+	models := []CriterionModel{
+		{Name: types.StringValue(dsAssignedUser), Value: types.StringValue("Admins")},
+	}
+	_, _, diags := ResolveDSGroupCriteria(context.Background(), f, ObjectTypeUser, models)
+	if !diags.HasError() {
+		t.Fatal("expected fail-closed diag for cross-class DS criterion")
+	}
+}
+
+func TestRestoreAuthoredDSGroupCriteria(t *testing.T) {
+	authored := map[string]string{wireBlob: "Admins"}
+	flattened := []CriterionModel{
+		{Name: types.StringValue(dsUsername), Value: types.StringValue(wireBlob)},
+		{Name: types.StringValue("Application Title"), Value: types.StringValue("Firefox")},
+	}
+	out := RestoreAuthoredDSGroupCriteria(flattened, authored)
+	if out[0].Value.ValueString() != "Admins" {
+		t.Errorf("restored value = %q, want Admins", out[0].Value.ValueString())
+	}
+	if out[1].Value.ValueString() != "Firefox" {
+		t.Errorf("non-DS criterion changed: %q", out[1].Value.ValueString())
+	}
+}
+
+func TestReadbackDSGroupCriteria(t *testing.T) {
+	f := &fakeSearcher{results: adminGroup()}
+	wireModels := []CriterionModel{
+		{Name: types.StringValue(dsUsername), Value: types.StringValue(wireBlob)},
+	}
+	prior := []CriterionModel{
+		{Name: types.StringValue(dsUsername), Value: types.StringValue("Admins")},
+	}
+	out := ReadbackDSGroupCriteria(context.Background(), f, ObjectTypeComputer, wireModels, prior)
+	if out[0].Value.ValueString() != "Admins" {
+		t.Errorf("readback value = %q, want Admins (name preserved)", out[0].Value.ValueString())
+	}
+
+	// No prior (import) → wire base64 kept.
+	out = ReadbackDSGroupCriteria(context.Background(), f, ObjectTypeComputer, wireModels, nil)
+	if out[0].Value.ValueString() != wireBlob {
+		t.Errorf("readback with no prior = %q, want wire blob", out[0].Value.ValueString())
+	}
+}
+
+func TestDSGroupValuesEquivalent(t *testing.T) {
+	otherBlob := encodeDSGroupValue(dsGroupRef{UUID: "FA257BC0-5F97-44D8-898E-2F4A19F4A413", ServerID: "31"})
+	tests := []struct {
+		name string
+		f    *fakeSearcher
+		a, b string
+		want bool
+	}{
+		{"identical strings short-circuit (no api)", &fakeSearcher{err: errors.New("must not call")}, wireBlob, wireBlob, true},
+		{"name vs equivalent base64", &fakeSearcher{results: adminGroup()}, "Admins", wireBlob, true},
+		// Same group, lowercase uuid in the pasted blob → semantic match.
+		{"name vs lowercase-uuid blob", &fakeSearcher{results: adminGroup()}, "Admins", b64JSON(`{"uuid":"e5efca3e-892c-4cce-b2c1-6ca1a32e9153","serverId":"31"}`), true},
+		{"name vs different base64", &fakeSearcher{results: adminGroup()}, "Admins", otherBlob, false},
+		{"unresolvable name (soft) → not equivalent", &fakeSearcher{results: nil}, "Gone", wireBlob, false},
+		{"transient error (soft) → not equivalent", &fakeSearcher{err: errors.New("boom")}, "Admins", wireBlob, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := DSGroupValuesEquivalent(context.Background(), tt.f, tt.a, tt.b); got != tt.want {
+				t.Errorf("got %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSuppressEquivalentDSGroupValues(t *testing.T) {
+	f := &fakeSearcher{results: adminGroup()}
+	// planned uses the NAME; prior state holds the equivalent base64 → suppress.
+	planned := []CriterionModel{
+		{Name: types.StringValue(dsUsername), Value: types.StringValue("Admins")},
+		{Name: types.StringValue("Application Title"), Value: types.StringValue("Firefox")},
+	}
+	prior := []CriterionModel{
+		{Name: types.StringValue(dsUsername), Value: types.StringValue(wireBlob)},
+		{Name: types.StringValue("Application Title"), Value: types.StringValue("Firefox")},
+	}
+	out := SuppressEquivalentDSGroupValues(context.Background(), f, planned, prior)
+	if out[0].Value.ValueString() != wireBlob {
+		t.Errorf("equivalent DS value not suppressed: got %q, want prior %q", out[0].Value.ValueString(), wireBlob)
+	}
+	if out[1].Value.ValueString() != "Firefox" {
+		t.Errorf("non-DS criterion changed: %q", out[1].Value.ValueString())
+	}
+
+	// An Unknown sibling field (priority churns to Unknown when the criteria list
+	// changes) must be reconciled to prior on a confirmed swap, else the element
+	// stays != state and defeats the no-op.
+	plannedUnknownPrio := []CriterionModel{
+		{Name: types.StringValue(dsUsername), Priority: types.Int64Unknown(), Value: types.StringValue("Admins")},
+	}
+	priorKnownPrio := []CriterionModel{
+		{Name: types.StringValue(dsUsername), Priority: types.Int64Value(0), Value: types.StringValue(wireBlob)},
+	}
+	out = SuppressEquivalentDSGroupValues(context.Background(), f, plannedUnknownPrio, priorKnownPrio)
+	if out[0].Priority.IsUnknown() || out[0].Priority.ValueInt64() != 0 {
+		t.Errorf("unknown priority not reconciled to prior: got %v", out[0].Priority)
+	}
+	if !CriteriaModelsEqual(out, priorKnownPrio) {
+		t.Error("after suppression a pure swap should equal prior state")
+	}
+
+	// Misaligned (different name at index) → no suppression.
+	priorMis := []CriterionModel{
+		{Name: types.StringValue(dsAssignedUser), Value: types.StringValue(wireBlob)},
+	}
+	out = SuppressEquivalentDSGroupValues(context.Background(), f, planned, priorMis)
+	if out[0].Value.ValueString() != "Admins" {
+		t.Errorf("misaligned prior should not suppress: got %q", out[0].Value.ValueString())
+	}
+
+	// Different group → no suppression (real change shows a diff).
+	priorDiff := []CriterionModel{
+		{Name: types.StringValue(dsUsername), Value: types.StringValue(encodeDSGroupValue(dsGroupRef{UUID: "FA257BC0-5F97-44D8-898E-2F4A19F4A413", ServerID: "31"}))},
+	}
+	out = SuppressEquivalentDSGroupValues(context.Background(), f, planned[:1], priorDiff)
+	if out[0].Value.ValueString() != "Admins" {
+		t.Errorf("different group should not suppress: got %q", out[0].Value.ValueString())
+	}
+}
+
+func TestCriteriaModelsEqual(t *testing.T) {
+	base := []CriterionModel{
+		{Name: types.StringValue(dsUsername), SearchType: types.StringValue("member of"), Value: types.StringValue(wireBlob)},
+	}
+	same := []CriterionModel{
+		{Name: types.StringValue(dsUsername), SearchType: types.StringValue("member of"), Value: types.StringValue(wireBlob)},
+	}
+	diffValue := []CriterionModel{
+		{Name: types.StringValue(dsUsername), SearchType: types.StringValue("member of"), Value: types.StringValue("Admins")},
+	}
+	if !CriteriaModelsEqual(base, same) {
+		t.Error("identical slices should be equal")
+	}
+	if CriteriaModelsEqual(base, diffValue) {
+		t.Error("differing value should not be equal")
+	}
+	if CriteriaModelsEqual(base, base[:0]) {
+		t.Error("differing length should not be equal")
+	}
+}
+
+// b64JSON base64-encodes a JSON literal for table tests.
+func b64JSON(s string) string {
+	return base64.StdEncoding.EncodeToString([]byte(s))
+}

--- a/internal/resources/device_group/crud.go
+++ b/internal/resources/device_group/crud.go
@@ -41,6 +41,68 @@ func isDeletePropagationConflict(err error) bool {
 	return apiErr.HasStatus(http.StatusNotAcceptable) || apiErr.HasStatus(http.StatusConflict)
 }
 
+// ModifyPlan suppresses a no-op diff when a directory-service group criterion's
+// planned value is a different REPRESENTATION of the same group already in state
+// (a raw base64 value swapped for the equivalent group name, or vice versa).
+// Skips create (no prior state) and destroy (no plan); soft — any resolve
+// failure leaves the diff intact.
+func (r *DeviceGroupResource) ModifyPlan(ctx context.Context, req resource.ModifyPlanRequest, resp *resource.ModifyPlanResponse) {
+	if req.Plan.Raw.IsNull() || req.State.Raw.IsNull() || r.proClient == nil {
+		return
+	}
+	var plan, state DeviceGroupResourceModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() || len(plan.Criteria) == 0 {
+		return
+	}
+	suppressed := suppressEquivalentDSGroupCriteria(ctx, r.proClient, plan.Criteria, state.Criteria)
+	changed := false
+	for i := range suppressed {
+		if !suppressed[i].AttributeValue.Equal(plan.Criteria[i].AttributeValue) {
+			changed = true
+			break
+		}
+	}
+	if !changed {
+		return // additive: only touch the plan when a representation actually collapsed
+	}
+	plan.Criteria = suppressed
+	// If suppression reconciled the criteria back to state, the swap is a pure
+	// representation change with no membership impact. member_count is Computed
+	// WITHOUT UseStateForUnknown, so core has already flipped it to unknown for the
+	// (now-reverted) update — leaving a phantom "member_count -> known after apply"
+	// diff. Restore it from state so a representation-only swap yields an empty
+	// plan. Safe: member_count depends only on membership, which is unchanged when
+	// the criteria are equal. (id / jamf_pro_id / members already use
+	// UseStateForUnknown and need no such restore.)
+	if deviceGroupCriteriaEqual(plan.Criteria, state.Criteria) {
+		plan.MemberCount = state.MemberCount
+	}
+	resp.Diagnostics.Append(resp.Plan.Set(ctx, &plan)...)
+}
+
+// deviceGroupCriteriaEqual reports whether two criteria slices are identical
+// across every modelled field — used to confirm a directory-service group
+// suppression left no real criteria change before restoring Computed siblings.
+func deviceGroupCriteriaEqual(a, b []DeviceGroupCriteriaModel) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if !a[i].Order.Equal(b[i].Order) ||
+			!a[i].AttributeName.Equal(b[i].AttributeName) ||
+			!a[i].Operator.Equal(b[i].Operator) ||
+			!a[i].AttributeValue.Equal(b[i].AttributeValue) ||
+			!a[i].JoinType.Equal(b[i].JoinType) ||
+			!a[i].HasOpeningParenthesis.Equal(b[i].HasOpeningParenthesis) ||
+			!a[i].HasClosingParenthesis.Equal(b[i].HasClosingParenthesis) {
+			return false
+		}
+	}
+	return true
+}
+
 // Create creates a new Jamf Platform device group resource.
 func (r *DeviceGroupResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
 	var plan DeviceGroupResourceModel
@@ -80,8 +142,16 @@ func (r *DeviceGroupResource) Create(ctx context.Context, req resource.CreateReq
 		GroupType:   strings.ToUpper(plan.GroupType.ValueString()),
 	}
 
+	var authoredDSGroups map[string]string
 	switch strings.ToLower(plan.GroupType.ValueString()) {
 	case "smart":
+		resolved, authored, dsDiags := resolveDSGroupCriteria(createCtx, r.proClient, dsObjectType(plan.DeviceType.ValueString()), plan.Criteria)
+		resp.Diagnostics.Append(dsDiags...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+		plan.Criteria = resolved
+		authoredDSGroups = authored
 		criteria := expandDeviceGroupCriteria(plan.Criteria)
 		reqBody.Criteria = &criteria
 	case "static":
@@ -109,6 +179,7 @@ func (r *DeviceGroupResource) Create(ctx context.Context, req resource.CreateReq
 	if !r.refreshDeviceGroupState(createCtx, created.ID, &plan, manageMembers, manageDescription, &resp.Diagnostics) {
 		return
 	}
+	plan.Criteria = restoreAuthoredDSGroupCriteria(plan.Criteria, authoredDSGroups)
 
 	// resolveJamfProID degrades all Pro bridging failures to warnings so the
 	// Platform Create result is never discarded. Append diagnostics without a
@@ -211,10 +282,12 @@ func (r *DeviceGroupResource) Read(ctx context.Context, req resource.ReadRequest
 		}
 	}
 
+	priorCriteria := state.Criteria
 	resp.Diagnostics.Append(assignDeviceGroupModel(readCtx, &state, grp, members, manageMembers, manageDescription)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
+	state.Criteria = readbackDSGroupCriteria(readCtx, r.proClient, state.Criteria, priorCriteria)
 
 	jamfProID, jamfProDiags := resolveJamfProID(readCtx, r.proClient, r.pd, state.ID.ValueString())
 	resp.Diagnostics.Append(jamfProDiags...)
@@ -259,7 +332,15 @@ func (r *DeviceGroupResource) Update(ctx context.Context, req resource.UpdateReq
 		Description: plan.Description.ValueStringPointer(),
 	}
 
+	var authoredDSGroups map[string]string
 	if strings.ToLower(plan.GroupType.ValueString()) == "smart" {
+		resolved, authored, dsDiags := resolveDSGroupCriteria(updateCtx, r.proClient, dsObjectType(plan.DeviceType.ValueString()), plan.Criteria)
+		resp.Diagnostics.Append(dsDiags...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+		plan.Criteria = resolved
+		authoredDSGroups = authored
 		criteria := expandDeviceGroupCriteria(plan.Criteria)
 		updateReq.Criteria = &criteria
 	}
@@ -304,6 +385,7 @@ func (r *DeviceGroupResource) Update(ctx context.Context, req resource.UpdateReq
 	if !r.refreshDeviceGroupState(updateCtx, plan.ID.ValueString(), &plan, manageMembers, manageDescription, &resp.Diagnostics) {
 		return
 	}
+	plan.Criteria = restoreAuthoredDSGroupCriteria(plan.Criteria, authoredDSGroups)
 
 	jamfProID, jamfProDiags := resolveJamfProID(updateCtx, r.proClient, r.pd, plan.ID.ValueString())
 	resp.Diagnostics.Append(jamfProDiags...)

--- a/internal/resources/device_group/dsgroup.go
+++ b/internal/resources/device_group/dsgroup.go
@@ -1,0 +1,131 @@
+// Copyright Jamf Software LLC 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package device_group
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+
+	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/common/criteria"
+	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/common/ldapgroups"
+)
+
+// Directory-service group criteria carry a base64 {uuid,serverId} blob as their
+// value (see internal/common/criteria/dsgroup.go). device_group has its own
+// criterion model (DeviceGroupCriteriaModel, value field AttributeValue) rather
+// than the shared criteria.CriterionModel, so these thin per-criterion loops
+// wire the shared primitives directly. The operator is upper-cased to MEMBER OF
+// by expandDeviceGroupCriteria already (the Platform surface wants UPPERCASE),
+// so only the value is transformed here.
+
+// dsObjectType maps the resource's device_type to the criteria object class that
+// dispatches the per-class directory-service group allowlist.
+func dsObjectType(deviceType string) criteria.ObjectType {
+	if strings.EqualFold(deviceType, "mobile") {
+		return criteria.ObjectTypeMobile
+	}
+	return criteria.ObjectTypeComputer
+}
+
+// resolveDSGroupCriteria resolves each directory-service group criterion's value
+// from a group NAME to the base64 wire form (pass-through when already encoded),
+// fail-closing on a name not accepted for this object class. Returns the resolved
+// models plus an authored map (wire→original) for restoring the authored form
+// after the post-write flatten. Call in Create/Update before expand.
+func resolveDSGroupCriteria(ctx context.Context, resolver ldapgroups.Searcher, ot criteria.ObjectType, in []DeviceGroupCriteriaModel) ([]DeviceGroupCriteriaModel, map[string]string, diag.Diagnostics) {
+	var diags diag.Diagnostics
+	if len(in) == 0 {
+		return in, nil, diags // preserve nil/empty
+	}
+	authored := map[string]string{}
+	out := make([]DeviceGroupCriteriaModel, len(in))
+	copy(out, in)
+	for i := range out {
+		name := out[i].AttributeName.ValueString()
+		original := out[i].AttributeValue.ValueString()
+		wire, isDS, err := criteria.ResolveCriterionValue(ctx, resolver, ot, name, original)
+		if !isDS {
+			continue
+		}
+		if err != nil {
+			diags.AddError("Invalid directory-service group criterion", fmt.Sprintf("Criterion %q: %s", name, err.Error()))
+			continue
+		}
+		out[i].AttributeValue = types.StringValue(wire)
+		authored[wire] = original
+	}
+	return out, authored, diags
+}
+
+// restoreAuthoredDSGroupCriteria rewrites each directory-service group criterion
+// value back to the authored form using the map from resolveDSGroupCriteria.
+// Pure (the wire echoes the value we wrote byte-stable). Call after the flatten.
+func restoreAuthoredDSGroupCriteria(in []DeviceGroupCriteriaModel, authored map[string]string) []DeviceGroupCriteriaModel {
+	if len(authored) == 0 {
+		return in
+	}
+	out := make([]DeviceGroupCriteriaModel, len(in))
+	copy(out, in)
+	for i := range out {
+		if !criteria.IsDSGroupCriterion(out[i].AttributeName.ValueString()) {
+			continue
+		}
+		if v, ok := authored[out[i].AttributeValue.ValueString()]; ok {
+			out[i].AttributeValue = types.StringValue(v)
+		}
+	}
+	return out
+}
+
+// readbackDSGroupCriteria maps each directory-service group criterion's wire
+// value back to the authored form on a pure Read, using prior state as the form
+// source (SOFT — never errors). Call in Read after the flatten.
+func readbackDSGroupCriteria(ctx context.Context, resolver ldapgroups.Searcher, in, prior []DeviceGroupCriteriaModel) []DeviceGroupCriteriaModel {
+	if len(in) == 0 {
+		return in // preserve nil/empty; never flip nil -> []
+	}
+	out := make([]DeviceGroupCriteriaModel, len(in))
+	copy(out, in)
+	for i := range out {
+		name := out[i].AttributeName.ValueString()
+		if !criteria.IsDSGroupCriterion(name) {
+			continue
+		}
+		p := ""
+		if i < len(prior) && prior[i].AttributeName.ValueString() == name {
+			p = prior[i].AttributeValue.ValueString()
+		}
+		out[i].AttributeValue = types.StringValue(criteria.ReadValue(ctx, resolver, out[i].AttributeValue.ValueString(), p))
+	}
+	return out
+}
+
+// suppressEquivalentDSGroupCriteria resets a planned directory-service group
+// criterion value to the prior state value when the two refer to the same group
+// (a base64<->name swap), suppressing a no-op diff. Aligned by index + name
+// match; SOFT. Call from ModifyPlan.
+func suppressEquivalentDSGroupCriteria(ctx context.Context, resolver ldapgroups.Searcher, planned, prior []DeviceGroupCriteriaModel) []DeviceGroupCriteriaModel {
+	if len(planned) == 0 {
+		return planned // preserve nil/empty
+	}
+	out := make([]DeviceGroupCriteriaModel, len(planned))
+	copy(out, planned)
+	for i := range out {
+		name := out[i].AttributeName.ValueString()
+		if !criteria.IsDSGroupCriterion(name) {
+			continue
+		}
+		if i >= len(prior) || prior[i].AttributeName.ValueString() != name {
+			continue
+		}
+		if criteria.DSGroupValuesEquivalent(ctx, resolver, out[i].AttributeValue.ValueString(), prior[i].AttributeValue.ValueString()) {
+			out[i].AttributeValue = prior[i].AttributeValue
+		}
+	}
+	return out
+}

--- a/internal/resources/device_group/resource.go
+++ b/internal/resources/device_group/resource.go
@@ -45,6 +45,7 @@ type DeviceGroupResource struct {
 var _ resource.Resource = &DeviceGroupResource{}
 var _ resource.ResourceWithImportState = &DeviceGroupResource{}
 var _ resource.ResourceWithIdentity = &DeviceGroupResource{}
+var _ resource.ResourceWithModifyPlan = &DeviceGroupResource{}
 
 const (
 	defaultCreateTimeout = 120 * time.Second

--- a/internal/resources/device_group/resource_acceptance_test.go
+++ b/internal/resources/device_group/resource_acceptance_test.go
@@ -8,11 +8,16 @@ package device_group_test
 import (
 	"context"
 	"fmt"
+	"os"
+	"strconv"
 	"testing"
 	"time"
 
 	"github.com/Jamf-Concepts/jamfplatform-go-sdk/jamfplatform/devicegroups"
+	"github.com/Jamf-Concepts/jamfplatform-go-sdk/jamfplatform/pro"
+	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/common/criteria"
 	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/common/helpers"
+	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/common/ldapgroups"
 	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/testhelpers"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
@@ -364,6 +369,127 @@ func TestAccResource_DeviceGroup_DescriptionNullVsEmpty(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(rn, "description", "restored"),
 				),
+			},
+		},
+	})
+}
+
+// Directory-service group criteria acceptance coverage.
+//
+// Gated behind JAMFPLATFORM_ACC_CRITERIA_DS_GROUP=1 because it requires a tenant
+// with a directory service configured and a real resolvable group. Supply:
+//
+//	JAMFPLATFORM_ACC_CRITERIA_DS_GROUP=1
+//	JAMFPLATFORM_ACC_CRITERIA_DS_GROUP_NAME   — the exact LDAP/cloud-IdP group name
+//
+// By default the equivalent base64 value is NOT required — the test resolves the
+// name via the same LDAP search the provider uses and encodes it itself, so the
+// swap value always matches what the provider produces (this isolates the
+// ModifyPlan suppression from operator data-entry). Optionally supply
+// JAMFPLATFORM_ACC_CRITERIA_DS_GROUP_VALUE with the real wire base64 for that
+// group: the test then asserts the provider's resolution equals it (an
+// INDEPENDENT encoding oracle against the live wire) and drives the swap with it.
+// Real group names are never committed — see memory: no real LDAP names in public
+// files.
+const (
+	envDSGroupGate  = "JAMFPLATFORM_ACC_CRITERIA_DS_GROUP"
+	envDSGroupName  = "JAMFPLATFORM_ACC_CRITERIA_DS_GROUP_NAME"
+	envDSGroupValue = "JAMFPLATFORM_ACC_CRITERIA_DS_GROUP_VALUE" // optional independent oracle
+)
+
+// TestAccResource_DeviceGroup_DSGroupCriteria exercises a directory-service group
+// smart-group criterion authored by NAME, asserts the provider stores the name
+// (not the base64) in state, and — the crux — that swapping the config to the
+// EQUIVALENT raw base64 value produces an EMPTY plan (the ModifyPlan semantic
+// equality suppression).
+func TestAccResource_DeviceGroup_DSGroupCriteria(t *testing.T) {
+	if os.Getenv(envDSGroupGate) == "" {
+		t.Skipf("set %s=1 (plus %s) to run directory-service group criteria acceptance", envDSGroupGate, envDSGroupName)
+	}
+	groupName := os.Getenv(envDSGroupName)
+	if groupName == "" {
+		t.Skipf("%s must be set", envDSGroupName)
+	}
+	testhelpers.AccPreCheck(t)
+
+	// Resolve the group exactly as the provider does, then encode it ourselves so
+	// the step-2 base64 is byte-identical to what the provider resolves the name
+	// to. Fail loudly (not skip) if the supplied name does not resolve uniquely —
+	// a misconfigured fixture should surface, not silently pass.
+	groups, err := ldapgroups.ResolveByName(context.Background(), pro.New(testhelpers.NewAcceptanceClient(t)), groupName)
+	if err != nil {
+		t.Fatalf("resolving %q: %v", groupName, err)
+	}
+	if len(groups) != 1 {
+		t.Fatalf("group %q must resolve to exactly one directory group (got %d) — pick an unambiguous name", groupName, len(groups))
+	}
+	if groups[0].UUID == "" {
+		t.Fatalf("group %q resolved with no uuid mapping; cannot build a directory-service group value", groupName)
+	}
+	groupValue := criteria.EncodeDSGroupValue(groups[0].UUID, strconv.Itoa(groups[0].LdapServerID))
+
+	// Optional independent oracle: if the operator supplied the real wire value,
+	// assert the provider's resolution reproduces it byte-for-byte (catches a
+	// shared-encoder bug the self-computed value cannot), then drive the swap with
+	// the operator-verified value rather than our own output.
+	if want := os.Getenv(envDSGroupValue); want != "" {
+		if groupValue != want {
+			t.Fatalf("provider resolved %q to %q, but %s=%q — name/value mismatch or an encoding bug", groupName, groupValue, envDSGroupValue, want)
+		}
+		groupValue = want
+	}
+
+	suffix := testhelpers.RunSuffix()
+	name := "tf-acc-dsgroup-" + suffix
+
+	const criterion = "Username directory service group" // accepted on the computer surface
+
+	cfg := func(value string) string {
+		return fmt.Sprintf(`
+			resource "jamfplatform_device_group" "dsgroup" {
+				name        = %q
+				description = "Acceptance test — safe to delete"
+				group_type  = "smart"
+				device_type = "computer"
+				criteria = [{
+					criteria = %q
+					operator = "member of"
+					value    = %q
+				}]
+			}
+		`, name, criterion, value)
+	}
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testhelpers.AccTestProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckDeviceGroupDestroy(t),
+		Steps: []resource.TestStep{
+			{
+				// Author by NAME. State must round-trip back to the NAME (not base64).
+				Config: cfg(groupName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("jamfplatform_device_group.dsgroup", "id"),
+					resource.TestCheckResourceAttr("jamfplatform_device_group.dsgroup", "criteria.0.criteria", criterion),
+					resource.TestCheckResourceAttr("jamfplatform_device_group.dsgroup", "criteria.0.value", groupName),
+				),
+			},
+			{
+				// Swap the config to the equivalent raw base64. Same group → no diff.
+				Config: cfg(groupValue),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+			{
+				// And back to the NAME again — also a no-op.
+				Config: cfg(groupName),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
 			},
 		},
 	})

--- a/internal/resources/pro/searches/advanced_computer_search/crud.go
+++ b/internal/resources/pro/searches/advanced_computer_search/crud.go
@@ -20,8 +20,54 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
+	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/common/criteria"
 	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/common/helpers"
 )
+
+// dsGroupObjectType is the object class this resource targets, used to dispatch
+// the per-class directory-service group criterion allowlist.
+const dsGroupObjectType = criteria.ObjectTypeComputer
+
+// ModifyPlan suppresses a no-op diff when a directory-service group criterion's
+// planned value is a different REPRESENTATION of the same group already in state
+// (a raw base64 value swapped for the equivalent group name, or vice versa). It
+// resets such a criterion's planned value to the prior state value so
+// `terraform plan` shows nothing to change. Skips create (no prior state) and
+// destroy (no plan); soft — any resolve failure leaves the diff intact.
+func (r *AdvancedComputerSearchResource) ModifyPlan(ctx context.Context, req resource.ModifyPlanRequest, resp *resource.ModifyPlanResponse) {
+	if req.Plan.Raw.IsNull() || req.State.Raw.IsNull() || r.ldap == nil {
+		return
+	}
+	var plan, state AdvancedComputerSearchResourceModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() || len(plan.Criteria) == 0 {
+		return
+	}
+	suppressed := criteria.SuppressEquivalentDSGroupValues(ctx, r.ldap, plan.Criteria, state.Criteria)
+	if !dsGroupCriteriaChanged(suppressed, plan.Criteria) {
+		return // additive: only touch the plan when a representation actually collapsed
+	}
+	plan.Criteria = suppressed
+	// site_name is Computed without UseStateForUnknown, so core flipped it to
+	// unknown for the (now-reverted) update. When suppression reconciled the
+	// criteria back to state, restore it so a representation-only swap is an empty
+	// plan. Safe: site_name derives from the unchanged site_id.
+	if criteria.CriteriaModelsEqual(plan.Criteria, state.Criteria) {
+		plan.SiteName = state.SiteName
+	}
+	resp.Diagnostics.Append(resp.Plan.Set(ctx, &plan)...)
+}
+
+// dsGroupCriteriaChanged reports whether suppression rewrote any criterion value.
+func dsGroupCriteriaChanged(suppressed, planned []criteria.CriterionModel) bool {
+	for i := range suppressed {
+		if !suppressed[i].Value.Equal(planned[i].Value) {
+			return true
+		}
+	}
+	return false
+}
 
 // Create creates a new advanced computer search. Classic POSTs to id="0"; the
 // server allocates the real integer ID and returns it in the response body
@@ -40,6 +86,13 @@ func (r *AdvancedComputerSearchResource) Create(ctx context.Context, req resourc
 	}
 	createCtx, cancel := context.WithTimeout(ctx, createTimeout)
 	defer cancel()
+
+	resolved, authored, dsDiags := criteria.ResolveDSGroupCriteria(createCtx, r.ldap, dsGroupObjectType, plan.Criteria)
+	resp.Diagnostics.Append(dsDiags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	plan.Criteria = resolved
 
 	input, inputDiags := buildAdvancedComputerSearchInput(createCtx, plan)
 	resp.Diagnostics.Append(inputDiags...)
@@ -70,6 +123,7 @@ func (r *AdvancedComputerSearchResource) Create(ctx context.Context, req resourc
 	if resp.Diagnostics.HasError() {
 		return
 	}
+	plan.Criteria = criteria.RestoreAuthoredDSGroupCriteria(plan.Criteria, authored)
 
 	resp.Diagnostics.Append(helpers.SetIdentity(ctx, resp.Identity, advancedComputerSearchIdentityModel{ID: plan.ID})...)
 	if resp.Diagnostics.HasError() {
@@ -142,10 +196,12 @@ func (r *AdvancedComputerSearchResource) Read(ctx context.Context, req resource.
 		return
 	}
 
+	priorCriteria := state.Criteria
 	resp.Diagnostics.Append(assignAdvancedComputerSearchResourceModel(readCtx, &state, got)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
+	state.Criteria = criteria.ReadbackDSGroupCriteria(readCtx, r.ldap, dsGroupObjectType, state.Criteria, priorCriteria)
 
 	resp.Diagnostics.Append(helpers.SetIdentity(ctx, resp.Identity, advancedComputerSearchIdentityModel{ID: state.ID})...)
 	if resp.Diagnostics.HasError() {
@@ -171,6 +227,13 @@ func (r *AdvancedComputerSearchResource) Update(ctx context.Context, req resourc
 	updateCtx, cancel := context.WithTimeout(ctx, updateTimeout)
 	defer cancel()
 
+	resolved, authored, dsDiags := criteria.ResolveDSGroupCriteria(updateCtx, r.ldap, dsGroupObjectType, plan.Criteria)
+	resp.Diagnostics.Append(dsDiags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	plan.Criteria = resolved
+
 	input, inputDiags := buildAdvancedComputerSearchInput(updateCtx, plan)
 	resp.Diagnostics.Append(inputDiags...)
 	if resp.Diagnostics.HasError() {
@@ -191,6 +254,7 @@ func (r *AdvancedComputerSearchResource) Update(ctx context.Context, req resourc
 	if resp.Diagnostics.HasError() {
 		return
 	}
+	plan.Criteria = criteria.RestoreAuthoredDSGroupCriteria(plan.Criteria, authored)
 
 	resp.Diagnostics.Append(helpers.SetIdentity(ctx, resp.Identity, advancedComputerSearchIdentityModel{ID: plan.ID})...)
 	if resp.Diagnostics.HasError() {

--- a/internal/resources/pro/searches/advanced_computer_search/dsgroup_acceptance_test.go
+++ b/internal/resources/pro/searches/advanced_computer_search/dsgroup_acceptance_test.go
@@ -1,0 +1,111 @@
+// Copyright Jamf Software LLC 2026
+// SPDX-License-Identifier: MPL-2.0
+
+//go:build acceptance
+
+package advanced_computer_search_test
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strconv"
+	"testing"
+
+	"github.com/Jamf-Concepts/jamfplatform-go-sdk/jamfplatform/pro"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
+
+	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/common/criteria"
+	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/common/ldapgroups"
+	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/testhelpers"
+)
+
+// Directory-service group criteria coverage — gated behind
+// JAMFPLATFORM_ACC_CRITERIA_DS_GROUP=1 (+ _NAME = an exact LDAP/cloud-IdP group
+// name). The equivalent base64 is resolved + encoded in-test (same path the
+// provider uses), so the swap value always matches; an optional _VALUE supplies
+// the real wire base64 as an independent encoding oracle. Real group names are
+// never committed — see memory: no real LDAP names in public files.
+const (
+	envDSGroupGate  = "JAMFPLATFORM_ACC_CRITERIA_DS_GROUP"
+	envDSGroupName  = "JAMFPLATFORM_ACC_CRITERIA_DS_GROUP_NAME"
+	envDSGroupValue = "JAMFPLATFORM_ACC_CRITERIA_DS_GROUP_VALUE" // optional independent oracle
+)
+
+// resolveDSGroupWireValue resolves a directory-service group by name exactly as
+// the provider does and returns the base64 {uuid,serverId} wire value, honouring
+// the optional _VALUE oracle. Fails loudly on an ambiguous / unmapped name.
+func resolveDSGroupWireValue(t *testing.T, name string) string {
+	t.Helper()
+	groups, err := ldapgroups.ResolveByName(context.Background(), pro.New(testhelpers.NewAcceptanceClient(t)), name)
+	if err != nil {
+		t.Fatalf("resolving %q: %v", name, err)
+	}
+	if len(groups) != 1 {
+		t.Fatalf("group %q must resolve to exactly one directory group (got %d) — pick an unambiguous name", name, len(groups))
+	}
+	if groups[0].UUID == "" {
+		t.Fatalf("group %q resolved with no uuid mapping", name)
+	}
+	wire := criteria.EncodeDSGroupValue(groups[0].UUID, strconv.Itoa(groups[0].LdapServerID))
+	if want := os.Getenv(envDSGroupValue); want != "" && wire != want {
+		t.Fatalf("provider resolved %q to %q, but %s=%q — name/value mismatch or an encoding bug", name, wire, envDSGroupValue, want)
+	}
+	return wire
+}
+
+// TestAccResource_ACS_DSGroupCriteria authors a directory-service group criterion
+// by NAME, asserts state round-trips back to the NAME, and asserts swapping the
+// config to the equivalent raw base64 (and back) produces EMPTY plans — the
+// ModifyPlan semantic-equality suppression on the []CriterionModel path.
+func TestAccResource_ACS_DSGroupCriteria(t *testing.T) {
+	if os.Getenv(envDSGroupGate) == "" {
+		t.Skipf("set %s=1 (plus %s) to run directory-service group criteria acceptance", envDSGroupGate, envDSGroupName)
+	}
+	groupName := os.Getenv(envDSGroupName)
+	if groupName == "" {
+		t.Skipf("%s must be set", envDSGroupName)
+	}
+	testhelpers.AccPreCheck(t)
+	groupValue := resolveDSGroupWireValue(t, groupName)
+
+	suffix := testhelpers.RunSuffix()
+	name := "tf-acc-acs-dsgroup-" + suffix
+	const rn = "jamfplatform_pro_advanced_computer_search.dsgroup"
+
+	cfg := func(value string) string {
+		return fmt.Sprintf(`
+			resource "jamfplatform_pro_advanced_computer_search" "dsgroup" {
+				name = %q
+				criteria = [{
+					name        = "Username directory service group"
+					search_type = "member of"
+					value       = %q
+				}]
+			}
+		`, name, value)
+	}
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testhelpers.AccTestProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckACSDestroy(t),
+		Steps: []resource.TestStep{
+			{
+				Config: cfg(groupName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet(rn, "id"),
+					resource.TestCheckResourceAttr(rn, "criteria.0.value", groupName),
+				),
+			},
+			{
+				Config:           cfg(groupValue),
+				ConfigPlanChecks: resource.ConfigPlanChecks{PreApply: []plancheck.PlanCheck{plancheck.ExpectEmptyPlan()}},
+			},
+			{
+				Config:           cfg(groupName),
+				ConfigPlanChecks: resource.ConfigPlanChecks{PreApply: []plancheck.PlanCheck{plancheck.ExpectEmptyPlan()}},
+			},
+		},
+	})
+}

--- a/internal/resources/pro/searches/advanced_computer_search/resource.go
+++ b/internal/resources/pro/searches/advanced_computer_search/resource.go
@@ -10,6 +10,7 @@ import (
 	"context"
 	"time"
 
+	"github.com/Jamf-Concepts/jamfplatform-go-sdk/jamfplatform/pro"
 	"github.com/Jamf-Concepts/jamfplatform-go-sdk/jamfplatform/proclassic"
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
@@ -24,6 +25,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
 	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/common/criteria"
+	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/common/ldapgroups"
 	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/providerdata"
 )
 
@@ -36,11 +38,16 @@ const minJamfProVersion = ""
 // advanced computer searches.
 type AdvancedComputerSearchResource struct {
 	client *proclassic.Client
+	// ldap resolves directory-service group criterion names to/from the base64
+	// {uuid,serverId} wire value. Built from the shared Pro client because the
+	// classic API has no LDAP-group search of its own.
+	ldap ldapgroups.Searcher
 }
 
 var _ resource.Resource = &AdvancedComputerSearchResource{}
 var _ resource.ResourceWithImportState = &AdvancedComputerSearchResource{}
 var _ resource.ResourceWithIdentity = &AdvancedComputerSearchResource{}
+var _ resource.ResourceWithModifyPlan = &AdvancedComputerSearchResource{}
 
 const (
 	defaultCreateTimeout = 60 * time.Second
@@ -131,6 +138,9 @@ func (r *AdvancedComputerSearchResource) Configure(ctx context.Context, req reso
 		return
 	}
 	r.client = client
+	if pd, ok := req.ProviderData.(*providerdata.Data); ok {
+		r.ldap = pro.New(pd.Client)
+	}
 }
 
 // ImportState imports an advanced computer search by ID.

--- a/internal/resources/pro/searches/advanced_mobile_device_search/crud.go
+++ b/internal/resources/pro/searches/advanced_mobile_device_search/crud.go
@@ -21,8 +21,73 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
+	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/common/criteria"
 	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/common/helpers"
 )
+
+// dsGroupObjectType is the object class this resource targets, used to dispatch
+// the per-class directory-service group criterion allowlist.
+const dsGroupObjectType = criteria.ObjectTypeMobile
+
+// ModifyPlan suppresses a no-op diff when a directory-service group criterion's
+// planned value is a different REPRESENTATION of the same group already in state
+// (a raw base64 value swapped for the equivalent group name, or vice versa). It
+// resets such a criterion's planned value to the prior state value so
+// `terraform plan` shows nothing to change. Skips create (no prior state) and
+// destroy (no plan); soft — any resolve failure leaves the diff intact.
+func (r *AdvancedMobileDeviceSearchResource) ModifyPlan(ctx context.Context, req resource.ModifyPlanRequest, resp *resource.ModifyPlanResponse) {
+	if req.Plan.Raw.IsNull() || req.State.Raw.IsNull() || r.client == nil {
+		return
+	}
+	var plan, state AdvancedMobileDeviceSearchResourceModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	plannedModels, planDiags := criteria.CriteriaModelsFromList(ctx, plan.Criteria)
+	resp.Diagnostics.Append(planDiags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	if len(plannedModels) == 0 {
+		// Nothing to suppress (also covers a null/unknown planned list, which
+		// CriteriaModelsFromList returns as nil) — return before any reconversion
+		// so a null/unknown list is never spuriously flipped to an empty list.
+		return
+	}
+
+	priorModels, priorDiags := criteria.CriteriaModelsFromList(ctx, state.Criteria)
+	resp.Diagnostics.Append(priorDiags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	suppressed := criteria.SuppressEquivalentDSGroupValues(ctx, r.client, plannedModels, priorModels)
+	// Additive: only reconvert + Set when suppression actually collapsed a
+	// representation. Otherwise leave the planned types.List exactly as the
+	// framework computed it — a non-DS plan must round-trip untouched.
+	changed := false
+	for i := range suppressed {
+		if !suppressed[i].Value.Equal(plannedModels[i].Value) {
+			changed = true
+			break
+		}
+	}
+	if !changed {
+		return
+	}
+
+	suppressedList, suppressedDiags := criteria.CriteriaListValue(ctx, suppressed)
+	resp.Diagnostics.Append(suppressedDiags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	plan.Criteria = suppressedList
+
+	resp.Diagnostics.Append(resp.Plan.Set(ctx, &plan)...)
+}
 
 // Create creates a new advanced mobile device search. The Pro POST returns only
 // an href + id (not the created object), so the ID is parsed from the response
@@ -41,6 +106,23 @@ func (r *AdvancedMobileDeviceSearchResource) Create(ctx context.Context, req res
 	}
 	createCtx, cancel := context.WithTimeout(ctx, createTimeout)
 	defer cancel()
+
+	planModels, planModelDiags := criteria.CriteriaModelsFromList(createCtx, plan.Criteria)
+	resp.Diagnostics.Append(planModelDiags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	resolved, authored, dsDiags := criteria.ResolveDSGroupCriteria(createCtx, r.client, dsGroupObjectType, planModels)
+	resp.Diagnostics.Append(dsDiags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	resolvedList, resolvedDiags := criteria.CriteriaListValue(createCtx, resolved)
+	resp.Diagnostics.Append(resolvedDiags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	plan.Criteria = resolvedList
 
 	input, inputDiags := buildAdvancedMobileDeviceSearchInput(createCtx, plan)
 	resp.Diagnostics.Append(inputDiags...)
@@ -70,6 +152,19 @@ func (r *AdvancedMobileDeviceSearchResource) Create(ctx context.Context, req res
 	resp.Diagnostics.Append(assignAdvancedMobileDeviceSearchResourceModel(createCtx, &plan, got)...)
 	if resp.Diagnostics.HasError() {
 		return
+	}
+	if len(authored) > 0 {
+		flattened, flattenDiags := criteria.CriteriaModelsFromList(createCtx, plan.Criteria)
+		resp.Diagnostics.Append(flattenDiags...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+		restoredList, restoredDiags := criteria.CriteriaListValue(createCtx, criteria.RestoreAuthoredDSGroupCriteria(flattened, authored))
+		resp.Diagnostics.Append(restoredDiags...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+		plan.Criteria = restoredList
 	}
 
 	resp.Diagnostics.Append(helpers.SetIdentity(ctx, resp.Identity, advancedMobileDeviceSearchIdentityModel{ID: plan.ID})...)
@@ -143,10 +238,27 @@ func (r *AdvancedMobileDeviceSearchResource) Read(ctx context.Context, req resou
 		return
 	}
 
+	priorCriteria := state.Criteria
 	resp.Diagnostics.Append(assignAdvancedMobileDeviceSearchResourceModel(readCtx, &state, got)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
+	priorModels, priorDiags := criteria.CriteriaModelsFromList(readCtx, priorCriteria)
+	resp.Diagnostics.Append(priorDiags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	wireModels, wireDiags := criteria.CriteriaModelsFromList(readCtx, state.Criteria)
+	resp.Diagnostics.Append(wireDiags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	readbackList, readbackDiags := criteria.CriteriaListValue(readCtx, criteria.ReadbackDSGroupCriteria(readCtx, r.client, dsGroupObjectType, wireModels, priorModels))
+	resp.Diagnostics.Append(readbackDiags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	state.Criteria = readbackList
 
 	resp.Diagnostics.Append(helpers.SetIdentity(ctx, resp.Identity, advancedMobileDeviceSearchIdentityModel{ID: state.ID})...)
 	if resp.Diagnostics.HasError() {
@@ -174,6 +286,23 @@ func (r *AdvancedMobileDeviceSearchResource) Update(ctx context.Context, req res
 	updateCtx, cancel := context.WithTimeout(ctx, updateTimeout)
 	defer cancel()
 
+	planModels, planModelDiags := criteria.CriteriaModelsFromList(updateCtx, plan.Criteria)
+	resp.Diagnostics.Append(planModelDiags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	resolved, authored, dsDiags := criteria.ResolveDSGroupCriteria(updateCtx, r.client, dsGroupObjectType, planModels)
+	resp.Diagnostics.Append(dsDiags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	resolvedList, resolvedDiags := criteria.CriteriaListValue(updateCtx, resolved)
+	resp.Diagnostics.Append(resolvedDiags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	plan.Criteria = resolvedList
+
 	input, inputDiags := buildAdvancedMobileDeviceSearchInput(updateCtx, plan)
 	resp.Diagnostics.Append(inputDiags...)
 	if resp.Diagnostics.HasError() {
@@ -193,6 +322,19 @@ func (r *AdvancedMobileDeviceSearchResource) Update(ctx context.Context, req res
 	resp.Diagnostics.Append(assignAdvancedMobileDeviceSearchResourceModel(updateCtx, &plan, got)...)
 	if resp.Diagnostics.HasError() {
 		return
+	}
+	if len(authored) > 0 {
+		flattened, flattenDiags := criteria.CriteriaModelsFromList(updateCtx, plan.Criteria)
+		resp.Diagnostics.Append(flattenDiags...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+		restoredList, restoredDiags := criteria.CriteriaListValue(updateCtx, criteria.RestoreAuthoredDSGroupCriteria(flattened, authored))
+		resp.Diagnostics.Append(restoredDiags...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+		plan.Criteria = restoredList
 	}
 
 	resp.Diagnostics.Append(helpers.SetIdentity(ctx, resp.Identity, advancedMobileDeviceSearchIdentityModel{ID: plan.ID})...)

--- a/internal/resources/pro/searches/advanced_mobile_device_search/dsgroup_acceptance_test.go
+++ b/internal/resources/pro/searches/advanced_mobile_device_search/dsgroup_acceptance_test.go
@@ -1,0 +1,105 @@
+// Copyright Jamf Software LLC 2026
+// SPDX-License-Identifier: MPL-2.0
+
+//go:build acceptance
+
+package advanced_mobile_device_search_test
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strconv"
+	"testing"
+
+	"github.com/Jamf-Concepts/jamfplatform-go-sdk/jamfplatform/pro"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
+
+	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/common/criteria"
+	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/common/ldapgroups"
+	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/testhelpers"
+)
+
+// Directory-service group criteria coverage — gated behind
+// JAMFPLATFORM_ACC_CRITERIA_DS_GROUP=1 (+ _NAME). This is the highest-value DS
+// acceptance: criteria is a types.List (Optional+Computed), so the resolve /
+// readback / suppress paths bridge types.List <-> []CriterionModel — exercise
+// that round-trip end to end. See the computer-search counterpart for rationale.
+const (
+	envDSGroupGate  = "JAMFPLATFORM_ACC_CRITERIA_DS_GROUP"
+	envDSGroupName  = "JAMFPLATFORM_ACC_CRITERIA_DS_GROUP_NAME"
+	envDSGroupValue = "JAMFPLATFORM_ACC_CRITERIA_DS_GROUP_VALUE" // optional independent oracle
+)
+
+func resolveDSGroupWireValue(t *testing.T, name string) string {
+	t.Helper()
+	groups, err := ldapgroups.ResolveByName(context.Background(), pro.New(testhelpers.NewAcceptanceClient(t)), name)
+	if err != nil {
+		t.Fatalf("resolving %q: %v", name, err)
+	}
+	if len(groups) != 1 {
+		t.Fatalf("group %q must resolve to exactly one directory group (got %d) — pick an unambiguous name", name, len(groups))
+	}
+	if groups[0].UUID == "" {
+		t.Fatalf("group %q resolved with no uuid mapping", name)
+	}
+	wire := criteria.EncodeDSGroupValue(groups[0].UUID, strconv.Itoa(groups[0].LdapServerID))
+	if want := os.Getenv(envDSGroupValue); want != "" && wire != want {
+		t.Fatalf("provider resolved %q to %q, but %s=%q — name/value mismatch or an encoding bug", name, wire, envDSGroupValue, want)
+	}
+	return wire
+}
+
+// TestAccResource_AMDS_DSGroupCriteria mirrors the computer-search test on the
+// mobile (Pro v1, types.List) surface.
+func TestAccResource_AMDS_DSGroupCriteria(t *testing.T) {
+	if os.Getenv(envDSGroupGate) == "" {
+		t.Skipf("set %s=1 (plus %s) to run directory-service group criteria acceptance", envDSGroupGate, envDSGroupName)
+	}
+	groupName := os.Getenv(envDSGroupName)
+	if groupName == "" {
+		t.Skipf("%s must be set", envDSGroupName)
+	}
+	testhelpers.AccPreCheck(t)
+	groupValue := resolveDSGroupWireValue(t, groupName)
+
+	suffix := testhelpers.RunSuffix()
+	name := "tf-acc-amds-dsgroup-" + suffix
+	const rn = "jamfplatform_pro_advanced_mobile_device_search.dsgroup"
+
+	cfg := func(value string) string {
+		return fmt.Sprintf(`
+			resource "jamfplatform_pro_advanced_mobile_device_search" "dsgroup" {
+				name = %q
+				criteria = [{
+					name        = "Username directory service group"
+					search_type = "member of"
+					value       = %q
+				}]
+			}
+		`, name, value)
+	}
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testhelpers.AccTestProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckAMDSDestroy(t),
+		Steps: []resource.TestStep{
+			{
+				Config: cfg(groupName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet(rn, "id"),
+					resource.TestCheckResourceAttr(rn, "criteria.0.value", groupName),
+				),
+			},
+			{
+				Config:           cfg(groupValue),
+				ConfigPlanChecks: resource.ConfigPlanChecks{PreApply: []plancheck.PlanCheck{plancheck.ExpectEmptyPlan()}},
+			},
+			{
+				Config:           cfg(groupName),
+				ConfigPlanChecks: resource.ConfigPlanChecks{PreApply: []plancheck.PlanCheck{plancheck.ExpectEmptyPlan()}},
+			},
+		},
+	})
+}

--- a/internal/resources/pro/searches/advanced_mobile_device_search/resource.go
+++ b/internal/resources/pro/searches/advanced_mobile_device_search/resource.go
@@ -44,6 +44,7 @@ type AdvancedMobileDeviceSearchResource struct {
 var _ resource.Resource = &AdvancedMobileDeviceSearchResource{}
 var _ resource.ResourceWithImportState = &AdvancedMobileDeviceSearchResource{}
 var _ resource.ResourceWithIdentity = &AdvancedMobileDeviceSearchResource{}
+var _ resource.ResourceWithModifyPlan = &AdvancedMobileDeviceSearchResource{}
 
 const (
 	defaultCreateTimeout = 60 * time.Second

--- a/internal/resources/pro/searches/advanced_user_search/crud.go
+++ b/internal/resources/pro/searches/advanced_user_search/crud.go
@@ -20,8 +20,54 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
+	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/common/criteria"
 	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/common/helpers"
 )
+
+// dsGroupObjectType is the object class this resource targets, used to dispatch
+// the per-class directory-service group criterion allowlist.
+const dsGroupObjectType = criteria.ObjectTypeUser
+
+// ModifyPlan suppresses a no-op diff when a directory-service group criterion's
+// planned value is a different REPRESENTATION of the same group already in state
+// (a raw base64 value swapped for the equivalent group name, or vice versa). It
+// resets such a criterion's planned value to the prior state value so
+// `terraform plan` shows nothing to change. Skips create (no prior state) and
+// destroy (no plan); soft — any resolve failure leaves the diff intact.
+func (r *AdvancedUserSearchResource) ModifyPlan(ctx context.Context, req resource.ModifyPlanRequest, resp *resource.ModifyPlanResponse) {
+	if req.Plan.Raw.IsNull() || req.State.Raw.IsNull() || r.ldap == nil {
+		return
+	}
+	var plan, state AdvancedUserSearchResourceModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() || len(plan.Criteria) == 0 {
+		return
+	}
+	suppressed := criteria.SuppressEquivalentDSGroupValues(ctx, r.ldap, plan.Criteria, state.Criteria)
+	if !dsGroupCriteriaChanged(suppressed, plan.Criteria) {
+		return // additive: only touch the plan when a representation actually collapsed
+	}
+	plan.Criteria = suppressed
+	// site_name is Computed without UseStateForUnknown, so core flipped it to
+	// unknown for the (now-reverted) update. When suppression reconciled the
+	// criteria back to state, restore it so a representation-only swap is an empty
+	// plan. Safe: site_name derives from the unchanged site_id.
+	if criteria.CriteriaModelsEqual(plan.Criteria, state.Criteria) {
+		plan.SiteName = state.SiteName
+	}
+	resp.Diagnostics.Append(resp.Plan.Set(ctx, &plan)...)
+}
+
+// dsGroupCriteriaChanged reports whether suppression rewrote any criterion value.
+func dsGroupCriteriaChanged(suppressed, planned []criteria.CriterionModel) bool {
+	for i := range suppressed {
+		if !suppressed[i].Value.Equal(planned[i].Value) {
+			return true
+		}
+	}
+	return false
+}
 
 // Create creates a new advanced user search. Classic POSTs to id="0"; the server
 // allocates the real integer ID and returns it in the response body (which
@@ -40,6 +86,13 @@ func (r *AdvancedUserSearchResource) Create(ctx context.Context, req resource.Cr
 	}
 	createCtx, cancel := context.WithTimeout(ctx, createTimeout)
 	defer cancel()
+
+	resolved, authored, dsDiags := criteria.ResolveDSGroupCriteria(createCtx, r.ldap, dsGroupObjectType, plan.Criteria)
+	resp.Diagnostics.Append(dsDiags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	plan.Criteria = resolved
 
 	input, inputDiags := buildAdvancedUserSearchInput(createCtx, plan)
 	resp.Diagnostics.Append(inputDiags...)
@@ -70,6 +123,7 @@ func (r *AdvancedUserSearchResource) Create(ctx context.Context, req resource.Cr
 	if resp.Diagnostics.HasError() {
 		return
 	}
+	plan.Criteria = criteria.RestoreAuthoredDSGroupCriteria(plan.Criteria, authored)
 
 	resp.Diagnostics.Append(helpers.SetIdentity(ctx, resp.Identity, advancedUserSearchIdentityModel{ID: plan.ID})...)
 	if resp.Diagnostics.HasError() {
@@ -142,10 +196,12 @@ func (r *AdvancedUserSearchResource) Read(ctx context.Context, req resource.Read
 		return
 	}
 
+	priorCriteria := state.Criteria
 	resp.Diagnostics.Append(assignAdvancedUserSearchResourceModel(readCtx, &state, got)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
+	state.Criteria = criteria.ReadbackDSGroupCriteria(readCtx, r.ldap, dsGroupObjectType, state.Criteria, priorCriteria)
 
 	resp.Diagnostics.Append(helpers.SetIdentity(ctx, resp.Identity, advancedUserSearchIdentityModel{ID: state.ID})...)
 	if resp.Diagnostics.HasError() {
@@ -171,6 +227,13 @@ func (r *AdvancedUserSearchResource) Update(ctx context.Context, req resource.Up
 	updateCtx, cancel := context.WithTimeout(ctx, updateTimeout)
 	defer cancel()
 
+	resolved, authored, dsDiags := criteria.ResolveDSGroupCriteria(updateCtx, r.ldap, dsGroupObjectType, plan.Criteria)
+	resp.Diagnostics.Append(dsDiags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	plan.Criteria = resolved
+
 	input, inputDiags := buildAdvancedUserSearchInput(updateCtx, plan)
 	resp.Diagnostics.Append(inputDiags...)
 	if resp.Diagnostics.HasError() {
@@ -191,6 +254,7 @@ func (r *AdvancedUserSearchResource) Update(ctx context.Context, req resource.Up
 	if resp.Diagnostics.HasError() {
 		return
 	}
+	plan.Criteria = criteria.RestoreAuthoredDSGroupCriteria(plan.Criteria, authored)
 
 	resp.Diagnostics.Append(helpers.SetIdentity(ctx, resp.Identity, advancedUserSearchIdentityModel{ID: plan.ID})...)
 	if resp.Diagnostics.HasError() {

--- a/internal/resources/pro/searches/advanced_user_search/dsgroup_acceptance_test.go
+++ b/internal/resources/pro/searches/advanced_user_search/dsgroup_acceptance_test.go
@@ -1,0 +1,104 @@
+// Copyright Jamf Software LLC 2026
+// SPDX-License-Identifier: MPL-2.0
+
+//go:build acceptance
+
+package advanced_user_search_test
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strconv"
+	"testing"
+
+	"github.com/Jamf-Concepts/jamfplatform-go-sdk/jamfplatform/pro"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
+
+	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/common/criteria"
+	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/common/ldapgroups"
+	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/testhelpers"
+)
+
+// Directory-service group criteria coverage — gated behind
+// JAMFPLATFORM_ACC_CRITERIA_DS_GROUP=1 (+ _NAME = an exact LDAP/cloud-IdP group
+// name). The user surface accepts only the Username directory-service group
+// criterion. See the computer-search counterpart for the full rationale.
+const (
+	envDSGroupGate  = "JAMFPLATFORM_ACC_CRITERIA_DS_GROUP"
+	envDSGroupName  = "JAMFPLATFORM_ACC_CRITERIA_DS_GROUP_NAME"
+	envDSGroupValue = "JAMFPLATFORM_ACC_CRITERIA_DS_GROUP_VALUE" // optional independent oracle
+)
+
+func resolveDSGroupWireValue(t *testing.T, name string) string {
+	t.Helper()
+	groups, err := ldapgroups.ResolveByName(context.Background(), pro.New(testhelpers.NewAcceptanceClient(t)), name)
+	if err != nil {
+		t.Fatalf("resolving %q: %v", name, err)
+	}
+	if len(groups) != 1 {
+		t.Fatalf("group %q must resolve to exactly one directory group (got %d) — pick an unambiguous name", name, len(groups))
+	}
+	if groups[0].UUID == "" {
+		t.Fatalf("group %q resolved with no uuid mapping", name)
+	}
+	wire := criteria.EncodeDSGroupValue(groups[0].UUID, strconv.Itoa(groups[0].LdapServerID))
+	if want := os.Getenv(envDSGroupValue); want != "" && wire != want {
+		t.Fatalf("provider resolved %q to %q, but %s=%q — name/value mismatch or an encoding bug", name, wire, envDSGroupValue, want)
+	}
+	return wire
+}
+
+// TestAccResource_AUS_DSGroupCriteria mirrors the computer-search test on the
+// user surface (Username criterion only).
+func TestAccResource_AUS_DSGroupCriteria(t *testing.T) {
+	if os.Getenv(envDSGroupGate) == "" {
+		t.Skipf("set %s=1 (plus %s) to run directory-service group criteria acceptance", envDSGroupGate, envDSGroupName)
+	}
+	groupName := os.Getenv(envDSGroupName)
+	if groupName == "" {
+		t.Skipf("%s must be set", envDSGroupName)
+	}
+	testhelpers.AccPreCheck(t)
+	groupValue := resolveDSGroupWireValue(t, groupName)
+
+	suffix := testhelpers.RunSuffix()
+	name := "tf-acc-aus-dsgroup-" + suffix
+	const rn = "jamfplatform_pro_advanced_user_search.dsgroup"
+
+	cfg := func(value string) string {
+		return fmt.Sprintf(`
+			resource "jamfplatform_pro_advanced_user_search" "dsgroup" {
+				name = %q
+				criteria = [{
+					name        = "Username directory service group"
+					search_type = "member of"
+					value       = %q
+				}]
+			}
+		`, name, value)
+	}
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testhelpers.AccTestProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckAUSDestroy(t),
+		Steps: []resource.TestStep{
+			{
+				Config: cfg(groupName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet(rn, "id"),
+					resource.TestCheckResourceAttr(rn, "criteria.0.value", groupName),
+				),
+			},
+			{
+				Config:           cfg(groupValue),
+				ConfigPlanChecks: resource.ConfigPlanChecks{PreApply: []plancheck.PlanCheck{plancheck.ExpectEmptyPlan()}},
+			},
+			{
+				Config:           cfg(groupName),
+				ConfigPlanChecks: resource.ConfigPlanChecks{PreApply: []plancheck.PlanCheck{plancheck.ExpectEmptyPlan()}},
+			},
+		},
+	})
+}

--- a/internal/resources/pro/searches/advanced_user_search/resource.go
+++ b/internal/resources/pro/searches/advanced_user_search/resource.go
@@ -10,6 +10,7 @@ import (
 	"context"
 	"time"
 
+	"github.com/Jamf-Concepts/jamfplatform-go-sdk/jamfplatform/pro"
 	"github.com/Jamf-Concepts/jamfplatform-go-sdk/jamfplatform/proclassic"
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
@@ -24,6 +25,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
 	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/common/criteria"
+	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/common/ldapgroups"
 	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/providerdata"
 )
 
@@ -36,11 +38,16 @@ const minJamfProVersion = ""
 // advanced user searches.
 type AdvancedUserSearchResource struct {
 	client *proclassic.Client
+	// ldap resolves directory-service group criterion names to/from the base64
+	// {uuid,serverId} wire value. Built from the shared Pro client because the
+	// classic API has no LDAP-group search of its own.
+	ldap ldapgroups.Searcher
 }
 
 var _ resource.Resource = &AdvancedUserSearchResource{}
 var _ resource.ResourceWithImportState = &AdvancedUserSearchResource{}
 var _ resource.ResourceWithIdentity = &AdvancedUserSearchResource{}
+var _ resource.ResourceWithModifyPlan = &AdvancedUserSearchResource{}
 
 const (
 	defaultCreateTimeout = 60 * time.Second
@@ -131,6 +138,9 @@ func (r *AdvancedUserSearchResource) Configure(ctx context.Context, req resource
 		return
 	}
 	r.client = client
+	if pd, ok := req.ProviderData.(*providerdata.Data); ok {
+		r.ldap = pro.New(pd.Client)
+	}
 }
 
 // ImportState imports an advanced user search by ID.

--- a/internal/resources/pro/users/user_group/crud.go
+++ b/internal/resources/pro/users/user_group/crud.go
@@ -21,8 +21,95 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
+	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/common/criteria"
 	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/common/helpers"
 )
+
+// dsGroupObjectType is the object class this resource targets, used to dispatch
+// the per-class directory-service group criterion allowlist. User groups accept
+// only the Username directory-service group criterion.
+const dsGroupObjectType = criteria.ObjectTypeUser
+
+// toCriterionModels / fromCriterionModels bridge the user-group criterion model
+// to the shared criteria.CriterionModel (field-identical) so the directory-service
+// group resolve/restore/readback/suppress helpers can be reused. The shared
+// helpers only ever mutate Value; every other field round-trips unchanged.
+func toCriterionModels(in []UserGroupCriterionModel) []criteria.CriterionModel {
+	if in == nil {
+		return nil // preserve nil (no-criteria static group) — never flip nil -> []
+	}
+	out := make([]criteria.CriterionModel, len(in))
+	for i, c := range in {
+		out[i] = criteria.CriterionModel{
+			Priority:              c.Priority,
+			Name:                  c.Name,
+			SearchType:            c.SearchType,
+			Value:                 c.Value,
+			AndOr:                 c.AndOr,
+			HasOpeningParenthesis: c.HasOpeningParenthesis,
+			HasClosingParenthesis: c.HasClosingParenthesis,
+		}
+	}
+	return out
+}
+
+func fromCriterionModels(in []criteria.CriterionModel) []UserGroupCriterionModel {
+	if in == nil {
+		return nil // preserve nil — never flip nil -> []
+	}
+	out := make([]UserGroupCriterionModel, len(in))
+	for i, c := range in {
+		out[i] = UserGroupCriterionModel{
+			Priority:              c.Priority,
+			Name:                  c.Name,
+			SearchType:            c.SearchType,
+			Value:                 c.Value,
+			AndOr:                 c.AndOr,
+			HasOpeningParenthesis: c.HasOpeningParenthesis,
+			HasClosingParenthesis: c.HasClosingParenthesis,
+		}
+	}
+	return out
+}
+
+// ModifyPlan suppresses a no-op diff when a directory-service group criterion's
+// planned value is a different REPRESENTATION of the same group already in state
+// (a raw base64 value swapped for the equivalent group name, or vice versa).
+// Skips create (no prior state) and destroy (no plan); soft — any resolve
+// failure leaves the diff intact.
+func (r *UserGroupResource) ModifyPlan(ctx context.Context, req resource.ModifyPlanRequest, resp *resource.ModifyPlanResponse) {
+	if req.Plan.Raw.IsNull() || req.State.Raw.IsNull() || r.ldap == nil {
+		return
+	}
+	var plan, state UserGroupResourceModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() || len(plan.Criteria) == 0 {
+		return
+	}
+	planModels := toCriterionModels(plan.Criteria)
+	suppressed := criteria.SuppressEquivalentDSGroupValues(ctx, r.ldap, planModels, toCriterionModels(state.Criteria))
+	changed := false
+	for i := range suppressed {
+		if !suppressed[i].Value.Equal(planModels[i].Value) {
+			changed = true
+			break
+		}
+	}
+	if !changed {
+		return // additive: only touch the plan when a representation actually collapsed
+	}
+	plan.Criteria = fromCriterionModels(suppressed)
+	// member_count is Computed without UseStateForUnknown, so core flipped it to
+	// unknown for the (now-reverted) update. When suppression reconciled the
+	// criteria back to state, restore it so a representation-only swap is an empty
+	// plan. Safe: member_count depends only on membership, which is unchanged when
+	// the criteria are equal. (site_name already uses UseStateForUnknown.)
+	if criteria.CriteriaModelsEqual(suppressed, toCriterionModels(state.Criteria)) {
+		plan.MemberCount = state.MemberCount
+	}
+	resp.Diagnostics.Append(resp.Plan.Set(ctx, &plan)...)
+}
 
 // Create creates a new Jamf Pro user group. Classic POSTs to id="0"; the
 // server allocates the real integer ID and returns it in the response body.
@@ -56,6 +143,13 @@ func (r *UserGroupResource) Create(ctx context.Context, req resource.CreateReque
 		return
 	}
 
+	resolved, authored, dsDiags := criteria.ResolveDSGroupCriteria(createCtx, r.ldap, dsGroupObjectType, toCriterionModels(plan.Criteria))
+	resp.Diagnostics.Append(dsDiags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	plan.Criteria = fromCriterionModels(resolved)
+
 	input, inputDiags := buildUserGroupInput(createCtx, plan)
 	resp.Diagnostics.Append(inputDiags...)
 	if resp.Diagnostics.HasError() {
@@ -85,6 +179,7 @@ func (r *UserGroupResource) Create(ctx context.Context, req resource.CreateReque
 	if resp.Diagnostics.HasError() {
 		return
 	}
+	plan.Criteria = fromCriterionModels(criteria.RestoreAuthoredDSGroupCriteria(toCriterionModels(plan.Criteria), authored))
 
 	resp.Diagnostics.Append(helpers.SetIdentity(ctx, resp.Identity, userGroupIdentityModel{ID: plan.ID})...)
 	if resp.Diagnostics.HasError() {
@@ -158,10 +253,12 @@ func (r *UserGroupResource) Read(ctx context.Context, req resource.ReadRequest, 
 	}
 
 	manageMembers := helpers.IsConfiguredValue(state.Members)
+	priorCriteria := toCriterionModels(state.Criteria)
 	resp.Diagnostics.Append(assignUserGroupResourceModel(readCtx, &state, got, manageMembers)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
+	state.Criteria = fromCriterionModels(criteria.ReadbackDSGroupCriteria(readCtx, r.ldap, dsGroupObjectType, toCriterionModels(state.Criteria), priorCriteria))
 
 	resp.Diagnostics.Append(helpers.SetIdentity(ctx, resp.Identity, userGroupIdentityModel{ID: state.ID})...)
 	if resp.Diagnostics.HasError() {
@@ -199,6 +296,13 @@ func (r *UserGroupResource) Update(ctx context.Context, req resource.UpdateReque
 		return
 	}
 
+	resolved, authored, dsDiags := criteria.ResolveDSGroupCriteria(updateCtx, r.ldap, dsGroupObjectType, toCriterionModels(plan.Criteria))
+	resp.Diagnostics.Append(dsDiags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	plan.Criteria = fromCriterionModels(resolved)
+
 	input, inputDiags := buildUserGroupInput(updateCtx, plan)
 	resp.Diagnostics.Append(inputDiags...)
 	if resp.Diagnostics.HasError() {
@@ -219,6 +323,7 @@ func (r *UserGroupResource) Update(ctx context.Context, req resource.UpdateReque
 	if resp.Diagnostics.HasError() {
 		return
 	}
+	plan.Criteria = fromCriterionModels(criteria.RestoreAuthoredDSGroupCriteria(toCriterionModels(plan.Criteria), authored))
 
 	resp.Diagnostics.Append(helpers.SetIdentity(ctx, resp.Identity, userGroupIdentityModel{ID: plan.ID})...)
 	if resp.Diagnostics.HasError() {

--- a/internal/resources/pro/users/user_group/dsgroup_acceptance_test.go
+++ b/internal/resources/pro/users/user_group/dsgroup_acceptance_test.go
@@ -1,0 +1,105 @@
+// Copyright Jamf Software LLC 2026
+// SPDX-License-Identifier: MPL-2.0
+
+//go:build acceptance
+
+package user_group_test
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strconv"
+	"testing"
+
+	"github.com/Jamf-Concepts/jamfplatform-go-sdk/jamfplatform/pro"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
+
+	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/common/criteria"
+	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/common/ldapgroups"
+	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/testhelpers"
+)
+
+// Directory-service group criteria coverage — gated behind
+// JAMFPLATFORM_ACC_CRITERIA_DS_GROUP=1 (+ _NAME). Exercises the user_group
+// own-model path (to/fromCriterionModels converters + member_count restore on a
+// representation swap). The user surface accepts only the Username criterion.
+const (
+	envDSGroupGate  = "JAMFPLATFORM_ACC_CRITERIA_DS_GROUP"
+	envDSGroupName  = "JAMFPLATFORM_ACC_CRITERIA_DS_GROUP_NAME"
+	envDSGroupValue = "JAMFPLATFORM_ACC_CRITERIA_DS_GROUP_VALUE" // optional independent oracle
+)
+
+func resolveDSGroupWireValue(t *testing.T, name string) string {
+	t.Helper()
+	groups, err := ldapgroups.ResolveByName(context.Background(), pro.New(testhelpers.NewAcceptanceClient(t)), name)
+	if err != nil {
+		t.Fatalf("resolving %q: %v", name, err)
+	}
+	if len(groups) != 1 {
+		t.Fatalf("group %q must resolve to exactly one directory group (got %d) — pick an unambiguous name", name, len(groups))
+	}
+	if groups[0].UUID == "" {
+		t.Fatalf("group %q resolved with no uuid mapping", name)
+	}
+	wire := criteria.EncodeDSGroupValue(groups[0].UUID, strconv.Itoa(groups[0].LdapServerID))
+	if want := os.Getenv(envDSGroupValue); want != "" && wire != want {
+		t.Fatalf("provider resolved %q to %q, but %s=%q — name/value mismatch or an encoding bug", name, wire, envDSGroupValue, want)
+	}
+	return wire
+}
+
+// TestAccResource_ProUserGroup_DSGroupCriteria mirrors the search tests on the
+// classic user-group surface (smart group, Username criterion only).
+func TestAccResource_ProUserGroup_DSGroupCriteria(t *testing.T) {
+	if os.Getenv(envDSGroupGate) == "" {
+		t.Skipf("set %s=1 (plus %s) to run directory-service group criteria acceptance", envDSGroupGate, envDSGroupName)
+	}
+	groupName := os.Getenv(envDSGroupName)
+	if groupName == "" {
+		t.Skipf("%s must be set", envDSGroupName)
+	}
+	testhelpers.AccPreCheck(t)
+	groupValue := resolveDSGroupWireValue(t, groupName)
+
+	suffix := testhelpers.RunSuffix()
+	name := "tf-acc-ug-dsgroup-" + suffix
+	const rn = "jamfplatform_pro_user_group.dsgroup"
+
+	cfg := func(value string) string {
+		return fmt.Sprintf(`
+			resource "jamfplatform_pro_user_group" "dsgroup" {
+				name       = %q
+				group_type = "smart"
+				criteria = [{
+					name        = "Username directory service group"
+					search_type = "member of"
+					value       = %q
+				}]
+			}
+		`, name, value)
+	}
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testhelpers.AccTestProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckUserGroupDestroy(t),
+		Steps: []resource.TestStep{
+			{
+				Config: cfg(groupName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet(rn, "id"),
+					resource.TestCheckResourceAttr(rn, "criteria.0.value", groupName),
+				),
+			},
+			{
+				Config:           cfg(groupValue),
+				ConfigPlanChecks: resource.ConfigPlanChecks{PreApply: []plancheck.PlanCheck{plancheck.ExpectEmptyPlan()}},
+			},
+			{
+				Config:           cfg(groupName),
+				ConfigPlanChecks: resource.ConfigPlanChecks{PreApply: []plancheck.PlanCheck{plancheck.ExpectEmptyPlan()}},
+			},
+		},
+	})
+}

--- a/internal/resources/pro/users/user_group/resource.go
+++ b/internal/resources/pro/users/user_group/resource.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"time"
 
+	"github.com/Jamf-Concepts/jamfplatform-go-sdk/jamfplatform/pro"
 	"github.com/Jamf-Concepts/jamfplatform-go-sdk/jamfplatform/proclassic"
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
@@ -25,6 +26,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
 	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/common/criteria"
+	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/common/ldapgroups"
 	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/providerdata"
 )
 
@@ -35,12 +37,17 @@ const minJamfProVersion = ""
 // UserGroupResource implements the Terraform resource for Jamf Pro user groups.
 type UserGroupResource struct {
 	client *proclassic.Client
+	// ldap resolves directory-service group criterion names to/from the base64
+	// {uuid,serverId} wire value. Built from the shared Pro client because the
+	// classic API has no LDAP-group search of its own.
+	ldap ldapgroups.Searcher
 }
 
 var _ resource.Resource = &UserGroupResource{}
 var _ resource.ResourceWithImportState = &UserGroupResource{}
 var _ resource.ResourceWithIdentity = &UserGroupResource{}
 var _ resource.ResourceWithConfigValidators = &UserGroupResource{}
+var _ resource.ResourceWithModifyPlan = &UserGroupResource{}
 
 const (
 	defaultCreateTimeout = 60 * time.Second
@@ -160,6 +167,9 @@ func (r *UserGroupResource) Configure(ctx context.Context, req resource.Configur
 		return
 	}
 	r.client = client
+	if pd, ok := req.ProviderData.(*providerdata.Data); ok {
+		r.ldap = pro.New(pd.Client)
+	}
 }
 
 // ImportState handles import by the Jamf Pro user group ID.


### PR DESCRIPTION
## What

Jamf Pro 11.29 adds **directory-service-group** criteria to smart groups and advanced searches. On the wire the criterion **value** is not a group name — it is a base64-encoded `{"uuid":"…","serverId":"…"}` blob resolving an LDAP / cloud-IdP group. This PR adds a shared helper so users author the group by **name** (or paste the raw base64) and the provider maps it transparently, wired into all five criteria-bearing constructs:

- `jamfplatform_device_group` (Platform)
- `jamfplatform_pro_user_group` (ProClassic)
- `jamfplatform_pro_advanced_computer_search` / `_user_search` (ProClassic)
- `jamfplatform_pro_advanced_mobile_device_search` (Pro JSON)

```hcl
criteria = [{
  criteria    = "Username directory service group"  # device_group: criteria/operator/value
  operator    = "member of"
  value       = "DataJAR_Admins"                    # provider resolves → base64 on write, back to name on read
}]
```

## How

New `internal/common/criteria/dsgroup.go`:
- **Two-tier name check** — set A (is it a DS-group criterion → encode the value) + per-object-class allowlist set B (computer 5 / mobile 4 / user 1), fail-closed at apply for an out-of-class name.
- `ResolveValue` (write; hard-errors on not-found / ambiguous / no-uuid / malformed), `ReadValue` (read; **soft** — drift surfaces as the wire base64, never errors), `ParseEncodedValue` (offline shape gate).
- Plan-time **diff suppression** (`ModifyPlan`): swapping a name for its equivalent base64 (or vice versa) is a no-op — empty plan. Suppression reconciles sibling fields core left `Unknown` (e.g. `priority`) and restores Computed-without-`UseStateForUnknown` siblings (`member_count` / `site_name`) when the criteria fully match state.

State keeps the readable **name**; raw base64 is a first-class input (escape hatch for multi-server disambiguation / copy-paste).

### Criterion casing (corrected vs the Jamf 11.29 doc)
Re-probed live against all five surfaces: every surface is **case-sensitive** on the whole string and the canonical form is **title-case** (`Assigned User…`, and `…- Mdm…` **not** `MDM`). Matrix: computer accepts all five; mobile drops the Computer criterion; the user surfaces accept **only** `Username directory service group`.

## Tests

- **Unit** (`dsgroup_test.go`): parse/resolve/read/equivalence/allowlist; encoding **byte-pinned to a real wire blob**.
- **Acceptance** (env-gated `JAMFPLATFORM_ACC_CRITERIA_DS_GROUP=1` + `_NAME`, optional `_VALUE` wire-oracle): each of the five resources runs a **name → base64 → name** empty-plan round-trip; self-computes the swap base64 from `_NAME` via the same LDAP search the provider uses. All green.

## Known follow-up (not introduced here)

Jamf Pro 11.29 also changed how **Jamf-group `member of`** criteria round-trip (the `"User Group" member of <name>` case in `user_group` `Smart_AllOperators`, and the equivalent on `device_group`): the server now echoes the group **id**, not the name, so those pre-existing acceptance subtests fail on `feat/pro-expansion` independently of this change (`"User Group"` is not a directory-service-group criterion and is untouched by this helper). Tracked for a separate investigation + a possible name→id fallback resolver.

🤖 Generated with [Claude Code](https://claude.com/claude-code)