### PR TITLE
fix(criteria): resolve Jamf-group "member of" criteria name↔id (Jamf Pro 11.29)

### DIFF
--- a/internal/common/criteria/groupref.go
+++ b/internal/common/criteria/groupref.go
@@ -1,0 +1,309 @@
+// Copyright Jamf Software LLC 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package criteria
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-framework/types"
+
+	"github.com/Jamf-Concepts/jamfplatform-go-sdk/jamfplatform/proclassic"
+)
+
+// Jamf-group "member of" criteria reference a Jamf group (computer / mobile-device
+// / user group — NOT a directory-service group; that family lives in dsgroup.go)
+// by NAME as their criterion VALUE. Jamf Pro 11.29 changed the read behaviour on
+// two surfaces: a value authored by name comes back as the group's numeric ID,
+// where it previously round-tripped the name. Left unmapped this trips "Provider
+// produced inconsistent result after apply" and then a perpetual name-vs-id diff.
+//
+// This file maps the wire value back to the authored group name on read. The
+// mapping is a FALLBACK, never a blind "the wire is an id": when the wire already
+// equals the configured value it is kept verbatim with no lookup, so the same code
+// path serves both pre-11.29 Jamf Pro (returns the name) and 11.29+ (returns the
+// id) with no version branch. See spike/JAMF_GROUP_MEMBER_OF_CRITERIA_SPIKE.md for
+// the per-surface wire-probe matrix. Only two (surface, criterion) pairs regress
+// and are wired: user_group/"User Group" and device_group/"Computer Group" (the
+// COMPUTER device type — MOBILE is clean but shares device_group's code path, where
+// wire==config holds so the resolver never fires). The three advanced searches are
+// confirmed clean and intentionally NOT wired; if a future Jamf release flips one,
+// the criterion name is already mapped per object class in jamfGroupCriterionName.
+//
+// Unlike dsgroup, the WRITE is a pure pass-through: the server accepts the group
+// name verbatim and stores the id itself, so there is no name->wire resolution at
+// apply — only the read-side id->name reverse-resolve, plus a ModifyPlan no-op
+// suppression for the case where a user pastes the equivalent id.
+
+// GroupResolver maps a Jamf group between its name and numeric id for the
+// ObjectType-appropriate collection (computer / mobile-device / user groups).
+// Defined as an interface so the value-level helpers are unit-testable without a
+// live client; NewProGroupResolver is the production proclassic-backed adapter.
+type GroupResolver interface {
+	// NameByID returns the canonical group name for a numeric id, or an error if
+	// the id is non-numeric, not found, or the lookup fails. Read callers treat
+	// any error as "cannot map" and surface the wire value as drift.
+	NameByID(ctx context.Context, ot ObjectType, id string) (string, error)
+	// IDByName returns the numeric id for an exact group name. Used only by
+	// plan-time equivalence (recognising a name<->id no-op swap).
+	IDByName(ctx context.Context, ot ObjectType, name string) (string, error)
+}
+
+// jamfGroupCriterionName is the per-object-class group-membership criterion name
+// (1:1 with a group collection). A criterion with this name AND a member-of
+// operator carries a group reference whose value Jamf Pro 11.29 may echo as an id.
+var jamfGroupCriterionName = map[ObjectType]string{
+	ObjectTypeComputer: "Computer Group",
+	ObjectTypeMobile:   "Mobile Device Group",
+	ObjectTypeUser:     "User Group",
+}
+
+// isMemberOfOperator reports whether searchType is the membership operator family.
+// Case-insensitive: the shared CriterionModel stores the lowercase classic form
+// ("member of"); device_group's own model also lowercases on flatten, but the
+// Platform wire is UPPERCASE — EqualFold covers every surface.
+func isMemberOfOperator(searchType string) bool {
+	return strings.EqualFold(searchType, "member of") || strings.EqualFold(searchType, "not member of")
+}
+
+// IsJamfGroupCriterion reports whether a criterion is a Jamf-group membership
+// reference for the given object class — its name matches the class's group
+// criterion AND the operator is member-of / not-member-of. Such a criterion's
+// value is a group name that Jamf Pro 11.29 reads back as a numeric id.
+func IsJamfGroupCriterion(ot ObjectType, name, searchType string) bool {
+	want, ok := jamfGroupCriterionName[ot]
+	return ok && name == want && isMemberOfOperator(searchType)
+}
+
+// ReadGroupValue maps a Jamf-group criterion's wire value back to the authored
+// group name. Version-agnostic and SOFT — any lookup failure surfaces the wire
+// value as drift, never an error (a single server-side change must not break every
+// subsequent `terraform plan`):
+//
+//   - prior == "" (import / data source) -> reverse-resolve wire id->name; fall
+//     back to wire on failure (pre-11.29 wire is already a name, so resolving it
+//     as an id fails and the name passes through unchanged).
+//   - wire == prior (case-insensitive) -> keep prior. Covers a pre-11.29 name
+//     round-trip and the steady state where state already holds the name; NO
+//     lookup, so it works even without the group-read privilege. Case-preserving
+//     (keeps the authored spelling) to suppress canonicalisation churn.
+//   - wire != prior -> reverse-resolve wire as an id; if it names the prior group,
+//     keep the prior (authored) value; else surface wire (genuine drift: the group
+//     was renamed/changed, or the value is unresolvable).
+func ReadGroupValue(ctx context.Context, resolver GroupResolver, ot ObjectType, wire, prior string) string {
+	if prior == "" {
+		if name, err := resolver.NameByID(ctx, ot, wire); err == nil && name != "" {
+			return name
+		}
+		return wire
+	}
+	if strings.EqualFold(wire, prior) {
+		return prior
+	}
+	if name, err := resolver.NameByID(ctx, ot, wire); err == nil && strings.EqualFold(name, prior) {
+		return prior
+	}
+	return wire
+}
+
+// GroupValuesEquivalent reports whether two Jamf-group criterion values reference
+// the same group — equal (case-insensitively), or one is the numeric id of the
+// other. SOFT: any lookup failure -> false (show the diff, never block plan). Used
+// by ModifyPlan to suppress a no-op name<->id swap.
+func GroupValuesEquivalent(ctx context.Context, resolver GroupResolver, ot ObjectType, a, b string) bool {
+	if strings.EqualFold(a, b) {
+		return true
+	}
+	ka := canonicalGroupID(ctx, resolver, ot, a)
+	kb := canonicalGroupID(ctx, resolver, ot, b)
+	return ka != "" && ka == kb
+}
+
+// canonicalGroupID reduces a value (name or id) to its numeric group id, or "" if
+// it cannot be resolved. Tries name->id first (the common authored form); falls
+// back to treating the value as an id validated via id->name.
+//
+// Precedence is NAME-first, and deliberately so: an ambiguous numeric value (e.g.
+// "25", when a group is literally NAMED "25" and a different group has ID 25)
+// resolves to the group with that NAME. The author-by-name model is the contract,
+// so a group is always reachable by its name; a raw numeric only reaches a group
+// named that number, or — if none is — is treated as a literal id. Every helper
+// here (canonicalGroupID, the device_group write resolver) uses this same
+// name-first order so write, read, and plan-time equivalence agree.
+func canonicalGroupID(ctx context.Context, resolver GroupResolver, ot ObjectType, v string) string {
+	if id, err := resolver.IDByName(ctx, ot, v); err == nil && id != "" {
+		return id
+	}
+	if _, err := resolver.NameByID(ctx, ot, v); err == nil {
+		return v
+	}
+	return ""
+}
+
+// ---- CriterionModel layer (user_group + the three advanced searches) ---------
+//
+// These wire the value-level helpers into the []CriterionModel path. device_group
+// has its own criterion model and calls the value-level helpers directly (see
+// internal/resources/device_group/groupref.go).
+
+// ReadbackGroupRefCriteria maps each Jamf-group criterion's wire value back to the
+// authored group name. Call in Read with prior=state, and after the post-write
+// flatten in Create/Update with prior=plan. wireModels are the freshly flattened
+// criteria; prior supplies the authored form, zipped by index + guarded by a name
+// match (import / data source / reorder -> no aligned prior -> wire passes the
+// import branch of ReadGroupValue). SOFT; preserves nil/empty.
+func ReadbackGroupRefCriteria(ctx context.Context, resolver GroupResolver, ot ObjectType, wireModels, prior []CriterionModel) []CriterionModel {
+	if len(wireModels) == 0 || resolver == nil {
+		return wireModels // preserve nil/empty; never flip nil -> []
+	}
+	out := make([]CriterionModel, len(wireModels))
+	copy(out, wireModels)
+	for i := range out {
+		name := out[i].Name.ValueString()
+		if !IsJamfGroupCriterion(ot, name, out[i].SearchType.ValueString()) {
+			continue
+		}
+		p := ""
+		if i < len(prior) && prior[i].Name.ValueString() == name {
+			p = prior[i].Value.ValueString()
+		}
+		out[i].Value = types.StringValue(ReadGroupValue(ctx, resolver, ot, out[i].Value.ValueString(), p))
+	}
+	return out
+}
+
+// ResolveAuthoredGroupRefMap (Create/Update, BEFORE the write) resolves each
+// Jamf-group criterion's authored value to the numeric id a 11.29+ server echoes
+// on read, returning a map id->authoredValue. RestoreAuthoredGroupRefCriteria uses
+// it after the post-write flatten to put the authored name back independent of any
+// server-side criteria reorder — mirroring dsgroup's byte-stable authored map,
+// which keys by the base64 wire value. Best-effort and SOFT: an unresolvable
+// criterion is omitted. A pre-11.29 server echoes the name (not an id), so the map
+// simply misses on read-back and the authored name passes through unchanged —
+// correct on both server versions with no version branch.
+func ResolveAuthoredGroupRefMap(ctx context.Context, resolver GroupResolver, ot ObjectType, models []CriterionModel) map[string]string {
+	out := map[string]string{}
+	if resolver == nil {
+		return out
+	}
+	for i := range models {
+		name := models[i].Name.ValueString()
+		if !IsJamfGroupCriterion(ot, name, models[i].SearchType.ValueString()) {
+			continue
+		}
+		v := models[i].Value.ValueString()
+		if id, err := resolver.IDByName(ctx, ot, v); err == nil && id != "" {
+			out[id] = v // authored as a name -> the server stores this id
+		} else if _, err := resolver.NameByID(ctx, ot, v); err == nil {
+			out[v] = v // authored as an id already -> the server echoes it verbatim
+		}
+	}
+	return out
+}
+
+// RestoreAuthoredGroupRefCriteria rewrites each Jamf-group criterion's flattened
+// wire value back to the authored value using the map from
+// ResolveAuthoredGroupRefMap. The wire id is by definition the id of the group we
+// just wrote by name, so this restore is unconditional (no resolver call, no
+// post-apply inconsistency risk). A criterion whose wire value is absent from the
+// map (pre-11.29 name echo, or an authored value that did not resolve) is left as
+// flattened. Pure; call in Create/Update after the flatten. Preserves nil/empty.
+func RestoreAuthoredGroupRefCriteria(flattened []CriterionModel, authored map[string]string, ot ObjectType) []CriterionModel {
+	if len(authored) == 0 || len(flattened) == 0 {
+		return flattened
+	}
+	out := make([]CriterionModel, len(flattened))
+	copy(out, flattened)
+	for i := range out {
+		if !IsJamfGroupCriterion(ot, out[i].Name.ValueString(), out[i].SearchType.ValueString()) {
+			continue
+		}
+		if v, ok := authored[out[i].Value.ValueString()]; ok {
+			out[i].Value = types.StringValue(v)
+		}
+	}
+	return out
+}
+
+// SuppressEquivalentGroupRefValues resets a planned Jamf-group criterion value to
+// the prior state value when both reference the same group (a name<->id swap),
+// suppressing a no-op diff. Aligned by index + name match; SOFT. Reconciles
+// siblings the plan left Unknown via reconcileCriterionToPrior (shared with
+// dsgroup). Call from ModifyPlan. Preserves nil/empty.
+func SuppressEquivalentGroupRefValues(ctx context.Context, resolver GroupResolver, ot ObjectType, planned, prior []CriterionModel) []CriterionModel {
+	if len(planned) == 0 || resolver == nil {
+		return planned // preserve nil/empty
+	}
+	out := make([]CriterionModel, len(planned))
+	copy(out, planned)
+	for i := range out {
+		name := out[i].Name.ValueString()
+		if !IsJamfGroupCriterion(ot, name, out[i].SearchType.ValueString()) {
+			continue
+		}
+		if i >= len(prior) || prior[i].Name.ValueString() != name {
+			continue
+		}
+		if GroupValuesEquivalent(ctx, resolver, ot, out[i].Value.ValueString(), prior[i].Value.ValueString()) {
+			out[i] = reconcileCriterionToPrior(out[i], prior[i])
+		}
+	}
+	return out
+}
+
+// ---- proclassic-backed resolver --------------------------------------------
+
+// proGroupResolver implements GroupResolver against the proclassic SDK client. The
+// classic group endpoints back every surface: device_group-COMPUTER membership
+// stores CLASSIC computer-group ids (wire-probed), so even the Platform device
+// group resolves its "Computer Group" reference here, not via Pro /v2/groups.
+type proGroupResolver struct{ c *proclassic.Client }
+
+// NewProGroupResolver returns the production GroupResolver. Construct it per
+// resource from the shared SDK client: criteria.NewProGroupResolver(proclassic.New(pd.Client)).
+func NewProGroupResolver(c *proclassic.Client) GroupResolver { return &proGroupResolver{c: c} }
+
+func (r *proGroupResolver) NameByID(ctx context.Context, ot ObjectType, id string) (string, error) {
+	switch ot {
+	case ObjectTypeMobile:
+		g, err := r.c.GetMobileDeviceGroupByID(ctx, id)
+		if err != nil {
+			return "", err
+		}
+		if g.Name == nil {
+			return "", fmt.Errorf("mobile device group id %q has no name", id)
+		}
+		return *g.Name, nil
+	case ObjectTypeUser:
+		g, err := r.c.GetUserGroupByID(ctx, id)
+		if err != nil {
+			return "", err
+		}
+		if g.Name == nil {
+			return "", fmt.Errorf("user group id %q has no name", id)
+		}
+		return *g.Name, nil
+	default: // ObjectTypeComputer
+		g, err := r.c.GetComputerGroupByID(ctx, id)
+		if err != nil {
+			return "", err
+		}
+		if g.Name == nil {
+			return "", fmt.Errorf("computer group id %q has no name", id)
+		}
+		return *g.Name, nil
+	}
+}
+
+func (r *proGroupResolver) IDByName(ctx context.Context, ot ObjectType, name string) (string, error) {
+	switch ot {
+	case ObjectTypeMobile:
+		return r.c.ResolveMobileDeviceGroupIDByName(ctx, name)
+	case ObjectTypeUser:
+		return r.c.ResolveUserGroupIDByName(ctx, name)
+	default: // ObjectTypeComputer
+		return r.c.ResolveComputerGroupIDByName(ctx, name)
+	}
+}

--- a/internal/common/criteria/groupref_test.go
+++ b/internal/common/criteria/groupref_test.go
@@ -1,0 +1,249 @@
+// Copyright Jamf Software LLC 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package criteria
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+// fakeGroupResolver models the proclassic group endpoints with an in-memory
+// id<->name table. calls counts every lookup so a test can assert the
+// backward-compatibility fast path performs NO lookup. err forces every lookup to
+// fail (transient / missing-privilege simulation).
+type fakeGroupResolver struct {
+	byID  map[string]string // id -> canonical name
+	calls int
+	err   error
+}
+
+func (f *fakeGroupResolver) NameByID(_ context.Context, _ ObjectType, id string) (string, error) {
+	f.calls++
+	if f.err != nil {
+		return "", f.err
+	}
+	if n, ok := f.byID[id]; ok {
+		return n, nil
+	}
+	return "", errors.New("not found")
+}
+
+func (f *fakeGroupResolver) IDByName(_ context.Context, _ ObjectType, name string) (string, error) {
+	f.calls++
+	if f.err != nil {
+		return "", f.err
+	}
+	for id, n := range f.byID {
+		if strings.EqualFold(n, name) { // /name/<n> classic lookup is case-insensitive
+			return id, nil
+		}
+	}
+	return "", errors.New("not found")
+}
+
+func newResolver() *fakeGroupResolver {
+	return &fakeGroupResolver{byID: map[string]string{"3": "Excluded Users", "25": "All 10.16+ Devices"}}
+}
+
+func crit(name, op, value string) CriterionModel {
+	return CriterionModel{
+		Name:       types.StringValue(name),
+		SearchType: types.StringValue(op),
+		Value:      types.StringValue(value),
+		Priority:   types.Int64Value(0),
+	}
+}
+
+func TestIsJamfGroupCriterion(t *testing.T) {
+	tests := []struct {
+		ot       ObjectType
+		name, op string
+		want     bool
+		desc     string
+	}{
+		{ObjectTypeUser, "User Group", "member of", true, "user group member of"},
+		{ObjectTypeUser, "User Group", "not member of", true, "user group not member of"},
+		{ObjectTypeUser, "User Group", "MEMBER OF", true, "operator case-insensitive"},
+		{ObjectTypeComputer, "Computer Group", "member of", true, "computer group"},
+		{ObjectTypeMobile, "Mobile Device Group", "member of", true, "mobile group"},
+		{ObjectTypeUser, "User Group", "is", false, "non-membership operator"},
+		{ObjectTypeUser, "Full Name", "member of", false, "non-group criterion name"},
+		{ObjectTypeComputer, "User Group", "member of", false, "wrong name for class"},
+		{ObjectTypeUser, "user group", "member of", false, "criterion name is case-sensitive"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			if got := IsJamfGroupCriterion(tt.ot, tt.name, tt.op); got != tt.want {
+				t.Fatalf("IsJamfGroupCriterion(%v,%q,%q) = %v, want %v", tt.ot, tt.name, tt.op, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestReadGroupValue_BackwardCompatNoLookup is the load-bearing backward-compat
+// assertion: when the wire value already equals the configured value (a pre-11.29
+// server returning the name, or the steady state), the value is kept verbatim and
+// the resolver is NEVER called. This is what lets the same code path serve old and
+// new Jamf Pro with no version branch and no group-read privilege requirement.
+func TestReadGroupValue_BackwardCompatNoLookup(t *testing.T) {
+	r := newResolver()
+	got := ReadGroupValue(context.Background(), r, ObjectTypeUser, "Excluded Users", "Excluded Users")
+	if got != "Excluded Users" {
+		t.Fatalf("got %q, want the name unchanged", got)
+	}
+	if r.calls != 0 {
+		t.Fatalf("resolver called %d times on the wire==prior fast path; want 0", r.calls)
+	}
+}
+
+func TestReadGroupValue(t *testing.T) {
+	tests := []struct {
+		desc        string
+		wire, prior string
+		err         error
+		want        string
+	}{
+		{"11.29 id maps back to configured name", "3", "Excluded Users", nil, "Excluded Users"},
+		{"case-insensitive wire==prior keeps authored casing", "excluded users", "Excluded Users", nil, "Excluded Users"},
+		{"id names a different group -> drift (wire)", "25", "Excluded Users", nil, "25"},
+		{"unresolvable id -> drift (wire)", "999", "Excluded Users", nil, "999"},
+		{"resolver error -> drift (wire), never panic", "3", "Excluded Users", errors.New("403"), "3"},
+		{"import (no prior): id reverse-resolves to name", "3", "", nil, "Excluded Users"},
+		{"import (no prior) old-Jamf name passes through", "Excluded Users", "", nil, "Excluded Users"},
+		{"import (no prior) unresolvable -> wire", "999", "", nil, "999"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			r := newResolver()
+			r.err = tt.err
+			if got := ReadGroupValue(context.Background(), r, ObjectTypeUser, tt.wire, tt.prior); got != tt.want {
+				t.Fatalf("ReadGroupValue(%q,%q) = %q, want %q", tt.wire, tt.prior, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGroupValuesEquivalent(t *testing.T) {
+	tests := []struct {
+		desc string
+		a, b string
+		err  error
+		want bool
+	}{
+		{"identical", "Excluded Users", "Excluded Users", nil, true},
+		{"case-only", "excluded users", "Excluded Users", nil, true},
+		{"name vs its id", "Excluded Users", "3", nil, true},
+		{"id vs name", "3", "Excluded Users", nil, true},
+		{"different groups", "Excluded Users", "All 10.16+ Devices", nil, false},
+		{"resolve failure -> not equivalent", "Excluded Users", "3", errors.New("boom"), false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			r := newResolver()
+			r.err = tt.err
+			if got := GroupValuesEquivalent(context.Background(), r, ObjectTypeUser, tt.a, tt.b); got != tt.want {
+				t.Fatalf("GroupValuesEquivalent(%q,%q) = %v, want %v", tt.a, tt.b, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestResolveAuthoredGroupRefMap(t *testing.T) {
+	r := newResolver()
+	models := []CriterionModel{
+		crit("User Group", "member of", "Excluded Users"), // name -> keyed by id "3"
+		crit("User Group", "member of", "3"),              // authored as id -> keyed by "3"
+		crit("Full Name", "is", "Excluded Users"),         // not a group criterion -> skipped
+	}
+	got := ResolveAuthoredGroupRefMap(context.Background(), r, ObjectTypeUser, models)
+	if v, ok := got["3"]; !ok || v == "" {
+		t.Fatalf("expected id 3 keyed in authored map, got %#v", got)
+	}
+	// nil resolver -> empty map, no panic.
+	if m := ResolveAuthoredGroupRefMap(context.Background(), nil, ObjectTypeUser, models); len(m) != 0 {
+		t.Fatalf("nil resolver should yield empty map, got %#v", m)
+	}
+}
+
+func TestRestoreAuthoredGroupRefCriteria(t *testing.T) {
+	authored := map[string]string{"3": "Excluded Users"}
+	// 11.29 flatten returns the id; restore puts the authored name back.
+	flattened := []CriterionModel{crit("User Group", "member of", "3")}
+	out := RestoreAuthoredGroupRefCriteria(flattened, authored, ObjectTypeUser)
+	if out[0].Value.ValueString() != "Excluded Users" {
+		t.Fatalf("got %q, want restored name", out[0].Value.ValueString())
+	}
+	// pre-11.29 flatten returns the name; not in the id-keyed map -> left as-is.
+	oldJamf := []CriterionModel{crit("User Group", "member of", "Excluded Users")}
+	out = RestoreAuthoredGroupRefCriteria(oldJamf, authored, ObjectTypeUser)
+	if out[0].Value.ValueString() != "Excluded Users" {
+		t.Fatalf("old-Jamf name should pass through, got %q", out[0].Value.ValueString())
+	}
+	// empty authored map / nil slice preserved.
+	if RestoreAuthoredGroupRefCriteria(flattened, nil, ObjectTypeUser)[0].Value.ValueString() != "3" {
+		t.Fatal("empty map must leave the value as flattened")
+	}
+	if RestoreAuthoredGroupRefCriteria(nil, authored, ObjectTypeUser) != nil {
+		t.Fatal("nil slice must be preserved")
+	}
+}
+
+func TestReadbackGroupRefCriteria(t *testing.T) {
+	r := newResolver()
+	wire := []CriterionModel{
+		crit("User Group", "member of", "3"), // -> Excluded Users
+		crit("Full Name", "is", "tf-acc"),    // untouched
+	}
+	prior := []CriterionModel{
+		crit("User Group", "member of", "Excluded Users"),
+		crit("Full Name", "is", "tf-acc"),
+	}
+	out := ReadbackGroupRefCriteria(context.Background(), r, ObjectTypeUser, wire, prior)
+	if out[0].Value.ValueString() != "Excluded Users" {
+		t.Fatalf("group criterion not mapped: %q", out[0].Value.ValueString())
+	}
+	if out[1].Value.ValueString() != "tf-acc" {
+		t.Fatalf("non-group criterion must be untouched: %q", out[1].Value.ValueString())
+	}
+	// nil resolver / nil slice preserved.
+	if ReadbackGroupRefCriteria(context.Background(), nil, ObjectTypeUser, wire, prior)[0].Value.ValueString() != "3" {
+		t.Fatal("nil resolver must leave wire unchanged")
+	}
+	if ReadbackGroupRefCriteria(context.Background(), r, ObjectTypeUser, nil, prior) != nil {
+		t.Fatal("nil slice must be preserved")
+	}
+}
+
+func TestSuppressEquivalentGroupRefValues(t *testing.T) {
+	r := newResolver()
+	// Planned pastes the id; prior holds the name for the same group -> collapse to prior.
+	planned := []CriterionModel{crit("User Group", "member of", "3")}
+	planned[0].Priority = types.Int64Unknown() // Optional+Computed churns to Unknown on a criteria change
+	prior := []CriterionModel{crit("User Group", "member of", "Excluded Users")}
+	out := SuppressEquivalentGroupRefValues(context.Background(), r, ObjectTypeUser, planned, prior)
+	if out[0].Value.ValueString() != "Excluded Users" {
+		t.Fatalf("equivalent swap not collapsed: %q", out[0].Value.ValueString())
+	}
+	if out[0].Priority.IsUnknown() || out[0].Priority.ValueInt64() != 0 {
+		t.Fatalf("Unknown sibling not reconciled from prior: %v", out[0].Priority)
+	}
+	// Different group -> not suppressed.
+	planned2 := []CriterionModel{crit("User Group", "member of", "25")}
+	prior2 := []CriterionModel{crit("User Group", "member of", "Excluded Users")}
+	out = SuppressEquivalentGroupRefValues(context.Background(), r, ObjectTypeUser, planned2, prior2)
+	if out[0].Value.ValueString() != "25" {
+		t.Fatalf("non-equivalent value must be left intact: %q", out[0].Value.ValueString())
+	}
+	// nil resolver / nil slice preserved.
+	if SuppressEquivalentGroupRefValues(context.Background(), nil, ObjectTypeUser, planned, prior)[0].Value.ValueString() != "3" {
+		t.Fatal("nil resolver must leave the plan unchanged")
+	}
+	if SuppressEquivalentGroupRefValues(context.Background(), r, ObjectTypeUser, nil, prior) != nil {
+		t.Fatal("nil slice must be preserved")
+	}
+}

--- a/internal/resources/device_group/crud.go
+++ b/internal/resources/device_group/crud.go
@@ -56,7 +56,12 @@ func (r *DeviceGroupResource) ModifyPlan(ctx context.Context, req resource.Modif
 	if resp.Diagnostics.HasError() || len(plan.Criteria) == 0 {
 		return
 	}
+	// Suppress no-op representation swaps for both criterion families: a
+	// directory-service group base64<->name swap, and a Jamf-group name<->id swap
+	// (11.29 reads a member-of value back as the group id). Disjoint criterion
+	// names, so the two passes never touch the same element.
 	suppressed := suppressEquivalentDSGroupCriteria(ctx, r.proClient, plan.Criteria, state.Criteria)
+	suppressed = suppressEquivalentGroupRefCriteria(ctx, r.groupRef, dsObjectType(plan.DeviceType.ValueString()), suppressed, state.Criteria)
 	changed := false
 	for i := range suppressed {
 		if !suppressed[i].AttributeValue.Equal(plan.Criteria[i].AttributeValue) {
@@ -143,6 +148,7 @@ func (r *DeviceGroupResource) Create(ctx context.Context, req resource.CreateReq
 	}
 
 	var authoredDSGroups map[string]string
+	var authoredGroupRefs map[string]string
 	switch strings.ToLower(plan.GroupType.ValueString()) {
 	case "smart":
 		resolved, authored, dsDiags := resolveDSGroupCriteria(createCtx, r.proClient, dsObjectType(plan.DeviceType.ValueString()), plan.Criteria)
@@ -152,7 +158,12 @@ func (r *DeviceGroupResource) Create(ctx context.Context, req resource.CreateReq
 		}
 		plan.Criteria = resolved
 		authoredDSGroups = authored
-		criteria := expandDeviceGroupCriteria(plan.Criteria)
+		// device_group's wire value must be the group ID (its PATCH endpoint rejects
+		// names — wire-probed); resolve name->id for the request, keep the id->name
+		// map to restore the authored name after the flatten.
+		var wireCriteria []DeviceGroupCriteriaModel
+		wireCriteria, authoredGroupRefs = resolveGroupRefWireIDs(createCtx, r.groupRef, dsObjectType(plan.DeviceType.ValueString()), plan.Criteria)
+		criteria := expandDeviceGroupCriteria(wireCriteria)
 		reqBody.Criteria = &criteria
 	case "static":
 		if manageMembers {
@@ -180,6 +191,7 @@ func (r *DeviceGroupResource) Create(ctx context.Context, req resource.CreateReq
 		return
 	}
 	plan.Criteria = restoreAuthoredDSGroupCriteria(plan.Criteria, authoredDSGroups)
+	plan.Criteria = restoreAuthoredGroupRefCriteria(plan.Criteria, authoredGroupRefs, dsObjectType(plan.DeviceType.ValueString()))
 
 	// resolveJamfProID degrades all Pro bridging failures to warnings so the
 	// Platform Create result is never discarded. Append diagnostics without a
@@ -288,6 +300,7 @@ func (r *DeviceGroupResource) Read(ctx context.Context, req resource.ReadRequest
 		return
 	}
 	state.Criteria = readbackDSGroupCriteria(readCtx, r.proClient, state.Criteria, priorCriteria)
+	state.Criteria = readbackGroupRefCriteria(readCtx, r.groupRef, dsObjectType(state.DeviceType.ValueString()), state.Criteria, priorCriteria)
 
 	jamfProID, jamfProDiags := resolveJamfProID(readCtx, r.proClient, r.pd, state.ID.ValueString())
 	resp.Diagnostics.Append(jamfProDiags...)
@@ -333,6 +346,7 @@ func (r *DeviceGroupResource) Update(ctx context.Context, req resource.UpdateReq
 	}
 
 	var authoredDSGroups map[string]string
+	var authoredGroupRefs map[string]string
 	if strings.ToLower(plan.GroupType.ValueString()) == "smart" {
 		resolved, authored, dsDiags := resolveDSGroupCriteria(updateCtx, r.proClient, dsObjectType(plan.DeviceType.ValueString()), plan.Criteria)
 		resp.Diagnostics.Append(dsDiags...)
@@ -341,7 +355,12 @@ func (r *DeviceGroupResource) Update(ctx context.Context, req resource.UpdateReq
 		}
 		plan.Criteria = resolved
 		authoredDSGroups = authored
-		criteria := expandDeviceGroupCriteria(plan.Criteria)
+		// device_group's UPDATE (PATCH) requires the group ID, not the name
+		// (wire-probed: PATCH with a name 400s). Resolve name->id for the request and
+		// keep the id->name map to restore the authored name after the flatten.
+		var wireCriteria []DeviceGroupCriteriaModel
+		wireCriteria, authoredGroupRefs = resolveGroupRefWireIDs(updateCtx, r.groupRef, dsObjectType(plan.DeviceType.ValueString()), plan.Criteria)
+		criteria := expandDeviceGroupCriteria(wireCriteria)
 		updateReq.Criteria = &criteria
 	}
 
@@ -386,6 +405,7 @@ func (r *DeviceGroupResource) Update(ctx context.Context, req resource.UpdateReq
 		return
 	}
 	plan.Criteria = restoreAuthoredDSGroupCriteria(plan.Criteria, authoredDSGroups)
+	plan.Criteria = restoreAuthoredGroupRefCriteria(plan.Criteria, authoredGroupRefs, dsObjectType(plan.DeviceType.ValueString()))
 
 	jamfProID, jamfProDiags := resolveJamfProID(updateCtx, r.proClient, r.pd, plan.ID.ValueString())
 	resp.Diagnostics.Append(jamfProDiags...)

--- a/internal/resources/device_group/data_source.go
+++ b/internal/resources/device_group/data_source.go
@@ -10,6 +10,8 @@ import (
 
 	"github.com/Jamf-Concepts/jamfplatform-go-sdk/jamfplatform/devicegroups"
 	"github.com/Jamf-Concepts/jamfplatform-go-sdk/jamfplatform/pro"
+	"github.com/Jamf-Concepts/jamfplatform-go-sdk/jamfplatform/proclassic"
+	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/common/criteria"
 	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/common/helpers"
 	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/providerdata"
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/datasource/timeouts"
@@ -24,6 +26,7 @@ type DeviceGroupDataSource struct {
 	client    *devicegroups.Client
 	proClient *pro.Client
 	pd        *providerdata.Data
+	groupRef  criteria.GroupResolver
 }
 
 // Ensure provider defined types fully satisfy framework interfaces.
@@ -136,6 +139,7 @@ func (d *DeviceGroupDataSource) Configure(ctx context.Context, req datasource.Co
 
 	d.client = devicegroups.New(pd.Client)
 	d.proClient = pro.New(pd.Client)
+	d.groupRef = criteria.NewProGroupResolver(proclassic.New(pd.Client))
 	d.pd = pd
 }
 
@@ -218,6 +222,9 @@ func (d *DeviceGroupDataSource) Read(ctx context.Context, req datasource.ReadReq
 		MemberCount: types.Int64Value(int64(grp.MemberCount)),
 		Timeouts:    timeoutsConfig,
 	}
+	// No prior state in a data-source read → reverse-resolve any Jamf-group
+	// "member of" criterion id back to the group name (11.29 read regression).
+	data.Criteria = readbackGroupRefCriteria(readCtx, d.groupRef, dsObjectType(deviceType.ValueString()), data.Criteria, nil)
 
 	tflog.Trace(ctx, "read device group data source", map[string]any{
 		"id": grp.ID,

--- a/internal/resources/device_group/groupref.go
+++ b/internal/resources/device_group/groupref.go
@@ -1,0 +1,130 @@
+// Copyright Jamf Software LLC 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package device_group
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/types"
+
+	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/common/criteria"
+)
+
+// Jamf-group "member of" criteria on a Platform device group reference a Jamf
+// group by NAME as their attributeValue. Jamf Pro 11.29 echoes that value back as
+// the group's numeric id on read for the COMPUTER device type (criterion
+// "Computer Group"); MOBILE round-trips the name unchanged (wire-probed — see
+// spike/JAMF_GROUP_MEMBER_OF_CRITERIA_SPIKE.md). These thin per-criterion loops
+// wire the shared value-level helpers (criteria.ReadGroupValue / GroupValuesEquivalent)
+// into device_group's own criterion model (DeviceGroupCriteriaModel, value field
+// AttributeValue), exactly as dsgroup.go does for the directory-service family.
+// The two families have disjoint criterion names, so they never touch the same
+// element. The mapping is version-agnostic: when wire==config it short-circuits
+// with no lookup, so a pre-11.29 server (name) and the clean MOBILE path are both
+// no-ops.
+
+// resolveGroupRefWireIDs returns a COPY of in with each Jamf-group criterion's
+// value rewritten from the group NAME to its numeric ID for the wire, plus an
+// id->authoredValue map for the post-flatten restore. device_group's UPDATE (PATCH)
+// endpoint REQUIRES the id — wire-probed: PATCH with a name 400s ("Computer/Mobile
+// Group depends on Group (<name>) which does not exist"), while the id succeeds on
+// both POST and PATCH. So unlike user_group (whose classic PUT resolves names), the
+// device_group wire value is always the id. Applies to both device types (mobile
+// regresses identically once updated). Best-effort/SOFT: a value that does not
+// resolve (already an id, or an unknown name) is passed through unchanged — an
+// unknown name then surfaces the server's clear "does not exist" error rather than
+// being masked.
+func resolveGroupRefWireIDs(ctx context.Context, resolver criteria.GroupResolver, ot criteria.ObjectType, in []DeviceGroupCriteriaModel) ([]DeviceGroupCriteriaModel, map[string]string) {
+	if resolver == nil || len(in) == 0 {
+		return in, nil
+	}
+	authored := map[string]string{}
+	out := make([]DeviceGroupCriteriaModel, len(in))
+	copy(out, in)
+	for i := range out {
+		name := out[i].AttributeName.ValueString()
+		if !criteria.IsJamfGroupCriterion(ot, name, out[i].Operator.ValueString()) {
+			continue
+		}
+		v := out[i].AttributeValue.ValueString()
+		if id, err := resolver.IDByName(ctx, ot, v); err == nil && id != "" {
+			out[i].AttributeValue = types.StringValue(id) // send the id on the wire
+			authored[id] = v                              // restore the authored name on read-back
+		} else {
+			authored[v] = v // already an id (or unresolved name) -> send as-is
+		}
+	}
+	return out, authored
+}
+
+// restoreAuthoredGroupRefCriteria rewrites each Jamf-group criterion's flattened
+// wire value back to the authored value using the map from
+// resolveAuthoredGroupRefMap. The wire id is by definition the id of the group we
+// just wrote by name, so the restore is unconditional (no resolver call, no
+// post-apply inconsistency risk). Call in Create/Update after the flatten.
+func restoreAuthoredGroupRefCriteria(in []DeviceGroupCriteriaModel, authored map[string]string, ot criteria.ObjectType) []DeviceGroupCriteriaModel {
+	if len(authored) == 0 || len(in) == 0 {
+		return in
+	}
+	out := make([]DeviceGroupCriteriaModel, len(in))
+	copy(out, in)
+	for i := range out {
+		if !criteria.IsJamfGroupCriterion(ot, out[i].AttributeName.ValueString(), out[i].Operator.ValueString()) {
+			continue
+		}
+		if v, ok := authored[out[i].AttributeValue.ValueString()]; ok {
+			out[i].AttributeValue = types.StringValue(v)
+		}
+	}
+	return out
+}
+
+// readbackGroupRefCriteria maps each Jamf-group criterion's wire value back to the
+// authored group name on a pure Read, using prior state as the form source (SOFT —
+// never errors; backward-compatible — wire==prior short-circuits with no lookup).
+// Call in Read after the flatten.
+func readbackGroupRefCriteria(ctx context.Context, resolver criteria.GroupResolver, ot criteria.ObjectType, in, prior []DeviceGroupCriteriaModel) []DeviceGroupCriteriaModel {
+	if len(in) == 0 || resolver == nil {
+		return in // preserve nil/empty; never flip nil -> []
+	}
+	out := make([]DeviceGroupCriteriaModel, len(in))
+	copy(out, in)
+	for i := range out {
+		name := out[i].AttributeName.ValueString()
+		if !criteria.IsJamfGroupCriterion(ot, name, out[i].Operator.ValueString()) {
+			continue
+		}
+		p := ""
+		if i < len(prior) && prior[i].AttributeName.ValueString() == name {
+			p = prior[i].AttributeValue.ValueString()
+		}
+		out[i].AttributeValue = types.StringValue(criteria.ReadGroupValue(ctx, resolver, ot, out[i].AttributeValue.ValueString(), p))
+	}
+	return out
+}
+
+// suppressEquivalentGroupRefCriteria resets a planned Jamf-group criterion value to
+// the prior state value when both reference the same group (a name<->id swap),
+// suppressing a no-op diff. Aligned by index + name match; SOFT. Call from
+// ModifyPlan.
+func suppressEquivalentGroupRefCriteria(ctx context.Context, resolver criteria.GroupResolver, ot criteria.ObjectType, planned, prior []DeviceGroupCriteriaModel) []DeviceGroupCriteriaModel {
+	if len(planned) == 0 || resolver == nil {
+		return planned // preserve nil/empty
+	}
+	out := make([]DeviceGroupCriteriaModel, len(planned))
+	copy(out, planned)
+	for i := range out {
+		name := out[i].AttributeName.ValueString()
+		if !criteria.IsJamfGroupCriterion(ot, name, out[i].Operator.ValueString()) {
+			continue
+		}
+		if i >= len(prior) || prior[i].AttributeName.ValueString() != name {
+			continue
+		}
+		if criteria.GroupValuesEquivalent(ctx, resolver, ot, out[i].AttributeValue.ValueString(), prior[i].AttributeValue.ValueString()) {
+			out[i].AttributeValue = prior[i].AttributeValue
+		}
+	}
+	return out
+}

--- a/internal/resources/device_group/groupref_acceptance_test.go
+++ b/internal/resources/device_group/groupref_acceptance_test.go
@@ -1,0 +1,120 @@
+// Copyright Jamf Software LLC 2026
+// SPDX-License-Identifier: MPL-2.0
+
+//go:build acceptance
+
+package device_group_test
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"testing"
+
+	"github.com/Jamf-Concepts/jamfplatform-go-sdk/jamfplatform/proclassic"
+	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/testhelpers"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
+)
+
+// TestAccResource_DeviceGroup_JamfGroupMemberOf covers the Jamf Pro 11.29
+// name->id regression for a Platform device group's "Computer Group" membership
+// criterion (the COMPUTER device type — wire-probed as the one device_group
+// surface that echoes the group id on read; see
+// spike/JAMF_GROUP_MEMBER_OF_CRITERIA_SPIKE.md).
+//
+// A static fixture computer group is created via the classic SDK (no Terraform
+// resource exists for classic computer groups) and referenced by name. The test
+// asserts:
+//
+//  1. Author by NAME -> state round-trips back to the NAME, NOT the numeric id the
+//     11.29 server stores. (Without the fix this is "produced inconsistent result
+//     after apply".)
+//  2. Re-applying the same config is an empty plan (no perpetual name-vs-id diff).
+//  3. Swapping the config to the equivalent numeric id is an empty plan (ModifyPlan
+//     recognises the name<->id representation swap as a no-op).
+func TestAccResource_DeviceGroup_JamfGroupMemberOf(t *testing.T) {
+	testhelpers.AccPreCheck(t)
+
+	suffix := testhelpers.RunSuffix()
+	fixtureName := "tf-acc-dg-cg-fixture-" + suffix
+	groupName := "tf-acc-dg-cg-memberof-" + suffix
+
+	ctx := context.Background()
+	client := proclassic.New(testhelpers.NewAcceptanceClient(t))
+
+	// Static, empty computer group to be the "member of" target.
+	isSmart := false
+	created, err := client.CreateComputerGroupByID(ctx, "0", &proclassic.ComputerGroupPost{
+		Name:    &fixtureName,
+		IsSmart: &isSmart,
+	})
+	if err != nil {
+		t.Fatalf("create fixture computer group: %v", err)
+	}
+	if created == nil || created.ID == nil {
+		t.Fatal("create fixture computer group: response missing id")
+	}
+	fixtureID := strconv.Itoa(*created.ID)
+	t.Cleanup(func() {
+		_ = client.DeleteComputerGroupByID(context.Background(), fixtureID)
+	})
+
+	cfgOp := func(op, value string) string {
+		return fmt.Sprintf(`
+			resource "jamfplatform_device_group" "test" {
+				name        = %q
+				description = "Acceptance test — safe to delete"
+				group_type  = "smart"
+				device_type = "computer"
+				criteria = [{
+					criteria = "Computer Group"
+					operator = %q
+					value    = %q
+				}]
+			}
+		`, groupName, op, value)
+	}
+	cfg := func(value string) string { return cfgOp("member of", value) }
+	cfgNot := func(value string) string { return cfgOp("not member of", value) }
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testhelpers.AccTestProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckDeviceGroupDestroy(t),
+		Steps: []resource.TestStep{
+			{
+				// (1) Author by name; state must hold the NAME, not the id.
+				Config: cfg(fixtureName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("jamfplatform_device_group.test", "id"),
+					resource.TestCheckResourceAttr("jamfplatform_device_group.test", "criteria.0.criteria", "Computer Group"),
+					resource.TestCheckResourceAttr("jamfplatform_device_group.test", "criteria.0.operator", "member of"),
+					resource.TestCheckResourceAttr("jamfplatform_device_group.test", "criteria.0.value", fixtureName),
+				),
+			},
+			{
+				// (2) Same config -> no perpetual diff.
+				Config: cfg(fixtureName),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{plancheck.ExpectEmptyPlan()},
+				},
+			},
+			{
+				// (3) Swap to the equivalent numeric id -> recognised as a no-op.
+				Config: cfg(fixtureID),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{plancheck.ExpectEmptyPlan()},
+				},
+			},
+			{
+				// (4) "not member of" regresses identically (probed id "1"); confirm
+				// it too round-trips back to the authored name.
+				Config: cfgNot(fixtureName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("jamfplatform_device_group.test", "criteria.0.operator", "not member of"),
+					resource.TestCheckResourceAttr("jamfplatform_device_group.test", "criteria.0.value", fixtureName),
+				),
+			},
+		},
+	})
+}

--- a/internal/resources/device_group/list_resource.go
+++ b/internal/resources/device_group/list_resource.go
@@ -9,6 +9,8 @@ import (
 
 	"github.com/Jamf-Concepts/jamfplatform-go-sdk/jamfplatform/devicegroups"
 	"github.com/Jamf-Concepts/jamfplatform-go-sdk/jamfplatform/pro"
+	"github.com/Jamf-Concepts/jamfplatform-go-sdk/jamfplatform/proclassic"
+	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/common/criteria"
 	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/common/filters"
 	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/common/helpers"
 	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/providerdata"
@@ -34,6 +36,7 @@ type DeviceGroupListResource struct {
 	client    *devicegroups.Client
 	proClient *pro.Client
 	pd        *providerdata.Data
+	groupRef  criteria.GroupResolver
 }
 
 // Metadata sets the list resource type name.
@@ -58,6 +61,7 @@ func (r *DeviceGroupListResource) Configure(ctx context.Context, req resource.Co
 
 	r.client = devicegroups.New(pd.Client)
 	r.proClient = pro.New(pd.Client)
+	r.groupRef = criteria.NewProGroupResolver(proclassic.New(pd.Client))
 	r.pd = pd
 }
 
@@ -168,6 +172,10 @@ func (r *DeviceGroupListResource) List(ctx context.Context, req list.ListRequest
 				stream.Results = list.ListResultsStreamDiagnostics(result.Diagnostics)
 				return
 			}
+			// No prior state in a list/query result → reverse-resolve any Jamf-group
+			// "member of" criterion id back to the group name (11.29 read regression)
+			// so `terraform query -generate-config-out` emits names, not ids.
+			state.Criteria = readbackGroupRefCriteria(ctx, r.groupRef, dsObjectType(state.DeviceType.ValueString()), state.Criteria, nil)
 
 			jamfProID, jamfProDiags := resolveJamfProID(ctx, r.proClient, r.pd, detail.ID)
 			result.Diagnostics.Append(jamfProDiags...)

--- a/internal/resources/device_group/resource.go
+++ b/internal/resources/device_group/resource.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/Jamf-Concepts/jamfplatform-go-sdk/jamfplatform/devicegroups"
 	"github.com/Jamf-Concepts/jamfplatform-go-sdk/jamfplatform/pro"
+	"github.com/Jamf-Concepts/jamfplatform-go-sdk/jamfplatform/proclassic"
 	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/common/criteria"
 	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/providerdata"
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
@@ -39,6 +40,12 @@ type DeviceGroupResource struct {
 	client    *devicegroups.Client
 	proClient *pro.Client
 	pd        *providerdata.Data
+	// groupRef maps a Jamf-group "member of" criterion value between its group
+	// name and the numeric id Jamf Pro 11.29 echoes on read (COMPUTER device type
+	// regresses; MOBILE is clean). Backed by the classic group endpoints —
+	// device_group COMPUTER membership stores CLASSIC computer-group ids, so this
+	// resolves via proclassic, not Pro /v2/groups.
+	groupRef criteria.GroupResolver
 }
 
 // Ensure provider defined types fully satisfy framework interfaces.
@@ -212,6 +219,7 @@ func (r *DeviceGroupResource) Configure(ctx context.Context, req resource.Config
 
 	r.client = devicegroups.New(pd.Client)
 	r.proClient = pro.New(pd.Client)
+	r.groupRef = criteria.NewProGroupResolver(proclassic.New(pd.Client))
 	r.pd = pd
 }
 

--- a/internal/resources/pro/users/user_group/crud.go
+++ b/internal/resources/pro/users/user_group/crud.go
@@ -78,7 +78,7 @@ func fromCriterionModels(in []criteria.CriterionModel) []UserGroupCriterionModel
 // Skips create (no prior state) and destroy (no plan); soft — any resolve
 // failure leaves the diff intact.
 func (r *UserGroupResource) ModifyPlan(ctx context.Context, req resource.ModifyPlanRequest, resp *resource.ModifyPlanResponse) {
-	if req.Plan.Raw.IsNull() || req.State.Raw.IsNull() || r.ldap == nil {
+	if req.Plan.Raw.IsNull() || req.State.Raw.IsNull() || (r.ldap == nil && r.groupRef == nil) {
 		return
 	}
 	var plan, state UserGroupResourceModel
@@ -88,7 +88,15 @@ func (r *UserGroupResource) ModifyPlan(ctx context.Context, req resource.ModifyP
 		return
 	}
 	planModels := toCriterionModels(plan.Criteria)
-	suppressed := criteria.SuppressEquivalentDSGroupValues(ctx, r.ldap, planModels, toCriterionModels(state.Criteria))
+	stateModels := toCriterionModels(state.Criteria)
+	// Suppress no-op representation swaps for both criterion families: a
+	// directory-service group base64<->name swap, and a Jamf-group name<->id swap
+	// (11.29 reads a member-of value back as the group id). Disjoint criterion
+	// names, so the two passes never touch the same element.
+	suppressed := criteria.SuppressEquivalentDSGroupValues(ctx, r.ldap, planModels, stateModels)
+	if r.groupRef != nil {
+		suppressed = criteria.SuppressEquivalentGroupRefValues(ctx, r.groupRef, dsGroupObjectType, suppressed, stateModels)
+	}
 	changed := false
 	for i := range suppressed {
 		if !suppressed[i].Value.Equal(planModels[i].Value) {
@@ -149,6 +157,11 @@ func (r *UserGroupResource) Create(ctx context.Context, req resource.CreateReque
 		return
 	}
 	plan.Criteria = fromCriterionModels(resolved)
+	// Resolve Jamf-group "member of" criterion names to the ids the 11.29+ server
+	// will echo on read, so the post-write flatten can restore the authored name
+	// (reorder-safe; see RestoreAuthoredGroupRefCriteria). Built from the authored
+	// (pre-write) criteria; the write itself still sends the name (pass-through).
+	groupRefAuthored := criteria.ResolveAuthoredGroupRefMap(createCtx, r.groupRef, dsGroupObjectType, resolved)
 
 	input, inputDiags := buildUserGroupInput(createCtx, plan)
 	resp.Diagnostics.Append(inputDiags...)
@@ -179,7 +192,9 @@ func (r *UserGroupResource) Create(ctx context.Context, req resource.CreateReque
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	plan.Criteria = fromCriterionModels(criteria.RestoreAuthoredDSGroupCriteria(toCriterionModels(plan.Criteria), authored))
+	restored := criteria.RestoreAuthoredDSGroupCriteria(toCriterionModels(plan.Criteria), authored)
+	restored = criteria.RestoreAuthoredGroupRefCriteria(restored, groupRefAuthored, dsGroupObjectType)
+	plan.Criteria = fromCriterionModels(restored)
 
 	resp.Diagnostics.Append(helpers.SetIdentity(ctx, resp.Identity, userGroupIdentityModel{ID: plan.ID})...)
 	if resp.Diagnostics.HasError() {
@@ -258,7 +273,9 @@ func (r *UserGroupResource) Read(ctx context.Context, req resource.ReadRequest, 
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	state.Criteria = fromCriterionModels(criteria.ReadbackDSGroupCriteria(readCtx, r.ldap, dsGroupObjectType, toCriterionModels(state.Criteria), priorCriteria))
+	readback := criteria.ReadbackDSGroupCriteria(readCtx, r.ldap, dsGroupObjectType, toCriterionModels(state.Criteria), priorCriteria)
+	readback = criteria.ReadbackGroupRefCriteria(readCtx, r.groupRef, dsGroupObjectType, readback, priorCriteria)
+	state.Criteria = fromCriterionModels(readback)
 
 	resp.Diagnostics.Append(helpers.SetIdentity(ctx, resp.Identity, userGroupIdentityModel{ID: state.ID})...)
 	if resp.Diagnostics.HasError() {
@@ -302,6 +319,7 @@ func (r *UserGroupResource) Update(ctx context.Context, req resource.UpdateReque
 		return
 	}
 	plan.Criteria = fromCriterionModels(resolved)
+	groupRefAuthored := criteria.ResolveAuthoredGroupRefMap(updateCtx, r.groupRef, dsGroupObjectType, resolved)
 
 	input, inputDiags := buildUserGroupInput(updateCtx, plan)
 	resp.Diagnostics.Append(inputDiags...)
@@ -323,7 +341,9 @@ func (r *UserGroupResource) Update(ctx context.Context, req resource.UpdateReque
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	plan.Criteria = fromCriterionModels(criteria.RestoreAuthoredDSGroupCriteria(toCriterionModels(plan.Criteria), authored))
+	restored := criteria.RestoreAuthoredDSGroupCriteria(toCriterionModels(plan.Criteria), authored)
+	restored = criteria.RestoreAuthoredGroupRefCriteria(restored, groupRefAuthored, dsGroupObjectType)
+	plan.Criteria = fromCriterionModels(restored)
 
 	resp.Diagnostics.Append(helpers.SetIdentity(ctx, resp.Identity, userGroupIdentityModel{ID: plan.ID})...)
 	if resp.Diagnostics.HasError() {

--- a/internal/resources/pro/users/user_group/data_source.go
+++ b/internal/resources/pro/users/user_group/data_source.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
+	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/common/criteria"
 	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/common/helpers"
 	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/providerdata"
 )
@@ -21,7 +22,8 @@ import (
 // UserGroupDataSource implements the Terraform data source for Jamf Pro user
 // groups. Lookup is by ID or by exact name — exactly one must be supplied.
 type UserGroupDataSource struct {
-	client *proclassic.Client
+	client   *proclassic.Client
+	groupRef criteria.GroupResolver
 }
 
 var (
@@ -111,6 +113,7 @@ func (d *UserGroupDataSource) Configure(ctx context.Context, req datasource.Conf
 		return
 	}
 	d.client = client
+	d.groupRef = criteria.NewProGroupResolver(client)
 }
 
 // Read fetches a user group by ID or by name.
@@ -155,6 +158,10 @@ func (d *UserGroupDataSource) Read(ctx context.Context, req datasource.ReadReque
 		return
 	}
 	assignUserGroupDataSourceModel(&data, got)
+	// No prior config in a data-source read → reverse-resolve any Jamf-group
+	// "member of" criterion id back to the group name (11.29 read regression) so a
+	// consumer (and `-generate-config-out`) sees the name, not the numeric id.
+	data.Criteria = fromCriterionModels(criteria.ReadbackGroupRefCriteria(readCtx, d.groupRef, dsGroupObjectType, toCriterionModels(data.Criteria), nil))
 
 	tflog.Trace(ctx, "read Jamf Pro user group data source", map[string]any{"id": data.ID.ValueString(), "name": data.Name.ValueString()})
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)

--- a/internal/resources/pro/users/user_group/groupref_acceptance_test.go
+++ b/internal/resources/pro/users/user_group/groupref_acceptance_test.go
@@ -1,0 +1,92 @@
+// Copyright Jamf Software LLC 2026
+// SPDX-License-Identifier: MPL-2.0
+
+//go:build acceptance
+
+package user_group_test
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"testing"
+
+	"github.com/Jamf-Concepts/jamfplatform-go-sdk/jamfplatform/proclassic"
+	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/testhelpers"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
+)
+
+// TestAccResource_ProUserGroup_JamfGroupMemberOf covers the Jamf Pro 11.29
+// name->id regression for a user group's "User Group" membership criterion (the
+// classic /usergroups surface echoes the group id on read; see
+// spike/JAMF_GROUP_MEMBER_OF_CRITERIA_SPIKE.md). The Smart_AllOperators sweep
+// asserts the create round-trip; this test adds the perpetual-diff guard and the
+// name<->id swap no-op that the sweep does not exercise.
+//
+// The "member of" target is a static fixture user group created via the classic
+// SDK (so its numeric id is known for the swap step) and referenced by name; it is
+// deleted on cleanup.
+func TestAccResource_ProUserGroup_JamfGroupMemberOf(t *testing.T) {
+	testhelpers.AccPreCheck(t)
+
+	suffix := testhelpers.RunSuffix()
+	fixtureName := "tf-acc-ug-cg-fixture-" + suffix
+	groupName := "tf-acc-ug-cg-memberof-" + suffix
+
+	ctx := context.Background()
+	client := proclassic.New(testhelpers.NewAcceptanceClient(t))
+	isSmart := false
+	created, err := client.CreateUserGroupByID(ctx, "0", &proclassic.UserGroup{
+		Name:    &fixtureName,
+		IsSmart: &isSmart,
+	})
+	if err != nil {
+		t.Fatalf("create fixture user group: %v", err)
+	}
+	if created == nil || created.ID == nil {
+		t.Fatal("create fixture user group: response missing id")
+	}
+	fixtureID := strconv.Itoa(*created.ID)
+	t.Cleanup(func() {
+		_ = client.DeleteUserGroupByID(context.Background(), fixtureID)
+	})
+
+	cfg := func(value string) string {
+		return fmt.Sprintf(`
+			resource "jamfplatform_pro_user_group" "test" {
+				name       = %q
+				group_type = "smart"
+				criteria = [{
+					name        = "User Group"
+					search_type = "member of"
+					value       = %q
+				}]
+			}
+		`, groupName, value)
+	}
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testhelpers.AccTestProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckUserGroupDestroy(t),
+		Steps: []resource.TestStep{
+			{
+				// Author by name; state must hold the NAME, not the numeric id.
+				Config: cfg(fixtureName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("jamfplatform_pro_user_group.test", "criteria.0.value", fixtureName),
+				),
+			},
+			{
+				// Same config -> no perpetual diff.
+				Config:           cfg(fixtureName),
+				ConfigPlanChecks: resource.ConfigPlanChecks{PreApply: []plancheck.PlanCheck{plancheck.ExpectEmptyPlan()}},
+			},
+			{
+				// Swap to the equivalent numeric id -> recognised as a no-op.
+				Config:           cfg(fixtureID),
+				ConfigPlanChecks: resource.ConfigPlanChecks{PreApply: []plancheck.PlanCheck{plancheck.ExpectEmptyPlan()}},
+			},
+		},
+	})
+}

--- a/internal/resources/pro/users/user_group/resource.go
+++ b/internal/resources/pro/users/user_group/resource.go
@@ -41,6 +41,10 @@ type UserGroupResource struct {
 	// {uuid,serverId} wire value. Built from the shared Pro client because the
 	// classic API has no LDAP-group search of its own.
 	ldap ldapgroups.Searcher
+	// groupRef maps a Jamf-group "member of" criterion value between its group
+	// name and the numeric id Jamf Pro 11.29 echoes on read. Backed by the same
+	// classic client.
+	groupRef criteria.GroupResolver
 }
 
 var _ resource.Resource = &UserGroupResource{}
@@ -167,6 +171,7 @@ func (r *UserGroupResource) Configure(ctx context.Context, req resource.Configur
 		return
 	}
 	r.client = client
+	r.groupRef = criteria.NewProGroupResolver(client)
 	if pd, ok := req.ProviderData.(*providerdata.Data); ok {
 		r.ldap = pro.New(pd.Client)
 	}


### PR DESCRIPTION
## Problem

Jamf Pro **11.29** changed the read behaviour of a Jamf-group membership criterion (criterion `User Group` / `Computer Group` / `Mobile Device Group` with a `member of` / `not member of` operator) authored by **group name**: the server now echoes the group's **numeric id** on read where it previously round-tripped the name. The provider's flatten copies the wire value verbatim, so state lands the id while config holds the name →

```
Error: Provider produced inconsistent result after apply
  .criteria[0].value: was "tf-acc-…", but now "511".
```

…followed by a perpetual name-vs-id diff.

## Scope (wire-probed, all 5 criteria surfaces)

Only **2 of 5** (surface, criterion) pairs regress — confirmed by live probe on Jamf Pro 11.29, both operators, built-in + custom targets:

| Surface | Endpoint | Read returns | Regresses |
|---|---|---|---|
| `jamfplatform_pro_user_group` | classic `/usergroups` | **id** | ✅ |
| `jamfplatform_device_group` (computer + mobile) | Platform `/device-groups/v1` | **id** | ✅ |
| `jamfplatform_pro_advanced_computer_search` | classic | name | ❌ |
| `jamfplatform_pro_advanced_user_search` | classic | name | ❌ |
| `jamfplatform_pro_advanced_mobile_device_search` | Pro v1 | name | ❌ |

The three advanced searches round-trip the name and are intentionally left untouched.

## Fix

New `internal/common/criteria/groupref.go` maps the wire value back to the authored group name. Key properties:

- **Version-agnostic / backward-compatible.** The mapping is a *fallback*: when the wire already equals the configured value it's kept verbatim with **no lookup**, so pre-11.29 servers (which return the name) and tenants without the group-read privilege keep working with no version branch. Only a differing value is reverse-resolved id→name.
- **Soft on every read** — a deleted/renamed group surfaces as drift, never blocks `terraform plan`.
- **Write differs by surface (wire-probed):**
  - `user_group` classic `/usergroups` accepts the name on **POST and PUT** → passthrough.
  - `device_group` Platform `/device-groups/v1` **UPDATE (PATCH) requires the numeric id** — PATCH with a name → `400 INVALID_FIELD "… depends on Group (<name>) which does not exist"`; the id works on both POST and PATCH (mobile included). So device_group resolves **name→id on every write** and restores the authored name to state.
- **All criteria-surfacing read paths resolve to names**: resource Read (incl. import / `plan -generate-config-out`), data sources, and the `device_group` list resource (`terraform query`) — so generated config carries names, not ids.
- Numeric values resolve **name-first** (a value matching both a group name and a different group's id → the name).

## Tests

- `groupref_test.go` — read fallback (incl. the backward-compat "no lookup when wire==config" assertion), equivalence, import, Create/Update restore, nil-preservation.
- New env-gated acceptance tests for both surfaces (create/round-trip, no-perpetual-diff, name↔id swap, not-member-of). The previously-red `TestAccResource_ProUserGroup_Smart_AllOperators/{member_of,not_member_of}` now passes.
- `go build ./...`, full unit suite, `go vet -tags=acceptance`, and `golangci-lint` all green; acceptance run green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)