### PR TITLE
chore(scope): promote proclassic IDName/SiteObject wrappers (Phase 10, tier 2)

### DIFF
--- a/internal/common/scope/proclassic.go
+++ b/internal/common/scope/proclassic.go
@@ -1,0 +1,61 @@
+// Copyright Jamf Software LLC 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package scope
+
+import (
+	"context"
+	"strconv"
+
+	"github.com/Jamf-Concepts/jamfplatform-go-sdk/jamfplatform/proclassic"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+// FlattenIDNameSet projects a ProClassic []IDName pointer-slice into a Terraform
+// Set<String> of the items' integer IDs. Thin, diagnostics-dropping wrapper over
+// FlattenIDSlice for the common proclassic.IDName shape that classic scope and
+// reference sub-blocks use throughout. Returns a null set for nil/empty input.
+func FlattenIDNameSet(ctx context.Context, items *[]proclassic.IDName) types.Set {
+	out, _ := FlattenIDSlice(ctx, items, func(i proclassic.IDName) *int { return i.ID })
+	return out
+}
+
+// FlattenNameSet projects a ProClassic []IDName pointer-slice into a Terraform
+// Set<String> of the items' names. Name-only sibling of FlattenIDNameSet.
+func FlattenNameSet(ctx context.Context, items *[]proclassic.IDName) types.Set {
+	out, _ := FlattenNameSlice(ctx, items, func(i proclassic.IDName) *string { return i.Name })
+	return out
+}
+
+// FlattenSiteObject unpacks a ProClassic SiteObject (nil-able integer ID + name)
+// into (idString, name) pointers for state assignment. Returns (nil, nil) when the
+// site is absent; the ID is rendered as its decimal string when present.
+func FlattenSiteObject(site *proclassic.SiteObject) (*string, *string) {
+	if site == nil {
+		return nil, nil
+	}
+	var idPtr *string
+	if site.ID != nil {
+		s := strconv.Itoa(*site.ID)
+		idPtr = &s
+	}
+	return idPtr, site.Name
+}
+
+// BuildSiteObject parses a Terraform string site ID into a ProClassic SiteObject
+// for write payloads. Returns nil for null/unknown/empty/un-parseable input so the
+// SDK omits the site element entirely.
+func BuildSiteObject(siteID types.String) *proclassic.SiteObject {
+	if siteID.IsNull() || siteID.IsUnknown() {
+		return nil
+	}
+	idStr := siteID.ValueString()
+	if idStr == "" {
+		return nil
+	}
+	id, err := strconv.Atoi(idStr)
+	if err != nil {
+		return nil
+	}
+	return &proclassic.SiteObject{ID: &id}
+}

--- a/internal/common/scope/proclassic_test.go
+++ b/internal/common/scope/proclassic_test.go
@@ -1,0 +1,62 @@
+// Copyright Jamf Software LLC 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package scope
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Jamf-Concepts/jamfplatform-go-sdk/jamfplatform/proclassic"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func iptr(i int) *int       { return &i }
+func sptr(s string) *string { return &s }
+
+func TestFlattenIDNameSet(t *testing.T) {
+	ctx := context.Background()
+	if got := FlattenIDNameSet(ctx, nil); !got.IsNull() {
+		t.Errorf("nil items should be null set, got %v", got)
+	}
+	items := &[]proclassic.IDName{{ID: iptr(1), Name: sptr("a")}, {ID: iptr(2), Name: sptr("b")}}
+	got := FlattenIDNameSet(ctx, items)
+	if got.IsNull() || len(got.Elements()) != 2 {
+		t.Errorf("expected 2-element set, got %v", got)
+	}
+}
+
+func TestFlattenNameSet(t *testing.T) {
+	ctx := context.Background()
+	if got := FlattenNameSet(ctx, nil); !got.IsNull() {
+		t.Errorf("nil items should be null set, got %v", got)
+	}
+	items := &[]proclassic.IDName{{ID: iptr(1), Name: sptr("alpha")}}
+	got := FlattenNameSet(ctx, items)
+	if got.IsNull() || len(got.Elements()) != 1 {
+		t.Errorf("expected 1-element set, got %v", got)
+	}
+}
+
+func TestFlattenSiteObject(t *testing.T) {
+	id, name := FlattenSiteObject(nil)
+	if id != nil || name != nil {
+		t.Errorf("nil site should yield (nil,nil)")
+	}
+	id, name = FlattenSiteObject(&proclassic.SiteObject{ID: iptr(7), Name: sptr("HQ")})
+	if id == nil || *id != "7" || name == nil || *name != "HQ" {
+		t.Errorf("got (%v,%v), want (\"7\",\"HQ\")", id, name)
+	}
+}
+
+func TestBuildSiteObject(t *testing.T) {
+	for _, in := range []types.String{types.StringNull(), types.StringUnknown(), types.StringValue(""), types.StringValue("nope")} {
+		if got := BuildSiteObject(in); got != nil {
+			t.Errorf("BuildSiteObject(%v) = %v, want nil", in, got)
+		}
+	}
+	got := BuildSiteObject(types.StringValue("12"))
+	if got == nil || got.ID == nil || *got.ID != 12 {
+		t.Errorf("BuildSiteObject(\"12\") = %v, want ID 12", got)
+	}
+}

--- a/internal/resources/pro/apps/ebook/state_builders.go
+++ b/internal/resources/pro/apps/ebook/state_builders.go
@@ -85,36 +85,36 @@ func flattenEbookScope(ctx context.Context, s *proclassic.EbookScope, state *Ebo
 		t.AllJssUsers = helpers.PreferCurrentBoolPointer(s.AllJssUsers, t.AllJssUsers)
 
 		t.ComputerIDs = flattenComputerItemSet(ctx, s.Computers)
-		t.ComputerGroupIDs = flattenIDNameSet(ctx, computerGroupSlice(s.ComputerGroups))
+		t.ComputerGroupIDs = scope.FlattenIDNameSet(ctx, computerGroupSlice(s.ComputerGroups))
 		t.MobileDeviceIDs = flattenMobileDeviceItemSet(ctx, s.MobileDevices)
-		t.MobileDeviceGroupIDs = flattenIDNameSet(ctx, mobileDeviceGroupSlice(s.MobileDeviceGroups))
-		t.BuildingIDs = flattenIDNameSet(ctx, buildingSlice(s.Buildings))
-		t.DepartmentIDs = flattenIDNameSet(ctx, departmentSlice(s.Departments))
-		t.UserIDs = flattenIDNameSet(ctx, jssUserSlice(s.JssUsers))
-		t.UserGroupIDs = flattenIDNameSet(ctx, jssUserGroupSlice(s.JssUserGroups))
-		t.ClassIDs = flattenIDNameSet(ctx, classSlice(s.Classes))
+		t.MobileDeviceGroupIDs = scope.FlattenIDNameSet(ctx, mobileDeviceGroupSlice(s.MobileDeviceGroups))
+		t.BuildingIDs = scope.FlattenIDNameSet(ctx, buildingSlice(s.Buildings))
+		t.DepartmentIDs = scope.FlattenIDNameSet(ctx, departmentSlice(s.Departments))
+		t.UserIDs = scope.FlattenIDNameSet(ctx, jssUserSlice(s.JssUsers))
+		t.UserGroupIDs = scope.FlattenIDNameSet(ctx, jssUserGroupSlice(s.JssUserGroups))
+		t.ClassIDs = scope.FlattenIDNameSet(ctx, classSlice(s.Classes))
 	}
 
 	if state.Limitations != nil && s.Limitations != nil {
 		l := s.Limitations
-		state.Limitations.NetworkSegmentIDs = flattenIDNameSet(ctx, limitationsSegmentSlice(l.NetworkSegments))
-		state.Limitations.DirectoryServiceOrLocalUserNames = flattenNameSet(ctx, limitationsUserSlice(l.Users))
-		state.Limitations.DirectoryServiceUserGroupNames = flattenNameSet(ctx, limitationsUserGroupSlice(l.UserGroups))
+		state.Limitations.NetworkSegmentIDs = scope.FlattenIDNameSet(ctx, limitationsSegmentSlice(l.NetworkSegments))
+		state.Limitations.DirectoryServiceOrLocalUserNames = scope.FlattenNameSet(ctx, limitationsUserSlice(l.Users))
+		state.Limitations.DirectoryServiceUserGroupNames = scope.FlattenNameSet(ctx, limitationsUserGroupSlice(l.UserGroups))
 	}
 
 	if state.Exclusions != nil && s.Exclusions != nil {
 		e := s.Exclusions
 		state.Exclusions.ComputerIDs = flattenExclComputerItemSet(ctx, e.Computers)
-		state.Exclusions.ComputerGroupIDs = flattenIDNameSet(ctx, exclComputerGroupSlice(e.ComputerGroups))
+		state.Exclusions.ComputerGroupIDs = scope.FlattenIDNameSet(ctx, exclComputerGroupSlice(e.ComputerGroups))
 		state.Exclusions.MobileDeviceIDs = flattenExclMobileDeviceItemSet(ctx, e.MobileDevices)
-		state.Exclusions.MobileDeviceGroupIDs = flattenIDNameSet(ctx, exclMobileDeviceGroupSlice(e.MobileDeviceGroups))
-		state.Exclusions.BuildingIDs = flattenIDNameSet(ctx, exclBuildingSlice(e.Buildings))
-		state.Exclusions.DepartmentIDs = flattenIDNameSet(ctx, exclDepartmentSlice(e.Departments))
-		state.Exclusions.UserIDs = flattenIDNameSet(ctx, exclJssUserSlice(e.JssUsers))
-		state.Exclusions.UserGroupIDs = flattenIDNameSet(ctx, exclJssUserGroupSlice(e.JssUserGroups))
+		state.Exclusions.MobileDeviceGroupIDs = scope.FlattenIDNameSet(ctx, exclMobileDeviceGroupSlice(e.MobileDeviceGroups))
+		state.Exclusions.BuildingIDs = scope.FlattenIDNameSet(ctx, exclBuildingSlice(e.Buildings))
+		state.Exclusions.DepartmentIDs = scope.FlattenIDNameSet(ctx, exclDepartmentSlice(e.Departments))
+		state.Exclusions.UserIDs = scope.FlattenIDNameSet(ctx, exclJssUserSlice(e.JssUsers))
+		state.Exclusions.UserGroupIDs = scope.FlattenIDNameSet(ctx, exclJssUserGroupSlice(e.JssUserGroups))
 		state.Exclusions.NetworkSegmentIDs = flattenExclNetworkSegmentSet(ctx, e.NetworkSegments)
 		state.Exclusions.DirectoryServiceOrLocalUserNames = flattenExclUsersNameSet(ctx, e.Users)
-		state.Exclusions.DirectoryServiceUserGroupNames = flattenNameSet(ctx, exclUserGroupSlice(e.UserGroups))
+		state.Exclusions.DirectoryServiceUserGroupNames = scope.FlattenNameSet(ctx, exclUserGroupSlice(e.UserGroups))
 	}
 }
 
@@ -343,15 +343,5 @@ func flattenExclUsersNameSet(ctx context.Context, u *proclassic.EbookScopeExclus
 		return types.SetNull(types.StringType)
 	}
 	out, _ := scope.FlattenNameSlice(ctx, u.User, func(i proclassic.EbookScopeExclusionsUsersUserItem) *string { return i.Name })
-	return out
-}
-
-func flattenIDNameSet(ctx context.Context, items *[]proclassic.IDName) types.Set {
-	out, _ := scope.FlattenIDSlice(ctx, items, func(i proclassic.IDName) *int { return i.ID })
-	return out
-}
-
-func flattenNameSet(ctx context.Context, items *[]proclassic.IDName) types.Set {
-	out, _ := scope.FlattenNameSlice(ctx, items, func(i proclassic.IDName) *string { return i.Name })
 	return out
 }

--- a/internal/resources/pro/apps/mac_app_store_app/state_builders.go
+++ b/internal/resources/pro/apps/mac_app_store_app/state_builders.go
@@ -89,31 +89,31 @@ func flattenMacAppScope(ctx context.Context, s *proclassic.MacApplicationScope, 
 		state.Targets.AllJssUsers = helpers.PreferCurrentBoolPointer(s.AllJssUsers, state.Targets.AllJssUsers)
 
 		state.Targets.ComputerIDs = flattenComputerItemSet(ctx, s.Computers)
-		state.Targets.ComputerGroupIDs = flattenIDNameSet(ctx, computerGroupSlice(s.ComputerGroups))
-		state.Targets.BuildingIDs = flattenIDNameSet(ctx, buildingSlice(s.Buildings))
-		state.Targets.DepartmentIDs = flattenIDNameSet(ctx, departmentSlice(s.Departments))
-		state.Targets.UserIDs = flattenIDNameSet(ctx, jssUserSlice(s.JssUsers))
-		state.Targets.UserGroupIDs = flattenIDNameSet(ctx, jssUserGroupSlice(s.JssUserGroups))
+		state.Targets.ComputerGroupIDs = scope.FlattenIDNameSet(ctx, computerGroupSlice(s.ComputerGroups))
+		state.Targets.BuildingIDs = scope.FlattenIDNameSet(ctx, buildingSlice(s.Buildings))
+		state.Targets.DepartmentIDs = scope.FlattenIDNameSet(ctx, departmentSlice(s.Departments))
+		state.Targets.UserIDs = scope.FlattenIDNameSet(ctx, jssUserSlice(s.JssUsers))
+		state.Targets.UserGroupIDs = scope.FlattenIDNameSet(ctx, jssUserGroupSlice(s.JssUserGroups))
 	}
 
 	if state.Limitations != nil && s.Limitations != nil {
 		l := s.Limitations
-		state.Limitations.NetworkSegmentIDs = flattenIDNameSet(ctx, limitationsSegmentSlice(l.NetworkSegments))
-		state.Limitations.DirectoryServiceOrLocalUserNames = flattenNameSet(ctx, limitationsUserSlice(l.Users))
-		state.Limitations.DirectoryServiceUserGroupNames = flattenNameSet(ctx, limitationsUserGroupSlice(l.UserGroups))
+		state.Limitations.NetworkSegmentIDs = scope.FlattenIDNameSet(ctx, limitationsSegmentSlice(l.NetworkSegments))
+		state.Limitations.DirectoryServiceOrLocalUserNames = scope.FlattenNameSet(ctx, limitationsUserSlice(l.Users))
+		state.Limitations.DirectoryServiceUserGroupNames = scope.FlattenNameSet(ctx, limitationsUserGroupSlice(l.UserGroups))
 	}
 
 	if state.Exclusions != nil && s.Exclusions != nil {
 		e := s.Exclusions
 		state.Exclusions.ComputerIDs = flattenExclComputerItemSet(ctx, e.Computers)
-		state.Exclusions.ComputerGroupIDs = flattenIDNameSet(ctx, exclComputerGroupSlice(e.ComputerGroups))
-		state.Exclusions.BuildingIDs = flattenIDNameSet(ctx, exclBuildingSlice(e.Buildings))
-		state.Exclusions.DepartmentIDs = flattenIDNameSet(ctx, exclDepartmentSlice(e.Departments))
-		state.Exclusions.UserIDs = flattenIDNameSet(ctx, exclJssUserSlice(e.JssUsers))
-		state.Exclusions.UserGroupIDs = flattenIDNameSet(ctx, exclJssUserGroupSlice(e.JssUserGroups))
+		state.Exclusions.ComputerGroupIDs = scope.FlattenIDNameSet(ctx, exclComputerGroupSlice(e.ComputerGroups))
+		state.Exclusions.BuildingIDs = scope.FlattenIDNameSet(ctx, exclBuildingSlice(e.Buildings))
+		state.Exclusions.DepartmentIDs = scope.FlattenIDNameSet(ctx, exclDepartmentSlice(e.Departments))
+		state.Exclusions.UserIDs = scope.FlattenIDNameSet(ctx, exclJssUserSlice(e.JssUsers))
+		state.Exclusions.UserGroupIDs = scope.FlattenIDNameSet(ctx, exclJssUserGroupSlice(e.JssUserGroups))
 		state.Exclusions.NetworkSegmentIDs = flattenExclNetworkSegmentSet(ctx, e.NetworkSegments)
 		state.Exclusions.DirectoryServiceOrLocalUserNames = flattenExclUsersNameSet(ctx, e.Users)
-		state.Exclusions.DirectoryServiceUserGroupNames = flattenNameSet(ctx, exclUserGroupSlice(e.UserGroups))
+		state.Exclusions.DirectoryServiceUserGroupNames = scope.FlattenNameSet(ctx, exclUserGroupSlice(e.UserGroups))
 	}
 }
 
@@ -310,15 +310,5 @@ func flattenExclUsersNameSet(ctx context.Context, u *proclassic.MacApplicationSc
 		return types.SetNull(types.StringType)
 	}
 	out, _ := scope.FlattenNameSlice(ctx, u.User, func(i proclassic.MacApplicationScopeExclusionsUsersUserItem) *string { return i.Name })
-	return out
-}
-
-func flattenIDNameSet(ctx context.Context, items *[]proclassic.IDName) types.Set {
-	out, _ := scope.FlattenIDSlice(ctx, items, func(i proclassic.IDName) *int { return i.ID })
-	return out
-}
-
-func flattenNameSet(ctx context.Context, items *[]proclassic.IDName) types.Set {
-	out, _ := scope.FlattenNameSlice(ctx, items, func(i proclassic.IDName) *string { return i.Name })
 	return out
 }

--- a/internal/resources/pro/apps/mobile_device_app/state_builders.go
+++ b/internal/resources/pro/apps/mobile_device_app/state_builders.go
@@ -119,31 +119,31 @@ func flattenMobileAppScope(ctx context.Context, s *proclassic.MobileDeviceApplic
 		state.Targets.AllJssUsers = helpers.PreferCurrentBoolPointer(s.AllJssUsers, state.Targets.AllJssUsers)
 
 		state.Targets.MobileDeviceIDs = flattenMobileDeviceItemSet(ctx, s.MobileDevices)
-		state.Targets.MobileDeviceGroupIDs = flattenIDNameSet(ctx, mobileDeviceGroupSlice(s.MobileDeviceGroups))
-		state.Targets.BuildingIDs = flattenIDNameSet(ctx, buildingSlice(s.Buildings))
-		state.Targets.DepartmentIDs = flattenIDNameSet(ctx, departmentSlice(s.Departments))
-		state.Targets.UserIDs = flattenIDNameSet(ctx, jssUserSlice(s.JssUsers))
-		state.Targets.UserGroupIDs = flattenIDNameSet(ctx, jssUserGroupSlice(s.JssUserGroups))
+		state.Targets.MobileDeviceGroupIDs = scope.FlattenIDNameSet(ctx, mobileDeviceGroupSlice(s.MobileDeviceGroups))
+		state.Targets.BuildingIDs = scope.FlattenIDNameSet(ctx, buildingSlice(s.Buildings))
+		state.Targets.DepartmentIDs = scope.FlattenIDNameSet(ctx, departmentSlice(s.Departments))
+		state.Targets.UserIDs = scope.FlattenIDNameSet(ctx, jssUserSlice(s.JssUsers))
+		state.Targets.UserGroupIDs = scope.FlattenIDNameSet(ctx, jssUserGroupSlice(s.JssUserGroups))
 	}
 
 	if state.Limitations != nil && s.Limitations != nil {
 		l := s.Limitations
-		state.Limitations.NetworkSegmentIDs = flattenIDNameSet(ctx, limitationsSegmentSlice(l.NetworkSegments))
-		state.Limitations.DirectoryServiceOrLocalUserNames = flattenNameSet(ctx, limitationsUserSlice(l.Users))
-		state.Limitations.DirectoryServiceUserGroupNames = flattenNameSet(ctx, limitationsUserGroupSlice(l.UserGroups))
+		state.Limitations.NetworkSegmentIDs = scope.FlattenIDNameSet(ctx, limitationsSegmentSlice(l.NetworkSegments))
+		state.Limitations.DirectoryServiceOrLocalUserNames = scope.FlattenNameSet(ctx, limitationsUserSlice(l.Users))
+		state.Limitations.DirectoryServiceUserGroupNames = scope.FlattenNameSet(ctx, limitationsUserGroupSlice(l.UserGroups))
 	}
 
 	if state.Exclusions != nil && s.Exclusions != nil {
 		e := s.Exclusions
 		state.Exclusions.MobileDeviceIDs = flattenExclMobileDeviceItemSet(ctx, e.MobileDevices)
-		state.Exclusions.MobileDeviceGroupIDs = flattenIDNameSet(ctx, exclMobileDeviceGroupSlice(e.MobileDeviceGroups))
-		state.Exclusions.BuildingIDs = flattenIDNameSet(ctx, exclBuildingSlice(e.Buildings))
-		state.Exclusions.DepartmentIDs = flattenIDNameSet(ctx, exclDepartmentSlice(e.Departments))
-		state.Exclusions.UserIDs = flattenIDNameSet(ctx, exclJssUserSlice(e.JssUsers))
-		state.Exclusions.UserGroupIDs = flattenIDNameSet(ctx, exclJssUserGroupSlice(e.JssUserGroups))
+		state.Exclusions.MobileDeviceGroupIDs = scope.FlattenIDNameSet(ctx, exclMobileDeviceGroupSlice(e.MobileDeviceGroups))
+		state.Exclusions.BuildingIDs = scope.FlattenIDNameSet(ctx, exclBuildingSlice(e.Buildings))
+		state.Exclusions.DepartmentIDs = scope.FlattenIDNameSet(ctx, exclDepartmentSlice(e.Departments))
+		state.Exclusions.UserIDs = scope.FlattenIDNameSet(ctx, exclJssUserSlice(e.JssUsers))
+		state.Exclusions.UserGroupIDs = scope.FlattenIDNameSet(ctx, exclJssUserGroupSlice(e.JssUserGroups))
 		state.Exclusions.NetworkSegmentIDs = flattenExclNetworkSegmentSet(ctx, e.NetworkSegments)
 		state.Exclusions.DirectoryServiceOrLocalUserNames = flattenExclUsersNameSet(ctx, e.Users)
-		state.Exclusions.DirectoryServiceUserGroupNames = flattenNameSet(ctx, exclUserGroupSlice(e.UserGroups))
+		state.Exclusions.DirectoryServiceUserGroupNames = scope.FlattenNameSet(ctx, exclUserGroupSlice(e.UserGroups))
 	}
 }
 
@@ -337,15 +337,5 @@ func flattenExclUsersNameSet(ctx context.Context, u *proclassic.MobileDeviceAppl
 		return types.SetNull(types.StringType)
 	}
 	out, _ := scope.FlattenNameSlice(ctx, u.User, func(i proclassic.MobileDeviceApplicationScopeExclusionsUsersUserItem) *string { return i.Name })
-	return out
-}
-
-func flattenIDNameSet(ctx context.Context, items *[]proclassic.IDName) types.Set {
-	out, _ := scope.FlattenIDSlice(ctx, items, func(i proclassic.IDName) *int { return i.ID })
-	return out
-}
-
-func flattenNameSet(ctx context.Context, items *[]proclassic.IDName) types.Set {
-	out, _ := scope.FlattenNameSlice(ctx, items, func(i proclassic.IDName) *string { return i.Name })
 	return out
 }

--- a/internal/resources/pro/configuration_profiles/macos_configuration_profile/resource_acceptance_test.go
+++ b/internal/resources/pro/configuration_profiles/macos_configuration_profile/resource_acceptance_test.go
@@ -213,17 +213,9 @@ resource "jamfplatform_pro_macos_configuration_profile" "test" {
 `, name, payload, jssUserID)
 }
 
-// newSDKClient returns a ProClassic SDK client wired to the acceptance-test
-// credentials. Used for setting up + tearing down fixture computers/users
-// the scope tests reference by classic ID.
-func newSDKClient(t *testing.T) *proclassic.Client {
-	t.Helper()
-	return proclassic.New(testhelpers.NewAcceptanceClient(t))
-}
-
 func createDummyComputer(t *testing.T, name string) string {
 	t.Helper()
-	c := newSDKClient(t)
+	c := testhelpers.NewProClassicClient(t)
 	ctx := context.Background()
 	if err := c.CreateComputerByID(ctx, "0", &proclassic.ComputerPost{
 		General: &proclassic.ComputerPostGeneral{Name: &name},
@@ -245,7 +237,7 @@ func createDummyComputer(t *testing.T, name string) string {
 
 func createDummyUser(t *testing.T, name string) string {
 	t.Helper()
-	c := newSDKClient(t)
+	c := testhelpers.NewProClassicClient(t)
 	ctx := context.Background()
 	got, err := c.CreateUserByID(ctx, "0", &proclassic.UserPost{Name: &name})
 	if err != nil || got == nil || got.ID == nil {
@@ -632,7 +624,7 @@ func TestAccResource_MacOSConfigurationProfile_ImportState(t *testing.T) {
 // survive the round-trip and surface as drift on the next plan.
 func mutatePPPCProfileChangeIdentifier(t *testing.T, profileID, newIdentifierValue string) {
 	t.Helper()
-	c := newSDKClient(t)
+	c := testhelpers.NewProClassicClient(t)
 	ctx := context.Background()
 
 	got, err := c.GetOSXConfigurationProfileByID(ctx, profileID)
@@ -785,7 +777,7 @@ func TestAccResource_MacOSConfigurationProfile_AdminUIEdit_SurfacesAsDrift(t *te
 // trip when the entry dict is well-formed.
 func mutatePPPCProfileAddValidService(t *testing.T, profileID, serviceKey string) {
 	t.Helper()
-	c := newSDKClient(t)
+	c := testhelpers.NewProClassicClient(t)
 	ctx := context.Background()
 
 	got, err := c.GetOSXConfigurationProfileByID(ctx, profileID)
@@ -827,7 +819,7 @@ func mutatePPPCProfileAddValidService(t *testing.T, profileID, serviceKey string
 // from PayloadContent[0].Services.
 func mutatePPPCProfileRemoveFirstService(t *testing.T, profileID string) {
 	t.Helper()
-	c := newSDKClient(t)
+	c := testhelpers.NewProClassicClient(t)
 	ctx := context.Background()
 
 	got, err := c.GetOSXConfigurationProfileByID(ctx, profileID)

--- a/internal/resources/pro/configuration_profiles/mobile_device_configuration_profile/resource_acceptance_test.go
+++ b/internal/resources/pro/configuration_profiles/mobile_device_configuration_profile/resource_acceptance_test.go
@@ -93,14 +93,9 @@ func freshPayload(t *testing.T, fixture string) string {
 
 // ── SDK helpers ───────────────────────────────────────────────────────────────
 
-func newSDKClient(t *testing.T) *proclassic.Client {
-	t.Helper()
-	return proclassic.New(testhelpers.NewAcceptanceClient(t))
-}
-
 func checkDestroy(t *testing.T) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		c := newSDKClient(t)
+		c := testhelpers.NewProClassicClient(t)
 		ctx := context.Background()
 		for _, rs := range s.RootModule().Resources {
 			if rs.Type != "jamfplatform_pro_mobile_device_configuration_profile" {
@@ -121,7 +116,7 @@ func checkDestroy(t *testing.T) resource.TestCheckFunc {
 
 func createDummyUser(t *testing.T, name string) string {
 	t.Helper()
-	c := newSDKClient(t)
+	c := testhelpers.NewProClassicClient(t)
 	ctx := context.Background()
 	got, err := c.CreateUserByID(ctx, "0", &proclassic.UserPost{Name: &name})
 	if err != nil || got == nil || got.ID == nil {
@@ -138,7 +133,7 @@ func createDummyUser(t *testing.T, name string) string {
 
 func createDummyMobileDeviceGroup(t *testing.T, name string) string {
 	t.Helper()
-	c := newSDKClient(t)
+	c := testhelpers.NewProClassicClient(t)
 	ctx := context.Background()
 	isSmart := false
 	got, err := c.CreateMobileDeviceGroupByID(ctx, "0", &proclassic.MobileDeviceGroup{

--- a/internal/resources/pro/patch/patch_policy/state_builders.go
+++ b/internal/resources/pro/patch/patch_policy/state_builders.go
@@ -105,25 +105,25 @@ func flattenScope(ctx context.Context, s *proclassic.PatchPolicyScope, state *Pa
 	if state.Targets != nil {
 		state.Targets.AllComputers = helpers.PreferCurrentBoolPointer(s.AllComputers, state.Targets.AllComputers)
 		state.Targets.ComputerIDs = flattenComputerSet(ctx, computerSlice(s.Computers))
-		state.Targets.ComputerGroupIDs = flattenIDNameSet(ctx, computerGroupSlice(s.ComputerGroups))
-		state.Targets.BuildingIDs = flattenIDNameSet(ctx, buildingSlice(s.Buildings))
-		state.Targets.DepartmentIDs = flattenIDNameSet(ctx, departmentSlice(s.Departments))
+		state.Targets.ComputerGroupIDs = scope.FlattenIDNameSet(ctx, computerGroupSlice(s.ComputerGroups))
+		state.Targets.BuildingIDs = scope.FlattenIDNameSet(ctx, buildingSlice(s.Buildings))
+		state.Targets.DepartmentIDs = scope.FlattenIDNameSet(ctx, departmentSlice(s.Departments))
 	}
 
 	if state.Limitations != nil && s.Limitations != nil {
 		l := s.Limitations
-		state.Limitations.NetworkSegmentIDs = flattenIDNameSet(ctx, limitationsNetworkSegmentSlice(l.NetworkSegments))
-		state.Limitations.IbeaconIDs = flattenIDNameSet(ctx, limitationsIbeaconSlice(l.Ibeacons))
+		state.Limitations.NetworkSegmentIDs = scope.FlattenIDNameSet(ctx, limitationsNetworkSegmentSlice(l.NetworkSegments))
+		state.Limitations.IbeaconIDs = scope.FlattenIDNameSet(ctx, limitationsIbeaconSlice(l.Ibeacons))
 	}
 
 	if state.Exclusions != nil && s.Exclusions != nil {
 		e := s.Exclusions
 		state.Exclusions.ComputerIDs = flattenExclComputerSet(ctx, exclComputerSlice(e.Computers))
-		state.Exclusions.ComputerGroupIDs = flattenIDNameSet(ctx, exclComputerGroupSlice(e.ComputerGroups))
-		state.Exclusions.BuildingIDs = flattenIDNameSet(ctx, exclBuildingSlice(e.Buildings))
-		state.Exclusions.DepartmentIDs = flattenIDNameSet(ctx, exclDepartmentSlice(e.Departments))
-		state.Exclusions.NetworkSegmentIDs = flattenIDNameSet(ctx, exclNetworkSegmentSlice(e.NetworkSegments))
-		state.Exclusions.IbeaconIDs = flattenIDNameSet(ctx, exclIbeaconSlice(e.Ibeacons))
+		state.Exclusions.ComputerGroupIDs = scope.FlattenIDNameSet(ctx, exclComputerGroupSlice(e.ComputerGroups))
+		state.Exclusions.BuildingIDs = scope.FlattenIDNameSet(ctx, exclBuildingSlice(e.Buildings))
+		state.Exclusions.DepartmentIDs = scope.FlattenIDNameSet(ctx, exclDepartmentSlice(e.Departments))
+		state.Exclusions.NetworkSegmentIDs = scope.FlattenIDNameSet(ctx, exclNetworkSegmentSlice(e.NetworkSegments))
+		state.Exclusions.IbeaconIDs = scope.FlattenIDNameSet(ctx, exclIbeaconSlice(e.Ibeacons))
 	}
 }
 
@@ -283,11 +283,6 @@ func exclIbeaconSlice(i *proclassic.PatchPolicyScopeExclusionsIbeacons) *[]procl
 }
 
 // ---- set flatteners ------------------------------------------------------------
-
-func flattenIDNameSet(ctx context.Context, items *[]proclassic.IDName) types.Set {
-	out, _ := scope.FlattenIDSlice(ctx, items, func(i proclassic.IDName) *int { return i.ID })
-	return out
-}
 
 func flattenComputerSet(ctx context.Context, items *[]proclassic.PatchPolicyScopeComputersComputerItem) types.Set {
 	out, _ := scope.FlattenIDSlice(ctx, items, func(i proclassic.PatchPolicyScopeComputersComputerItem) *int { return i.ID })

--- a/internal/resources/pro/policies/policy/resource_acceptance_test.go
+++ b/internal/resources/pro/policies/policy/resource_acceptance_test.go
@@ -30,16 +30,6 @@ import (
 	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/testhelpers"
 )
 
-// newSDKClient returns a real ProClassic SDK client wired to the same
-// acceptance-test credentials the provider factory uses. Used for setup +
-// teardown of fixture records (computer, user) that the project does not yet
-// expose as Terraform resources but the policy resource's scope sub-blocks
-// reference by classic ID.
-func newSDKClient(t *testing.T) *proclassic.Client {
-	t.Helper()
-	return proclassic.New(testhelpers.NewAcceptanceClient(t))
-}
-
 // createDummyComputer creates a minimal classic computer record via the SDK
 // and returns its server-assigned ID as a string. Cleanup runs at test end
 // via t.Cleanup.
@@ -49,7 +39,7 @@ func newSDKClient(t *testing.T) *proclassic.Client {
 // by name to discover the assigned ID.
 func createDummyComputer(t *testing.T, name string) string {
 	t.Helper()
-	c := newSDKClient(t)
+	c := testhelpers.NewProClassicClient(t)
 	ctx := context.Background()
 	if err := c.CreateComputerByID(ctx, "0", &proclassic.ComputerPost{
 		General: &proclassic.ComputerPostGeneral{Name: &name},
@@ -74,7 +64,7 @@ func createDummyComputer(t *testing.T, name string) string {
 // t.Cleanup.
 func createDummyUser(t *testing.T, name string) string {
 	t.Helper()
-	c := newSDKClient(t)
+	c := testhelpers.NewProClassicClient(t)
 	ctx := context.Background()
 	got, err := c.CreateUserByID(ctx, "0", &proclassic.UserPost{Name: &name})
 	if err != nil || got == nil || got.ID == nil {

--- a/internal/resources/pro/policies/policy/state_builders.go
+++ b/internal/resources/pro/policies/policy/state_builders.go
@@ -181,33 +181,33 @@ func flattenPolicyScope(ctx context.Context, s *proclassic.PolicyScope, state *s
 		state.Targets.AllJssUsers = helpers.PreferCurrentBoolPointer(s.AllJssUsers, state.Targets.AllJssUsers)
 
 		state.Targets.ComputerIDs = flattenComputerItemSet(ctx, s.Computers)
-		state.Targets.ComputerGroupIDs = flattenIDNameSet(ctx, idNameSliceFromGroups(s.ComputerGroups))
-		state.Targets.BuildingIDs = flattenIDNameSet(ctx, idNameSliceFromBuildings(s.Buildings))
-		state.Targets.DepartmentIDs = flattenIDNameSet(ctx, idNameSliceFromDepartments(s.Departments))
-		state.Targets.UserIDs = flattenIDNameSet(ctx, idNameSliceFromJssUsers(s.JssUsers))
-		state.Targets.UserGroupIDs = flattenIDNameSet(ctx, idNameSliceFromJssUserGroups(s.JssUserGroups))
+		state.Targets.ComputerGroupIDs = scope.FlattenIDNameSet(ctx, idNameSliceFromGroups(s.ComputerGroups))
+		state.Targets.BuildingIDs = scope.FlattenIDNameSet(ctx, idNameSliceFromBuildings(s.Buildings))
+		state.Targets.DepartmentIDs = scope.FlattenIDNameSet(ctx, idNameSliceFromDepartments(s.Departments))
+		state.Targets.UserIDs = scope.FlattenIDNameSet(ctx, idNameSliceFromJssUsers(s.JssUsers))
+		state.Targets.UserGroupIDs = scope.FlattenIDNameSet(ctx, idNameSliceFromJssUserGroups(s.JssUserGroups))
 	}
 
 	if state.Limitations != nil && s.Limitations != nil {
 		l := s.Limitations
-		state.Limitations.NetworkSegmentIDs = flattenIDNameSet(ctx, idNameSliceFromLimitationsSegments(l.NetworkSegments))
-		state.Limitations.IbeaconIDs = flattenIDNameSet(ctx, idNameSliceFromLimitationsIbeacons(l.Ibeacons))
-		state.Limitations.DirectoryServiceOrLocalUserNames = flattenNameSet(ctx, idNameSliceFromLimitationsUsers(l.Users))
-		state.Limitations.DirectoryServiceUserGroupNames = flattenNameSet(ctx, idNameSliceFromLimitationsUserGroups(l.UserGroups))
+		state.Limitations.NetworkSegmentIDs = scope.FlattenIDNameSet(ctx, idNameSliceFromLimitationsSegments(l.NetworkSegments))
+		state.Limitations.IbeaconIDs = scope.FlattenIDNameSet(ctx, idNameSliceFromLimitationsIbeacons(l.Ibeacons))
+		state.Limitations.DirectoryServiceOrLocalUserNames = scope.FlattenNameSet(ctx, idNameSliceFromLimitationsUsers(l.Users))
+		state.Limitations.DirectoryServiceUserGroupNames = scope.FlattenNameSet(ctx, idNameSliceFromLimitationsUserGroups(l.UserGroups))
 	}
 
 	if state.Exclusions != nil && s.Exclusions != nil {
 		e := s.Exclusions
 		state.Exclusions.ComputerIDs = flattenExclComputerItemSet(ctx, e.Computers)
-		state.Exclusions.ComputerGroupIDs = flattenIDNameSet(ctx, idNameSliceFromExclComputerGroups(e.ComputerGroups))
-		state.Exclusions.BuildingIDs = flattenIDNameSet(ctx, idNameSliceFromExclBuildings(e.Buildings))
-		state.Exclusions.DepartmentIDs = flattenIDNameSet(ctx, idNameSliceFromExclDepartments(e.Departments))
-		state.Exclusions.UserIDs = flattenIDNameSet(ctx, idNameSliceFromExclJssUsers(e.JssUsers))
-		state.Exclusions.UserGroupIDs = flattenIDNameSet(ctx, idNameSliceFromExclJssUserGroups(e.JssUserGroups))
+		state.Exclusions.ComputerGroupIDs = scope.FlattenIDNameSet(ctx, idNameSliceFromExclComputerGroups(e.ComputerGroups))
+		state.Exclusions.BuildingIDs = scope.FlattenIDNameSet(ctx, idNameSliceFromExclBuildings(e.Buildings))
+		state.Exclusions.DepartmentIDs = scope.FlattenIDNameSet(ctx, idNameSliceFromExclDepartments(e.Departments))
+		state.Exclusions.UserIDs = scope.FlattenIDNameSet(ctx, idNameSliceFromExclJssUsers(e.JssUsers))
+		state.Exclusions.UserGroupIDs = scope.FlattenIDNameSet(ctx, idNameSliceFromExclJssUserGroups(e.JssUserGroups))
 		state.Exclusions.NetworkSegmentIDs = flattenExclNetworkSegmentSet(ctx, e.NetworkSegments)
-		state.Exclusions.IbeaconIDs = flattenIDNameSet(ctx, idNameSliceFromExclIbeacons(e.Ibeacons))
+		state.Exclusions.IbeaconIDs = scope.FlattenIDNameSet(ctx, idNameSliceFromExclIbeacons(e.Ibeacons))
 		state.Exclusions.DirectoryServiceOrLocalUserNames = flattenExclUsersNameSet(ctx, e.Users)
-		state.Exclusions.DirectoryServiceUserGroupNames = flattenNameSet(ctx, idNameSliceFromExclUserGroups(e.UserGroups))
+		state.Exclusions.DirectoryServiceUserGroupNames = scope.FlattenNameSet(ctx, idNameSliceFromExclUserGroups(e.UserGroups))
 	}
 
 	return diags
@@ -358,16 +358,6 @@ func flattenExclUsersNameSet(ctx context.Context, u *proclassic.PolicyScopeExclu
 		return types.SetNull(types.StringType)
 	}
 	out, _ := scope.FlattenNameSlice(ctx, u.User, func(i proclassic.PolicyScopeExclusionsUsersUserItem) *string { return i.Name })
-	return out
-}
-
-func flattenIDNameSet(ctx context.Context, items *[]proclassic.IDName) types.Set {
-	out, _ := scope.FlattenIDSlice(ctx, items, func(i proclassic.IDName) *int { return i.ID })
-	return out
-}
-
-func flattenNameSet(ctx context.Context, items *[]proclassic.IDName) types.Set {
-	out, _ := scope.FlattenNameSlice(ctx, items, func(i proclassic.IDName) *string { return i.Name })
 	return out
 }
 

--- a/internal/resources/pro/policies/restricted_software/state_builders.go
+++ b/internal/resources/pro/policies/restricted_software/state_builders.go
@@ -68,19 +68,19 @@ func flattenGeneral(g *proclassic.RestrictedSoftwareGeneral, state *RestrictedSo
 func flattenScope(ctx context.Context, s *proclassic.RestrictedSoftwareScope, state *RestrictedSoftwareScopeModel) {
 	if state.Targets != nil {
 		state.Targets.AllComputers = helpers.PreferCurrentBoolPointer(s.AllComputers, state.Targets.AllComputers)
-		state.Targets.ComputerIDs = flattenIDNameSet(ctx, computerSlice(s.Computers))
-		state.Targets.ComputerGroupIDs = flattenIDNameSet(ctx, computerGroupSlice(s.ComputerGroups))
-		state.Targets.BuildingIDs = flattenIDNameSet(ctx, buildingSlice(s.Buildings))
-		state.Targets.DepartmentIDs = flattenIDNameSet(ctx, departmentSlice(s.Departments))
+		state.Targets.ComputerIDs = scope.FlattenIDNameSet(ctx, computerSlice(s.Computers))
+		state.Targets.ComputerGroupIDs = scope.FlattenIDNameSet(ctx, computerGroupSlice(s.ComputerGroups))
+		state.Targets.BuildingIDs = scope.FlattenIDNameSet(ctx, buildingSlice(s.Buildings))
+		state.Targets.DepartmentIDs = scope.FlattenIDNameSet(ctx, departmentSlice(s.Departments))
 	}
 
 	if state.Exclusions != nil && s.Exclusions != nil {
 		e := s.Exclusions
-		state.Exclusions.ComputerIDs = flattenIDNameSet(ctx, exclComputerSlice(e.Computers))
-		state.Exclusions.ComputerGroupIDs = flattenIDNameSet(ctx, exclComputerGroupSlice(e.ComputerGroups))
-		state.Exclusions.BuildingIDs = flattenIDNameSet(ctx, exclBuildingSlice(e.Buildings))
-		state.Exclusions.DepartmentIDs = flattenIDNameSet(ctx, exclDepartmentSlice(e.Departments))
-		state.Exclusions.DirectoryServiceOrLocalUserNames = flattenNameSet(ctx, exclUsersSlice(e.Users))
+		state.Exclusions.ComputerIDs = scope.FlattenIDNameSet(ctx, exclComputerSlice(e.Computers))
+		state.Exclusions.ComputerGroupIDs = scope.FlattenIDNameSet(ctx, exclComputerGroupSlice(e.ComputerGroups))
+		state.Exclusions.BuildingIDs = scope.FlattenIDNameSet(ctx, exclBuildingSlice(e.Buildings))
+		state.Exclusions.DepartmentIDs = scope.FlattenIDNameSet(ctx, exclDepartmentSlice(e.Departments))
+		state.Exclusions.DirectoryServiceOrLocalUserNames = scope.FlattenNameSet(ctx, exclUsersSlice(e.Users))
 	}
 }
 
@@ -150,13 +150,3 @@ func exclUsersSlice(u *proclassic.RestrictedSoftwareScopeExclusionsUsers) *[]pro
 }
 
 // ---- set flatteners ------------------------------------------------------------
-
-func flattenIDNameSet(ctx context.Context, items *[]proclassic.IDName) types.Set {
-	out, _ := scope.FlattenIDSlice(ctx, items, func(i proclassic.IDName) *int { return i.ID })
-	return out
-}
-
-func flattenNameSet(ctx context.Context, items *[]proclassic.IDName) types.Set {
-	out, _ := scope.FlattenNameSlice(ctx, items, func(i proclassic.IDName) *string { return i.Name })
-	return out
-}

--- a/internal/resources/pro/searches/advanced_computer_search/dsgroup_acceptance_test.go
+++ b/internal/resources/pro/searches/advanced_computer_search/dsgroup_acceptance_test.go
@@ -6,18 +6,13 @@
 package advanced_computer_search_test
 
 import (
-	"context"
 	"fmt"
 	"os"
-	"strconv"
 	"testing"
 
-	"github.com/Jamf-Concepts/jamfplatform-go-sdk/jamfplatform/pro"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 
-	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/common/criteria"
-	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/common/ldapgroups"
 	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/testhelpers"
 )
 
@@ -28,32 +23,9 @@ import (
 // the real wire base64 as an independent encoding oracle. Real group names are
 // never committed — see memory: no real LDAP names in public files.
 const (
-	envDSGroupGate  = "JAMFPLATFORM_ACC_CRITERIA_DS_GROUP"
-	envDSGroupName  = "JAMFPLATFORM_ACC_CRITERIA_DS_GROUP_NAME"
-	envDSGroupValue = "JAMFPLATFORM_ACC_CRITERIA_DS_GROUP_VALUE" // optional independent oracle
+	envDSGroupGate = "JAMFPLATFORM_ACC_CRITERIA_DS_GROUP"
+	envDSGroupName = "JAMFPLATFORM_ACC_CRITERIA_DS_GROUP_NAME"
 )
-
-// resolveDSGroupWireValue resolves a directory-service group by name exactly as
-// the provider does and returns the base64 {uuid,serverId} wire value, honouring
-// the optional _VALUE oracle. Fails loudly on an ambiguous / unmapped name.
-func resolveDSGroupWireValue(t *testing.T, name string) string {
-	t.Helper()
-	groups, err := ldapgroups.ResolveByName(context.Background(), pro.New(testhelpers.NewAcceptanceClient(t)), name)
-	if err != nil {
-		t.Fatalf("resolving %q: %v", name, err)
-	}
-	if len(groups) != 1 {
-		t.Fatalf("group %q must resolve to exactly one directory group (got %d) — pick an unambiguous name", name, len(groups))
-	}
-	if groups[0].UUID == "" {
-		t.Fatalf("group %q resolved with no uuid mapping", name)
-	}
-	wire := criteria.EncodeDSGroupValue(groups[0].UUID, strconv.Itoa(groups[0].LdapServerID))
-	if want := os.Getenv(envDSGroupValue); want != "" && wire != want {
-		t.Fatalf("provider resolved %q to %q, but %s=%q — name/value mismatch or an encoding bug", name, wire, envDSGroupValue, want)
-	}
-	return wire
-}
 
 // TestAccResource_ACS_DSGroupCriteria authors a directory-service group criterion
 // by NAME, asserts state round-trips back to the NAME, and asserts swapping the
@@ -68,7 +40,7 @@ func TestAccResource_ACS_DSGroupCriteria(t *testing.T) {
 		t.Skipf("%s must be set", envDSGroupName)
 	}
 	testhelpers.AccPreCheck(t)
-	groupValue := resolveDSGroupWireValue(t, groupName)
+	groupValue := testhelpers.ResolveDSGroupWireValue(t, groupName)
 
 	suffix := testhelpers.RunSuffix()
 	name := "tf-acc-acs-dsgroup-" + suffix

--- a/internal/resources/pro/searches/advanced_computer_search/input_builders.go
+++ b/internal/resources/pro/searches/advanced_computer_search/input_builders.go
@@ -5,7 +5,6 @@ package advanced_computer_search
 
 import (
 	"context"
-	"strconv"
 
 	"github.com/Jamf-Concepts/jamfplatform-go-sdk/jamfplatform/proclassic"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
@@ -13,6 +12,7 @@ import (
 
 	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/common/criteria"
 	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/common/helpers"
+	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/common/scope"
 )
 
 // buildAdvancedComputerSearchInput converts a plan model into the SDK payload
@@ -38,30 +38,12 @@ func buildAdvancedComputerSearchInput(ctx context.Context, plan AdvancedComputer
 
 	search := &proclassic.AdvancedComputerSearch{
 		Name:          &name,
-		Site:          buildSiteObject(plan.SiteID),
+		Site:          scope.BuildSiteObject(plan.SiteID),
 		Criteria:      buildCriteriaWrapper(plan.Criteria),
 		DisplayFields: displayFields,
 	}
 
 	return search, diags
-}
-
-// buildSiteObject converts the plan site_id into the SDK SiteObject. site_id is
-// Optional+Computed with a static default of "-1"; we always send a non-nil
-// Site so the wire payload is explicit about the NONE assignment.
-func buildSiteObject(siteID types.String) *proclassic.SiteObject {
-	if siteID.IsNull() || siteID.IsUnknown() {
-		return nil
-	}
-	idStr := siteID.ValueString()
-	if idStr == "" {
-		return nil
-	}
-	id, err := strconv.Atoi(idStr)
-	if err != nil {
-		return nil
-	}
-	return &proclassic.SiteObject{ID: &id}
 }
 
 // buildCriteriaWrapper wraps the shared criterion-slice builder in the

--- a/internal/resources/pro/searches/advanced_computer_search/input_builders_test.go
+++ b/internal/resources/pro/searches/advanced_computer_search/input_builders_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
 	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/common/criteria"
+	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/common/scope"
 )
 
 func TestBuildInput_AlwaysEmitsCriteriaAndDisplayWrappers(t *testing.T) {
@@ -78,10 +79,10 @@ func TestBuildInput_PopulatedDisplayFieldsAndCriteria(t *testing.T) {
 }
 
 func TestBuildSiteObject_NoneSentinel(t *testing.T) {
-	if got := buildSiteObject(types.StringValue("-1")); got == nil || got.ID == nil || *got.ID != -1 {
+	if got := scope.BuildSiteObject(types.StringValue("-1")); got == nil || got.ID == nil || *got.ID != -1 {
 		t.Errorf("expected site id -1, got %v", got)
 	}
-	if got := buildSiteObject(types.StringNull()); got != nil {
+	if got := scope.BuildSiteObject(types.StringNull()); got != nil {
 		t.Errorf("null site_id should produce nil SiteObject, got %v", got)
 	}
 }

--- a/internal/resources/pro/searches/advanced_computer_search/state_builders.go
+++ b/internal/resources/pro/searches/advanced_computer_search/state_builders.go
@@ -5,7 +5,6 @@ package advanced_computer_search
 
 import (
 	"context"
-	"strconv"
 
 	"github.com/Jamf-Concepts/jamfplatform-go-sdk/jamfplatform/proclassic"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
@@ -13,6 +12,7 @@ import (
 
 	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/common/criteria"
 	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/common/helpers"
+	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/common/scope"
 )
 
 // assignAdvancedComputerSearchResourceModel populates a resource model from an
@@ -29,7 +29,7 @@ func assignAdvancedComputerSearchResourceModel(ctx context.Context, state *Advan
 	}
 	state.Name = helpers.StringPointerValueOrNull(search.Name)
 
-	siteID, siteName := flattenSite(search.Site)
+	siteID, siteName := scope.FlattenSiteObject(search.Site)
 	state.SiteID = helpers.ReconcileOptionalStringPointer(siteID, state.SiteID)
 	state.SiteName = helpers.StringPointerValueOrNull(siteName)
 
@@ -58,7 +58,7 @@ func assignAdvancedComputerSearchDataSourceModel(ctx context.Context, state *Adv
 	}
 	state.Name = helpers.StringPointerValueOrNull(search.Name)
 
-	siteID, siteName := flattenSite(search.Site)
+	siteID, siteName := scope.FlattenSiteObject(search.Site)
 	state.SiteID = helpers.StringPointerValueOrNull(siteID)
 	state.SiteName = helpers.StringPointerValueOrNull(siteName)
 
@@ -81,20 +81,6 @@ func criterionSlice(wrapper *proclassic.AdvancedComputerSearchCriteria) *[]procl
 		return nil
 	}
 	return wrapper.Criterion
-}
-
-// flattenSite returns (id-as-string, name) pointers from a SiteObject. Returns
-// (nil, nil) when site is absent.
-func flattenSite(site *proclassic.SiteObject) (*string, *string) {
-	if site == nil {
-		return nil, nil
-	}
-	var idPtr *string
-	if site.ID != nil {
-		s := strconv.Itoa(*site.ID)
-		idPtr = &s
-	}
-	return idPtr, site.Name
 }
 
 // flattenDisplayFields converts the SDK display-fields wrapper into a Set of

--- a/internal/resources/pro/searches/advanced_mobile_device_search/dsgroup_acceptance_test.go
+++ b/internal/resources/pro/searches/advanced_mobile_device_search/dsgroup_acceptance_test.go
@@ -6,18 +6,13 @@
 package advanced_mobile_device_search_test
 
 import (
-	"context"
 	"fmt"
 	"os"
-	"strconv"
 	"testing"
 
-	"github.com/Jamf-Concepts/jamfplatform-go-sdk/jamfplatform/pro"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 
-	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/common/criteria"
-	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/common/ldapgroups"
 	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/testhelpers"
 )
 
@@ -27,29 +22,9 @@ import (
 // readback / suppress paths bridge types.List <-> []CriterionModel — exercise
 // that round-trip end to end. See the computer-search counterpart for rationale.
 const (
-	envDSGroupGate  = "JAMFPLATFORM_ACC_CRITERIA_DS_GROUP"
-	envDSGroupName  = "JAMFPLATFORM_ACC_CRITERIA_DS_GROUP_NAME"
-	envDSGroupValue = "JAMFPLATFORM_ACC_CRITERIA_DS_GROUP_VALUE" // optional independent oracle
+	envDSGroupGate = "JAMFPLATFORM_ACC_CRITERIA_DS_GROUP"
+	envDSGroupName = "JAMFPLATFORM_ACC_CRITERIA_DS_GROUP_NAME"
 )
-
-func resolveDSGroupWireValue(t *testing.T, name string) string {
-	t.Helper()
-	groups, err := ldapgroups.ResolveByName(context.Background(), pro.New(testhelpers.NewAcceptanceClient(t)), name)
-	if err != nil {
-		t.Fatalf("resolving %q: %v", name, err)
-	}
-	if len(groups) != 1 {
-		t.Fatalf("group %q must resolve to exactly one directory group (got %d) — pick an unambiguous name", name, len(groups))
-	}
-	if groups[0].UUID == "" {
-		t.Fatalf("group %q resolved with no uuid mapping", name)
-	}
-	wire := criteria.EncodeDSGroupValue(groups[0].UUID, strconv.Itoa(groups[0].LdapServerID))
-	if want := os.Getenv(envDSGroupValue); want != "" && wire != want {
-		t.Fatalf("provider resolved %q to %q, but %s=%q — name/value mismatch or an encoding bug", name, wire, envDSGroupValue, want)
-	}
-	return wire
-}
 
 // TestAccResource_AMDS_DSGroupCriteria mirrors the computer-search test on the
 // mobile (Pro v1, types.List) surface.
@@ -62,7 +37,7 @@ func TestAccResource_AMDS_DSGroupCriteria(t *testing.T) {
 		t.Skipf("%s must be set", envDSGroupName)
 	}
 	testhelpers.AccPreCheck(t)
-	groupValue := resolveDSGroupWireValue(t, groupName)
+	groupValue := testhelpers.ResolveDSGroupWireValue(t, groupName)
 
 	suffix := testhelpers.RunSuffix()
 	name := "tf-acc-amds-dsgroup-" + suffix

--- a/internal/resources/pro/searches/advanced_user_search/dsgroup_acceptance_test.go
+++ b/internal/resources/pro/searches/advanced_user_search/dsgroup_acceptance_test.go
@@ -6,18 +6,13 @@
 package advanced_user_search_test
 
 import (
-	"context"
 	"fmt"
 	"os"
-	"strconv"
 	"testing"
 
-	"github.com/Jamf-Concepts/jamfplatform-go-sdk/jamfplatform/pro"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 
-	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/common/criteria"
-	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/common/ldapgroups"
 	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/testhelpers"
 )
 
@@ -26,29 +21,9 @@ import (
 // name). The user surface accepts only the Username directory-service group
 // criterion. See the computer-search counterpart for the full rationale.
 const (
-	envDSGroupGate  = "JAMFPLATFORM_ACC_CRITERIA_DS_GROUP"
-	envDSGroupName  = "JAMFPLATFORM_ACC_CRITERIA_DS_GROUP_NAME"
-	envDSGroupValue = "JAMFPLATFORM_ACC_CRITERIA_DS_GROUP_VALUE" // optional independent oracle
+	envDSGroupGate = "JAMFPLATFORM_ACC_CRITERIA_DS_GROUP"
+	envDSGroupName = "JAMFPLATFORM_ACC_CRITERIA_DS_GROUP_NAME"
 )
-
-func resolveDSGroupWireValue(t *testing.T, name string) string {
-	t.Helper()
-	groups, err := ldapgroups.ResolveByName(context.Background(), pro.New(testhelpers.NewAcceptanceClient(t)), name)
-	if err != nil {
-		t.Fatalf("resolving %q: %v", name, err)
-	}
-	if len(groups) != 1 {
-		t.Fatalf("group %q must resolve to exactly one directory group (got %d) — pick an unambiguous name", name, len(groups))
-	}
-	if groups[0].UUID == "" {
-		t.Fatalf("group %q resolved with no uuid mapping", name)
-	}
-	wire := criteria.EncodeDSGroupValue(groups[0].UUID, strconv.Itoa(groups[0].LdapServerID))
-	if want := os.Getenv(envDSGroupValue); want != "" && wire != want {
-		t.Fatalf("provider resolved %q to %q, but %s=%q — name/value mismatch or an encoding bug", name, wire, envDSGroupValue, want)
-	}
-	return wire
-}
 
 // TestAccResource_AUS_DSGroupCriteria mirrors the computer-search test on the
 // user surface (Username criterion only).
@@ -61,7 +36,7 @@ func TestAccResource_AUS_DSGroupCriteria(t *testing.T) {
 		t.Skipf("%s must be set", envDSGroupName)
 	}
 	testhelpers.AccPreCheck(t)
-	groupValue := resolveDSGroupWireValue(t, groupName)
+	groupValue := testhelpers.ResolveDSGroupWireValue(t, groupName)
 
 	suffix := testhelpers.RunSuffix()
 	name := "tf-acc-aus-dsgroup-" + suffix

--- a/internal/resources/pro/searches/advanced_user_search/input_builders.go
+++ b/internal/resources/pro/searches/advanced_user_search/input_builders.go
@@ -5,7 +5,6 @@ package advanced_user_search
 
 import (
 	"context"
-	"strconv"
 
 	"github.com/Jamf-Concepts/jamfplatform-go-sdk/jamfplatform/proclassic"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
@@ -13,6 +12,7 @@ import (
 
 	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/common/criteria"
 	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/common/helpers"
+	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/common/scope"
 )
 
 // buildAdvancedUserSearchInput converts a plan model into the SDK payload used
@@ -34,30 +34,12 @@ func buildAdvancedUserSearchInput(ctx context.Context, plan AdvancedUserSearchRe
 
 	search := &proclassic.AdvancedUserSearch{
 		Name:          &name,
-		Site:          buildSiteObject(plan.SiteID),
+		Site:          scope.BuildSiteObject(plan.SiteID),
 		Criteria:      buildCriteriaWrapper(plan.Criteria),
 		DisplayFields: displayFields,
 	}
 
 	return search, diags
-}
-
-// buildSiteObject converts the plan site_id into the SDK SiteObject. site_id is
-// Optional+Computed with a static default of "-1"; we always send a non-nil
-// Site so the wire payload is explicit about the NONE assignment.
-func buildSiteObject(siteID types.String) *proclassic.SiteObject {
-	if siteID.IsNull() || siteID.IsUnknown() {
-		return nil
-	}
-	idStr := siteID.ValueString()
-	if idStr == "" {
-		return nil
-	}
-	id, err := strconv.Atoi(idStr)
-	if err != nil {
-		return nil
-	}
-	return &proclassic.SiteObject{ID: &id}
 }
 
 // buildCriteriaWrapper wraps the shared criterion-slice builder in the

--- a/internal/resources/pro/searches/advanced_user_search/input_builders_test.go
+++ b/internal/resources/pro/searches/advanced_user_search/input_builders_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
 	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/common/criteria"
+	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/common/scope"
 )
 
 func TestBuildInput_AlwaysEmitsCriteriaAndDisplayWrappers(t *testing.T) {
@@ -60,10 +61,10 @@ func TestBuildInput_PopulatedCriteriaAndDisplay(t *testing.T) {
 }
 
 func TestBuildSiteObject_NoneSentinel(t *testing.T) {
-	if got := buildSiteObject(types.StringValue("-1")); got == nil || got.ID == nil || *got.ID != -1 {
+	if got := scope.BuildSiteObject(types.StringValue("-1")); got == nil || got.ID == nil || *got.ID != -1 {
 		t.Errorf("expected site id -1, got %v", got)
 	}
-	if got := buildSiteObject(types.StringNull()); got != nil {
+	if got := scope.BuildSiteObject(types.StringNull()); got != nil {
 		t.Errorf("null site_id should produce nil SiteObject, got %v", got)
 	}
 }

--- a/internal/resources/pro/searches/advanced_user_search/state_builders.go
+++ b/internal/resources/pro/searches/advanced_user_search/state_builders.go
@@ -5,7 +5,6 @@ package advanced_user_search
 
 import (
 	"context"
-	"strconv"
 
 	"github.com/Jamf-Concepts/jamfplatform-go-sdk/jamfplatform/proclassic"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
@@ -13,6 +12,7 @@ import (
 
 	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/common/criteria"
 	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/common/helpers"
+	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/common/scope"
 )
 
 // assignAdvancedUserSearchResourceModel populates a resource model from an
@@ -29,7 +29,7 @@ func assignAdvancedUserSearchResourceModel(ctx context.Context, state *AdvancedU
 	}
 	state.Name = helpers.StringPointerValueOrNull(search.Name)
 
-	siteID, siteName := flattenSite(search.Site)
+	siteID, siteName := scope.FlattenSiteObject(search.Site)
 	state.SiteID = helpers.ReconcileOptionalStringPointer(siteID, state.SiteID)
 	state.SiteName = helpers.StringPointerValueOrNull(siteName)
 
@@ -58,7 +58,7 @@ func assignAdvancedUserSearchDataSourceModel(ctx context.Context, state *Advance
 	}
 	state.Name = helpers.StringPointerValueOrNull(search.Name)
 
-	siteID, siteName := flattenSite(search.Site)
+	siteID, siteName := scope.FlattenSiteObject(search.Site)
 	state.SiteID = helpers.StringPointerValueOrNull(siteID)
 	state.SiteName = helpers.StringPointerValueOrNull(siteName)
 
@@ -81,20 +81,6 @@ func criterionSlice(wrapper *proclassic.AdvancedUserSearchCriteria) *[]proclassi
 		return nil
 	}
 	return wrapper.Criterion
-}
-
-// flattenSite returns (id-as-string, name) pointers from a SiteObject. Returns
-// (nil, nil) when site is absent.
-func flattenSite(site *proclassic.SiteObject) (*string, *string) {
-	if site == nil {
-		return nil, nil
-	}
-	var idPtr *string
-	if site.ID != nil {
-		s := strconv.Itoa(*site.ID)
-		idPtr = &s
-	}
-	return idPtr, site.Name
 }
 
 // flattenDisplayFields converts the SDK display-fields wrapper into a Set of

--- a/internal/resources/pro/settings/access_management_settings/resource_acceptance_test.go
+++ b/internal/resources/pro/settings/access_management_settings/resource_acceptance_test.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/Jamf-Concepts/jamfplatform-go-sdk/jamfplatform/pro"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
 	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/testhelpers"
 )
@@ -44,17 +43,9 @@ func adeFixture(name, token string, woVersion int) string {
 // on the tenant after Terraform destroys the resources from state. The remote Delete is a
 // no-op, so the API must still return the record post-destroy.
 func checkSingletonRecordStillExists(t *testing.T) resource.TestCheckFunc {
-	return func(_ *terraform.State) error {
-		c := pro.New(testhelpers.NewAcceptanceClient(t))
-		got, err := c.GetEnrollmentAccessManagementV4(context.Background())
-		if err != nil {
-			return fmt.Errorf("expected Access Management settings record to persist on tenant after destroy, got error: %w", err)
-		}
-		if got == nil {
-			return fmt.Errorf("expected non-nil Access Management settings record post-destroy")
-		}
-		return nil
-	}
+	return testhelpers.RequireSingletonStillExists(t, "Access Management settings", func(ctx context.Context) (any, error) {
+		return pro.New(testhelpers.NewAcceptanceClient(t)).GetEnrollmentAccessManagementV4(ctx)
+	})
 }
 
 // TestAccResource_ProAccessManagementSettings_Basic creates an ADE server object from the

--- a/internal/resources/pro/settings/activation_code/resource_acceptance_test.go
+++ b/internal/resources/pro/settings/activation_code/resource_acceptance_test.go
@@ -24,7 +24,6 @@ import (
 
 	"github.com/Jamf-Concepts/jamfplatform-go-sdk/jamfplatform/proclassic"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
 	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/testhelpers"
 )
@@ -49,17 +48,9 @@ func currentActivationCode(t *testing.T) (org, code string) {
 // checkSingletonRecordStillExists verifies the activation code record persists on the
 // tenant after Terraform destroys the resource from state (the remote Delete is a no-op).
 func checkSingletonRecordStillExists(t *testing.T) resource.TestCheckFunc {
-	return func(_ *terraform.State) error {
-		c := proclassic.New(testhelpers.NewAcceptanceClient(t))
-		got, err := c.GetActivationCode(context.Background())
-		if err != nil {
-			return fmt.Errorf("expected activation code record to persist on tenant after destroy, got error: %w", err)
-		}
-		if got == nil {
-			return fmt.Errorf("expected non-nil activation code record post-destroy")
-		}
-		return nil
-	}
+	return testhelpers.RequireSingletonStillExists(t, "activation code", func(ctx context.Context) (any, error) {
+		return proclassic.New(testhelpers.NewAcceptanceClient(t)).GetActivationCode(ctx)
+	})
 }
 
 func configFor(org, code string) string {

--- a/internal/resources/pro/settings/app_installer_settings/resource_acceptance_test.go
+++ b/internal/resources/pro/settings/app_installer_settings/resource_acceptance_test.go
@@ -21,17 +21,9 @@ import (
 // checkSingletonRecordStillExists verifies the App Installer global settings record
 // persists on the tenant after Terraform destroys the resource from state.
 func checkSingletonRecordStillExists(t *testing.T) resource.TestCheckFunc {
-	return func(_ *terraform.State) error {
-		c := pro.New(testhelpers.NewAcceptanceClient(t))
-		got, err := c.GetAppInstallerGlobalSettingsV1(context.Background())
-		if err != nil {
-			return fmt.Errorf("expected App Installer settings to persist after destroy: %w", err)
-		}
-		if got == nil {
-			return fmt.Errorf("expected non-nil App Installer settings post-destroy")
-		}
-		return nil
-	}
+	return testhelpers.RequireSingletonStillExists(t, "App Installer settings", func(ctx context.Context) (any, error) {
+		return pro.New(testhelpers.NewAcceptanceClient(t)).GetAppInstallerGlobalSettingsV1(ctx)
+	})
 }
 
 // TestAccResource_ProAppInstallerSettings_Basic creates settings with both blocks,

--- a/internal/resources/pro/settings/computer_check_in_settings/resource_acceptance_test.go
+++ b/internal/resources/pro/settings/computer_check_in_settings/resource_acceptance_test.go
@@ -7,13 +7,11 @@ package computer_check_in_settings_test
 
 import (
 	"context"
-	"fmt"
 	"regexp"
 	"testing"
 
 	"github.com/Jamf-Concepts/jamfplatform-go-sdk/jamfplatform/pro"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
 	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/testhelpers"
 )
@@ -23,17 +21,9 @@ import (
 // Canonical singleton acceptance check: the remote Delete is a no-op, so the API
 // must still return the record (with whatever value was last applied) post-destroy.
 func checkSingletonRecordStillExists(t *testing.T) resource.TestCheckFunc {
-	return func(_ *terraform.State) error {
-		c := pro.New(testhelpers.NewAcceptanceClient(t))
-		got, err := c.GetCheckInSettingsV3(context.Background())
-		if err != nil {
-			return fmt.Errorf("expected Client Check-In settings record to persist on tenant after destroy, got error: %w", err)
-		}
-		if got == nil {
-			return fmt.Errorf("expected non-nil Client Check-In settings record post-destroy")
-		}
-		return nil
-	}
+	return testhelpers.RequireSingletonStillExists(t, "Client Check-In settings", func(ctx context.Context) (any, error) {
+		return pro.New(testhelpers.NewAcceptanceClient(t)).GetCheckInSettingsV3(ctx)
+	})
 }
 
 // TestAccResource_ProComputerCheckInSettings_Basic mutates every attribute across two Update

--- a/internal/resources/pro/settings/computer_inventory_collection_settings/resource_acceptance_test.go
+++ b/internal/resources/pro/settings/computer_inventory_collection_settings/resource_acceptance_test.go
@@ -7,13 +7,11 @@ package computer_inventory_collection_settings_test
 
 import (
 	"context"
-	"fmt"
 	"regexp"
 	"testing"
 
 	"github.com/Jamf-Concepts/jamfplatform-go-sdk/jamfplatform/pro"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
 	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/testhelpers"
 )
@@ -23,17 +21,9 @@ const resName = "jamfplatform_pro_computer_inventory_collection_settings.test"
 // checkSingletonRecordStillExists verifies the settings record persists on the tenant
 // after Terraform destroys the resource from state. The remote Delete is a no-op.
 func checkSingletonRecordStillExists(t *testing.T) resource.TestCheckFunc {
-	return func(_ *terraform.State) error {
-		c := pro.New(testhelpers.NewAcceptanceClient(t))
-		got, err := c.GetComputerInventoryCollectionSettingsV2(context.Background())
-		if err != nil {
-			return fmt.Errorf("expected computer inventory collection settings to persist on tenant after destroy, got error: %w", err)
-		}
-		if got == nil {
-			return fmt.Errorf("expected non-nil settings record post-destroy")
-		}
-		return nil
-	}
+	return testhelpers.RequireSingletonStillExists(t, "computer inventory collection settings", func(ctx context.Context) (any, error) {
+		return pro.New(testhelpers.NewAcceptanceClient(t)).GetComputerInventoryCollectionSettingsV2(ctx)
+	})
 }
 
 // TestAccResource_ProComputerInventoryCollectionSettings_Basic exercises a full Update

--- a/internal/resources/pro/settings/gsx_connection/resource_acceptance_test.go
+++ b/internal/resources/pro/settings/gsx_connection/resource_acceptance_test.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/Jamf-Concepts/jamfplatform-go-sdk/jamfplatform/pro"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
 	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/testhelpers"
 )
@@ -64,17 +63,9 @@ func requireGsxCreds(t *testing.T) gsxCreds {
 // checkSingletonRecordStillExists verifies the GSX Connection record persists on the tenant
 // after Terraform destroys the resource from state (Delete is a no-op for singletons).
 func checkSingletonRecordStillExists(t *testing.T) resource.TestCheckFunc {
-	return func(_ *terraform.State) error {
-		c := pro.New(testhelpers.NewAcceptanceClient(t))
-		got, err := c.GetGSXConnectionV1(context.Background())
-		if err != nil {
-			return fmt.Errorf("expected GSX Connection record to persist on tenant after destroy: %w", err)
-		}
-		if got == nil {
-			return fmt.Errorf("expected non-nil GSX Connection record post-destroy")
-		}
-		return nil
-	}
+	return testhelpers.RequireSingletonStillExists(t, "GSX Connection", func(ctx context.Context) (any, error) {
+		return pro.New(testhelpers.NewAcceptanceClient(t)).GetGSXConnectionV1(ctx)
+	})
 }
 
 func gsxConfig(c gsxCreds, enabled bool) string {

--- a/internal/resources/pro/settings/impact_alert_notification_settings/resource_acceptance_test.go
+++ b/internal/resources/pro/settings/impact_alert_notification_settings/resource_acceptance_test.go
@@ -7,13 +7,11 @@ package impact_alert_notification_settings_test
 
 import (
 	"context"
-	"fmt"
 	"regexp"
 	"testing"
 
 	"github.com/Jamf-Concepts/jamfplatform-go-sdk/jamfplatform/pro"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
 	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/testhelpers"
 )
@@ -23,17 +21,9 @@ import (
 // Canonical singleton acceptance check: the remote Delete is a no-op, so the API must
 // still return the record (with whatever value was last applied) post-destroy.
 func checkSingletonRecordStillExists(t *testing.T) resource.TestCheckFunc {
-	return func(_ *terraform.State) error {
-		c := pro.New(testhelpers.NewAcceptanceClient(t))
-		got, err := c.GetImpactAlertNotificationSettingsV1(context.Background())
-		if err != nil {
-			return fmt.Errorf("expected Impact Alert Notification settings record to persist on tenant after destroy, got error: %w", err)
-		}
-		if got == nil {
-			return fmt.Errorf("expected non-nil Impact Alert Notification settings record post-destroy")
-		}
-		return nil
-	}
+	return testhelpers.RequireSingletonStillExists(t, "Impact Alert Notification settings", func(ctx context.Context) (any, error) {
+		return pro.New(testhelpers.NewAcceptanceClient(t)).GetImpactAlertNotificationSettingsV1(ctx)
+	})
 }
 
 // TestAccResource_ProImpactAlertNotificationSettings_Basic mutates every toggle across two

--- a/internal/resources/pro/settings/login_page/resource_acceptance_test.go
+++ b/internal/resources/pro/settings/login_page/resource_acceptance_test.go
@@ -7,13 +7,11 @@ package login_page_test
 
 import (
 	"context"
-	"fmt"
 	"regexp"
 	"testing"
 
 	"github.com/Jamf-Concepts/jamfplatform-go-sdk/jamfplatform/pro"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
 	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/testhelpers"
 )
@@ -25,17 +23,9 @@ func strptr(s string) *string { return &s }
 // on the tenant after Terraform destroys the resource from state. Canonical singleton
 // acceptance check: the remote Delete is a no-op, so the API must still return the record.
 func checkSingletonRecordStillExists(t *testing.T) resource.TestCheckFunc {
-	return func(_ *terraform.State) error {
-		c := pro.New(testhelpers.NewAcceptanceClient(t))
-		got, err := c.GetLoginCustomizationV1(context.Background())
-		if err != nil {
-			return fmt.Errorf("expected login page settings record to persist on tenant after destroy, got error: %w", err)
-		}
-		if got == nil {
-			return fmt.Errorf("expected non-nil login page settings record post-destroy")
-		}
-		return nil
-	}
+	return testhelpers.RequireSingletonStillExists(t, "login page settings", func(ctx context.Context) (any, error) {
+		return pro.New(testhelpers.NewAcceptanceClient(t)).GetLoginCustomizationV1(ctx)
+	})
 }
 
 // TestAccResource_ProLoginPageSettings_Basic mutates every field across two Update steps

--- a/internal/resources/pro/settings/macos_onboarding/resource_acceptance_test.go
+++ b/internal/resources/pro/settings/macos_onboarding/resource_acceptance_test.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/Jamf-Concepts/jamfplatform-go-sdk/jamfplatform/pro"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
 	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/testhelpers"
 )
@@ -111,17 +110,9 @@ func snapshotAndRestoreOnboarding(t *testing.T) {
 // checkSingletonRecordStillExists verifies the onboarding record persists on the tenant
 // after Terraform destroys the resource from state (singleton — remote delete is a no-op).
 func checkSingletonRecordStillExists(t *testing.T) resource.TestCheckFunc {
-	return func(_ *terraform.State) error {
-		c := pro.New(testhelpers.NewAcceptanceClient(t))
-		got, err := c.GetOnboardingV1(context.Background())
-		if err != nil {
-			return fmt.Errorf("expected onboarding record to persist on tenant after destroy, got error: %w", err)
-		}
-		if got == nil {
-			return fmt.Errorf("expected non-nil onboarding record post-destroy")
-		}
-		return nil
-	}
+	return testhelpers.RequireSingletonStillExists(t, "onboarding", func(ctx context.Context) (any, error) {
+		return pro.New(testhelpers.NewAcceptanceClient(t)).GetOnboardingV1(ctx)
+	})
 }
 
 const (

--- a/internal/resources/pro/settings/managed_software_updates/resource_acceptance_test.go
+++ b/internal/resources/pro/settings/managed_software_updates/resource_acceptance_test.go
@@ -7,13 +7,11 @@ package managed_software_updates_test
 
 import (
 	"context"
-	"fmt"
 	"regexp"
 	"testing"
 
 	"github.com/Jamf-Concepts/jamfplatform-go-sdk/jamfplatform/pro"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
 	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/testhelpers"
 )
@@ -21,17 +19,9 @@ import (
 // checkSingletonRecordStillExists verifies the feature-toggle record persists on the tenant
 // after Terraform destroys the resource from state — the remote Delete is a no-op.
 func checkSingletonRecordStillExists(t *testing.T) resource.TestCheckFunc {
-	return func(_ *terraform.State) error {
-		c := pro.New(testhelpers.NewAcceptanceClient(t))
-		got, err := c.GetManagedSoftwareUpdateFeatureToggleV1(context.Background())
-		if err != nil {
-			return fmt.Errorf("expected Managed Software Updates feature toggle to persist on tenant after destroy, got error: %w", err)
-		}
-		if got == nil {
-			return fmt.Errorf("expected non-nil feature toggle record post-destroy")
-		}
-		return nil
-	}
+	return testhelpers.RequireSingletonStillExists(t, "Managed Software Updates feature toggle", func(ctx context.Context) (any, error) {
+		return pro.New(testhelpers.NewAcceptanceClient(t)).GetManagedSoftwareUpdateFeatureToggleV1(ctx)
+	})
 }
 
 // TestAccResource_ProManagedSoftwareUpdateFeatureToggle_Basic flips the toggle across two

--- a/internal/resources/pro/settings/mdm_profile_settings/resource_acceptance_test.go
+++ b/internal/resources/pro/settings/mdm_profile_settings/resource_acceptance_test.go
@@ -7,13 +7,11 @@ package mdm_profile_settings_test
 
 import (
 	"context"
-	"fmt"
 	"regexp"
 	"testing"
 
 	"github.com/Jamf-Concepts/jamfplatform-go-sdk/jamfplatform/pro"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
 	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/testhelpers"
 )
@@ -23,17 +21,9 @@ import (
 // Canonical singleton acceptance check: the remote Delete is a no-op, so the API
 // must still return the record (with whatever value was last applied) post-destroy.
 func checkSingletonRecordStillExists(t *testing.T) resource.TestCheckFunc {
-	return func(_ *terraform.State) error {
-		c := pro.New(testhelpers.NewAcceptanceClient(t))
-		got, err := c.GetDeviceCommunicationSettingsV1(context.Background())
-		if err != nil {
-			return fmt.Errorf("expected device communication settings record to persist on tenant after destroy, got error: %w", err)
-		}
-		if got == nil {
-			return fmt.Errorf("expected non-nil device communication settings record post-destroy")
-		}
-		return nil
-	}
+	return testhelpers.RequireSingletonStillExists(t, "device communication settings", func(ctx context.Context) (any, error) {
+		return pro.New(testhelpers.NewAcceptanceClient(t)).GetDeviceCommunicationSettingsV1(ctx)
+	})
 }
 
 // TestAccResource_ProMDMProfileSettings_Basic mutates all six settings on, then

--- a/internal/resources/pro/settings/self_service_macos_settings/resource_acceptance_test.go
+++ b/internal/resources/pro/settings/self_service_macos_settings/resource_acceptance_test.go
@@ -7,14 +7,12 @@ package self_service_macos_settings_test
 
 import (
 	"context"
-	"fmt"
 	"os"
 	"regexp"
 	"testing"
 
 	"github.com/Jamf-Concepts/jamfplatform-go-sdk/jamfplatform/pro"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
 	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/testhelpers"
 )
@@ -66,17 +64,9 @@ func snapshotAndRestoreSettings(t *testing.T) {
 // singleton acceptance check: the remote Delete is a no-op, so the API must still return
 // the record (with whatever value was last applied) post-destroy.
 func checkSingletonRecordStillExists(t *testing.T) resource.TestCheckFunc {
-	return func(_ *terraform.State) error {
-		c := pro.New(testhelpers.NewAcceptanceClient(t))
-		got, err := c.GetSelfServiceSettingsV1(context.Background())
-		if err != nil {
-			return fmt.Errorf("expected Self Service settings record to persist on tenant after destroy, got error: %w", err)
-		}
-		if got == nil {
-			return fmt.Errorf("expected non-nil Self Service settings record post-destroy")
-		}
-		return nil
-	}
+	return testhelpers.RequireSingletonStillExists(t, "Self Service settings", func(ctx context.Context) (any, error) {
+		return pro.New(testhelpers.NewAcceptanceClient(t)).GetSelfServiceSettingsV1(ctx)
+	})
 }
 
 // TestAccResource_ProSelfServiceMacosSettings_Basic drives every attribute across two Update

--- a/internal/resources/pro/settings/self_service_plus_settings/resource_acceptance_test.go
+++ b/internal/resources/pro/settings/self_service_plus_settings/resource_acceptance_test.go
@@ -7,13 +7,11 @@ package self_service_plus_settings_test
 
 import (
 	"context"
-	"fmt"
 	"regexp"
 	"testing"
 
 	"github.com/Jamf-Concepts/jamfplatform-go-sdk/jamfplatform/pro"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
 	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/testhelpers"
 )
@@ -23,17 +21,9 @@ import (
 // Canonical singleton acceptance check: the remote Delete is a no-op, so the API
 // must still return the record (with whatever value was last applied) post-destroy.
 func checkSingletonRecordStillExists(t *testing.T) resource.TestCheckFunc {
-	return func(_ *terraform.State) error {
-		c := pro.New(testhelpers.NewAcceptanceClient(t))
-		got, err := c.GetSelfServicePlusSettingsV1(context.Background())
-		if err != nil {
-			return fmt.Errorf("expected Self Service Plus settings record to persist on tenant after destroy, got error: %w", err)
-		}
-		if got == nil {
-			return fmt.Errorf("expected non-nil Self Service Plus settings record post-destroy")
-		}
-		return nil
-	}
+	return testhelpers.RequireSingletonStillExists(t, "Self Service Plus settings", func(ctx context.Context) (any, error) {
+		return pro.New(testhelpers.NewAcceptanceClient(t)).GetSelfServicePlusSettingsV1(ctx)
+	})
 }
 
 // TestAccResource_ProSelfServicePlusSettings_Basic toggles Self Service Plus on, then

--- a/internal/resources/pro/settings/service_discovery_enrollment/resource_acceptance_test.go
+++ b/internal/resources/pro/settings/service_discovery_enrollment/resource_acceptance_test.go
@@ -62,17 +62,9 @@ func serviceDiscoveryConfig(adeName, token string, enrollmentType string) string
 // checkSingletonRecordStillExists verifies the well-known settings record persists on the
 // tenant after Terraform destroys the resources from state (singleton — no remote delete).
 func checkSingletonRecordStillExists(t *testing.T) resource.TestCheckFunc {
-	return func(_ *terraform.State) error {
-		c := pro.New(testhelpers.NewAcceptanceClient(t))
-		got, err := c.GetServiceDiscoveryEnrollmentWellKnownSettingsV1(context.Background())
-		if err != nil {
-			return fmt.Errorf("expected service discovery well-known settings to persist post-destroy, got error: %w", err)
-		}
-		if got == nil {
-			return fmt.Errorf("expected non-nil well-known settings record post-destroy")
-		}
-		return nil
-	}
+	return testhelpers.RequireSingletonStillExists(t, "service discovery well-known settings", func(ctx context.Context) (any, error) {
+		return pro.New(testhelpers.NewAcceptanceClient(t)).GetServiceDiscoveryEnrollmentWellKnownSettingsV1(ctx)
+	})
 }
 
 // TestAccResource_ProServiceDiscoveryEnrollment_Basic creates an ADE server object from

--- a/internal/resources/pro/settings/smtp_server/resource_acceptance_test.go
+++ b/internal/resources/pro/settings/smtp_server/resource_acceptance_test.go
@@ -7,14 +7,12 @@ package smtp_server_test
 
 import (
 	"context"
-	"fmt"
 	"os"
 	"regexp"
 	"testing"
 
 	"github.com/Jamf-Concepts/jamfplatform-go-sdk/jamfplatform/pro"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
 	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/testhelpers"
 )
@@ -25,17 +23,9 @@ const smtpAddr = "jamfplatform_pro_smtp_server.test"
 // persists on the tenant after Terraform destroys the resource from state. The
 // remote Delete is a no-op, so the API must still return the record post-destroy.
 func checkSingletonRecordStillExists(t *testing.T) resource.TestCheckFunc {
-	return func(_ *terraform.State) error {
-		c := pro.New(testhelpers.NewAcceptanceClient(t))
-		got, err := c.GetSmtpServerV2(context.Background())
-		if err != nil {
-			return fmt.Errorf("expected SMTP Server record to persist on tenant after destroy, got error: %w", err)
-		}
-		if got == nil {
-			return fmt.Errorf("expected non-nil SMTP Server record post-destroy")
-		}
-		return nil
-	}
+	return testhelpers.RequireSingletonStillExists(t, "SMTP Server", func(ctx context.Context) (any, error) {
+		return pro.New(testhelpers.NewAcceptanceClient(t)).GetSmtpServerV2(ctx)
+	})
 }
 
 // TestAccResource_ProSmtpServer_Basic exercises the BASIC happy-path plus a

--- a/internal/resources/pro/users/class/input_builders.go
+++ b/internal/resources/pro/users/class/input_builders.go
@@ -5,11 +5,10 @@ package class
 
 import (
 	"context"
-	"strconv"
 
 	"github.com/Jamf-Concepts/jamfplatform-go-sdk/jamfplatform/proclassic"
+	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/common/scope"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
-	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
 // buildClassInput converts a plan model into the SDK payload used for Create and
@@ -44,7 +43,7 @@ func buildClassInput(ctx context.Context, plan ClassResourceModel) (*proclassic.
 	input := &proclassic.ClassPost{
 		Name:                 &name,
 		Description:          plan.Description.ValueStringPointer(),
-		Site:                 buildSiteObject(plan.SiteID),
+		Site:                 scope.BuildSiteObject(plan.SiteID),
 		Students:             &proclassic.ClassPostStudents{Student: &students},
 		Teachers:             &proclassic.ClassPostTeachers{Teacher: &teachers},
 		StudentGroupIds:      &proclassic.ClassPostStudentGroupIds{ID: &studentGroups},
@@ -53,22 +52,4 @@ func buildClassInput(ctx context.Context, plan ClassResourceModel) (*proclassic.
 	}
 
 	return input, diags
-}
-
-// buildSiteObject converts the plan site_id into the SDK SiteObject. Returns nil
-// when site_id is null/unknown/empty so the server applies its default (the NONE
-// site, ID -1).
-func buildSiteObject(siteID types.String) *proclassic.SiteObject {
-	if siteID.IsNull() || siteID.IsUnknown() {
-		return nil
-	}
-	idStr := siteID.ValueString()
-	if idStr == "" {
-		return nil
-	}
-	id, err := strconv.Atoi(idStr)
-	if err != nil {
-		return nil
-	}
-	return &proclassic.SiteObject{ID: &id}
 }

--- a/internal/resources/pro/users/class/input_builders_test.go
+++ b/internal/resources/pro/users/class/input_builders_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/common/scope"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
@@ -143,10 +144,10 @@ func TestBuildInput_NonIntegerGroupID(t *testing.T) {
 }
 
 func TestBuildSiteObject_NoneSentinel(t *testing.T) {
-	if got := buildSiteObject(types.StringValue("-1")); got == nil || got.ID == nil || *got.ID != -1 {
+	if got := scope.BuildSiteObject(types.StringValue("-1")); got == nil || got.ID == nil || *got.ID != -1 {
 		t.Errorf("expected site id -1, got %v", got)
 	}
-	if got := buildSiteObject(types.StringNull()); got != nil {
+	if got := scope.BuildSiteObject(types.StringNull()); got != nil {
 		t.Errorf("null site_id should produce nil SiteObject, got %v", got)
 	}
 }

--- a/internal/resources/pro/users/class/state_builders.go
+++ b/internal/resources/pro/users/class/state_builders.go
@@ -5,13 +5,13 @@ package class
 
 import (
 	"context"
-	"strconv"
 
 	"github.com/Jamf-Concepts/jamfplatform-go-sdk/jamfplatform/proclassic"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
 	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/common/helpers"
+	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/common/scope"
 )
 
 // assignClassResourceModel populates a resource model from a Class response.
@@ -31,7 +31,7 @@ func assignClassResourceModel(ctx context.Context, state *ClassResourceModel, c 
 	state.Description = helpers.ReconcileOptionalStringPointer(c.Description, state.Description)
 	state.Source = helpers.StringPointerValueOrNull(c.Source)
 
-	siteID, siteName := flattenSite(c.Site)
+	siteID, siteName := scope.FlattenSiteObject(c.Site)
 	state.SiteID = helpers.ReconcileOptionalStringPointer(siteID, state.SiteID)
 	state.SiteName = helpers.StringPointerValueOrNull(siteName)
 
@@ -71,7 +71,7 @@ func assignClassDataSourceModel(ctx context.Context, state *ClassDataSourceModel
 	state.Description = helpers.StringPointerValueOrNull(c.Description)
 	state.Source = helpers.StringPointerValueOrNull(c.Source)
 
-	siteID, siteName := flattenSite(c.Site)
+	siteID, siteName := scope.FlattenSiteObject(c.Site)
 	state.SiteID = helpers.StringPointerValueOrNull(siteID)
 	state.SiteName = helpers.StringPointerValueOrNull(siteName)
 
@@ -100,20 +100,6 @@ func stringSetOrNull(ctx context.Context, values []string) (types.Set, diag.Diag
 		return types.SetNull(types.StringType), nil
 	}
 	return types.SetValueFrom(ctx, types.StringType, values)
-}
-
-// flattenSite returns (id-as-string, name) pointers from a SiteObject. Returns
-// (nil, nil) when site is absent.
-func flattenSite(site *proclassic.SiteObject) (*string, *string) {
-	if site == nil {
-		return nil, nil
-	}
-	var idPtr *string
-	if site.ID != nil {
-		s := strconv.Itoa(*site.ID)
-		idPtr = &s
-	}
-	return idPtr, site.Name
 }
 
 // --- inner-collection accessors (nil-safe) ---

--- a/internal/resources/pro/users/user_group/dsgroup_acceptance_test.go
+++ b/internal/resources/pro/users/user_group/dsgroup_acceptance_test.go
@@ -6,18 +6,13 @@
 package user_group_test
 
 import (
-	"context"
 	"fmt"
 	"os"
-	"strconv"
 	"testing"
 
-	"github.com/Jamf-Concepts/jamfplatform-go-sdk/jamfplatform/pro"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 
-	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/common/criteria"
-	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/common/ldapgroups"
 	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/testhelpers"
 )
 
@@ -26,29 +21,9 @@ import (
 // own-model path (to/fromCriterionModels converters + member_count restore on a
 // representation swap). The user surface accepts only the Username criterion.
 const (
-	envDSGroupGate  = "JAMFPLATFORM_ACC_CRITERIA_DS_GROUP"
-	envDSGroupName  = "JAMFPLATFORM_ACC_CRITERIA_DS_GROUP_NAME"
-	envDSGroupValue = "JAMFPLATFORM_ACC_CRITERIA_DS_GROUP_VALUE" // optional independent oracle
+	envDSGroupGate = "JAMFPLATFORM_ACC_CRITERIA_DS_GROUP"
+	envDSGroupName = "JAMFPLATFORM_ACC_CRITERIA_DS_GROUP_NAME"
 )
-
-func resolveDSGroupWireValue(t *testing.T, name string) string {
-	t.Helper()
-	groups, err := ldapgroups.ResolveByName(context.Background(), pro.New(testhelpers.NewAcceptanceClient(t)), name)
-	if err != nil {
-		t.Fatalf("resolving %q: %v", name, err)
-	}
-	if len(groups) != 1 {
-		t.Fatalf("group %q must resolve to exactly one directory group (got %d) — pick an unambiguous name", name, len(groups))
-	}
-	if groups[0].UUID == "" {
-		t.Fatalf("group %q resolved with no uuid mapping", name)
-	}
-	wire := criteria.EncodeDSGroupValue(groups[0].UUID, strconv.Itoa(groups[0].LdapServerID))
-	if want := os.Getenv(envDSGroupValue); want != "" && wire != want {
-		t.Fatalf("provider resolved %q to %q, but %s=%q — name/value mismatch or an encoding bug", name, wire, envDSGroupValue, want)
-	}
-	return wire
-}
 
 // TestAccResource_ProUserGroup_DSGroupCriteria mirrors the search tests on the
 // classic user-group surface (smart group, Username criterion only).
@@ -61,7 +36,7 @@ func TestAccResource_ProUserGroup_DSGroupCriteria(t *testing.T) {
 		t.Skipf("%s must be set", envDSGroupName)
 	}
 	testhelpers.AccPreCheck(t)
-	groupValue := resolveDSGroupWireValue(t, groupName)
+	groupValue := testhelpers.ResolveDSGroupWireValue(t, groupName)
 
 	suffix := testhelpers.RunSuffix()
 	name := "tf-acc-ug-dsgroup-" + suffix

--- a/internal/resources/pro/users/user_group/input_builders.go
+++ b/internal/resources/pro/users/user_group/input_builders.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
 	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/common/helpers"
+	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/common/scope"
 )
 
 // buildUserGroupInput converts a plan model into the SDK UserGroup payload used
@@ -30,7 +31,7 @@ func buildUserGroupInput(ctx context.Context, plan UserGroupResourceModel) (*pro
 		Name:             helpers.OptionalStringPointer(plan.Name),
 		IsSmart:          &isSmart,
 		IsNotifyOnChange: plan.NotifyOnMembershipChange.ValueBoolPointer(),
-		Site:             buildSiteObject(plan.SiteID),
+		Site:             scope.BuildSiteObject(plan.SiteID),
 	}
 
 	if isSmart {
@@ -45,26 +46,6 @@ func buildUserGroupInput(ctx context.Context, plan UserGroupResourceModel) (*pro
 	}
 
 	return ug, diags
-}
-
-// buildSiteObject converts the plan site_id into the SDK SiteObject. site_id
-// is Optional+Computed with a static default of "-1"; we always send a
-// non-nil Site so the wire payload is explicit about NONE assignment unless
-// the value is Unknown (during initial Create with no default applied yet,
-// which the framework default avoids in practice).
-func buildSiteObject(siteID types.String) *proclassic.SiteObject {
-	if siteID.IsNull() || siteID.IsUnknown() {
-		return nil
-	}
-	idStr := siteID.ValueString()
-	if idStr == "" {
-		return nil
-	}
-	id, err := strconv.Atoi(idStr)
-	if err != nil {
-		return nil
-	}
-	return &proclassic.SiteObject{ID: &id}
 }
 
 // buildCriteriaWrapper expands the plan criteria slice into the SDK's wrapper

--- a/internal/resources/pro/users/user_group/state_builders.go
+++ b/internal/resources/pro/users/user_group/state_builders.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
 	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/common/helpers"
+	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/common/scope"
 )
 
 // assignUserGroupResourceModel populates a resource model from a UserGroup
@@ -45,7 +46,7 @@ func assignUserGroupResourceModel(
 	// returned the value.
 	state.NotifyOnMembershipChange = helpers.BoolPointerValueOrNull(ug.IsNotifyOnChange)
 
-	siteID, siteName := flattenSite(ug.Site)
+	siteID, siteName := scope.FlattenSiteObject(ug.Site)
 	state.SiteID = helpers.ReconcileOptionalStringPointer(siteID, state.SiteID)
 	state.SiteName = helpers.StringPointerValueOrNull(siteName)
 
@@ -95,7 +96,7 @@ func assignUserGroupDataSourceModel(state *UserGroupDataSourceModel, ug *proclas
 	state.GroupType = groupTypeFromIsSmart(ug.IsSmart)
 	state.NotifyOnMembershipChange = helpers.BoolPointerValueOrNull(ug.IsNotifyOnChange)
 
-	siteID, siteName := flattenSite(ug.Site)
+	siteID, siteName := scope.FlattenSiteObject(ug.Site)
 	state.SiteID = helpers.StringPointerValueOrNull(siteID)
 	state.SiteName = helpers.StringPointerValueOrNull(siteName)
 
@@ -115,20 +116,6 @@ func groupTypeFromIsSmart(isSmart *bool) types.String {
 		return types.StringValue("smart")
 	}
 	return types.StringValue("static")
-}
-
-// flattenSite returns (id-as-string, name) pointers from a SiteObject.
-// Returns (nil, nil) when site is absent.
-func flattenSite(site *proclassic.SiteObject) (*string, *string) {
-	if site == nil {
-		return nil, nil
-	}
-	var idPtr *string
-	if site.ID != nil {
-		s := strconv.Itoa(*site.ID)
-		idPtr = &s
-	}
-	return idPtr, site.Name
 }
 
 // flattenCriteria converts the SDK criteria wrapper into the Terraform model

--- a/internal/resources/pro/users/user_group/state_builders_test.go
+++ b/internal/resources/pro/users/user_group/state_builders_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/Jamf-Concepts/jamfplatform-go-sdk/jamfplatform/proclassic"
+	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/common/scope"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
@@ -132,11 +133,11 @@ func TestGroupTypeFromIsSmart(t *testing.T) {
 }
 
 func TestFlattenSite(t *testing.T) {
-	id, name := flattenSite(&proclassic.SiteObject{ID: new(5), Name: new("Site5")})
+	id, name := scope.FlattenSiteObject(&proclassic.SiteObject{ID: new(5), Name: new("Site5")})
 	if id == nil || *id != "5" || name == nil || *name != "Site5" {
 		t.Errorf("unexpected: id=%v name=%v", id, name)
 	}
-	id, name = flattenSite(nil)
+	id, name = scope.FlattenSiteObject(nil)
 	if id != nil || name != nil {
 		t.Errorf("nil site must yield (nil, nil)")
 	}

--- a/internal/resources/pro/volume_purchasing/vpp_assignment/state_builders.go
+++ b/internal/resources/pro/volume_purchasing/vpp_assignment/state_builders.go
@@ -83,17 +83,17 @@ func assignVPPAssignmentDataSourceModel(ctx context.Context, state *VPPAssignmen
 func flattenScope(ctx context.Context, s *proclassic.VppAssignmentScope, state *scope.UserScopeModel) {
 	if state.Targets != nil {
 		state.Targets.AllJssUsers = helpers.BoolPointerValueOrNull(s.AllJssUsers)
-		state.Targets.JssUserIDs = flattenIDNameSet(ctx, jssUsersSlice(s.JssUsers))
-		state.Targets.JssUserGroupIDs = flattenIDNameSet(ctx, jssUserGroupsSlice(s.JssUserGroups))
+		state.Targets.JssUserIDs = scope.FlattenIDNameSet(ctx, jssUsersSlice(s.JssUsers))
+		state.Targets.JssUserGroupIDs = scope.FlattenIDNameSet(ctx, jssUserGroupsSlice(s.JssUserGroups))
 	}
 
 	if state.Limitations != nil {
-		state.Limitations.DirectoryServiceUserGroupNames = flattenNameSet(ctx, limitationsUserGroupsSlice(s.Limitations))
+		state.Limitations.DirectoryServiceUserGroupNames = scope.FlattenNameSet(ctx, limitationsUserGroupsSlice(s.Limitations))
 	}
 	if state.Exclusions != nil && s.Exclusions != nil {
 		e := s.Exclusions
-		state.Exclusions.JssUserIDs = flattenIDNameSet(ctx, exclJssUsersSlice(e.JssUsers))
-		state.Exclusions.JssUserGroupIDs = flattenIDNameSet(ctx, exclJssUserGroupsSlice(e.JssUserGroups))
+		state.Exclusions.JssUserIDs = scope.FlattenIDNameSet(ctx, exclJssUsersSlice(e.JssUsers))
+		state.Exclusions.JssUserGroupIDs = scope.FlattenIDNameSet(ctx, exclJssUserGroupsSlice(e.JssUserGroups))
 		state.Exclusions.DirectoryServiceUserGroupNames = flattenExclDSGroupSet(ctx, exclDSGroupsSlice(e.UserGroups))
 	}
 }
@@ -254,16 +254,6 @@ func exclDSGroupsSlice(g *proclassic.VppAssignmentScopeExclusionsUserGroups) *[]
 }
 
 // ---- scope set flatteners ------------------------------------------------------
-
-func flattenIDNameSet(ctx context.Context, items *[]proclassic.IDName) types.Set {
-	out, _ := scope.FlattenIDSlice(ctx, items, func(i proclassic.IDName) *int { return i.ID })
-	return out
-}
-
-func flattenNameSet(ctx context.Context, items *[]proclassic.IDName) types.Set {
-	out, _ := scope.FlattenNameSlice(ctx, items, func(i proclassic.IDName) *string { return i.Name })
-	return out
-}
 
 func flattenExclDSGroupSet(ctx context.Context, items *[]proclassic.VppAssignmentScopeExclusionsUserGroupsUserGroupItem) types.Set {
 	out, _ := scope.FlattenNameSlice(ctx, items, func(i proclassic.VppAssignmentScopeExclusionsUserGroupsUserGroupItem) *string { return i.Name })

--- a/internal/resources/pro/volume_purchasing/vpp_invitation/state_builders.go
+++ b/internal/resources/pro/volume_purchasing/vpp_invitation/state_builders.go
@@ -80,17 +80,17 @@ func assignVPPInvitationDataSourceModel(ctx context.Context, state *VPPInvitatio
 func flattenScope(ctx context.Context, s *proclassic.VppInvitationScope, state *scope.UserScopeModel) {
 	if state.Targets != nil {
 		state.Targets.AllJssUsers = helpers.BoolPointerValueOrNull(s.AllJssUsers)
-		state.Targets.JssUserIDs = flattenIDNameSet(ctx, jssUsersSlice(s.JssUsers))
-		state.Targets.JssUserGroupIDs = flattenIDNameSet(ctx, jssUserGroupsSlice(s.JssUserGroups))
+		state.Targets.JssUserIDs = scope.FlattenIDNameSet(ctx, jssUsersSlice(s.JssUsers))
+		state.Targets.JssUserGroupIDs = scope.FlattenIDNameSet(ctx, jssUserGroupsSlice(s.JssUserGroups))
 	}
 
 	if state.Limitations != nil {
-		state.Limitations.DirectoryServiceUserGroupNames = flattenNameSet(ctx, limitationsUserGroupsSlice(s.Limitations))
+		state.Limitations.DirectoryServiceUserGroupNames = scope.FlattenNameSet(ctx, limitationsUserGroupsSlice(s.Limitations))
 	}
 	if state.Exclusions != nil && s.Exclusions != nil {
 		e := s.Exclusions
-		state.Exclusions.JssUserIDs = flattenIDNameSet(ctx, exclJssUsersSlice(e.JssUsers))
-		state.Exclusions.JssUserGroupIDs = flattenIDNameSet(ctx, exclJssUserGroupsSlice(e.JssUserGroups))
+		state.Exclusions.JssUserIDs = scope.FlattenIDNameSet(ctx, exclJssUsersSlice(e.JssUsers))
+		state.Exclusions.JssUserGroupIDs = scope.FlattenIDNameSet(ctx, exclJssUserGroupsSlice(e.JssUserGroups))
 		state.Exclusions.DirectoryServiceUserGroupNames = flattenExclDSGroupSet(ctx, exclDSGroupsSlice(e.UserGroups))
 	}
 }
@@ -140,16 +140,6 @@ func exclDSGroupsSlice(g *proclassic.VppInvitationScopeExclusionsUserGroups) *[]
 }
 
 // ---- set flatteners ------------------------------------------------------------
-
-func flattenIDNameSet(ctx context.Context, items *[]proclassic.IDName) types.Set {
-	out, _ := scope.FlattenIDSlice(ctx, items, func(i proclassic.IDName) *int { return i.ID })
-	return out
-}
-
-func flattenNameSet(ctx context.Context, items *[]proclassic.IDName) types.Set {
-	out, _ := scope.FlattenNameSlice(ctx, items, func(i proclassic.IDName) *string { return i.Name })
-	return out
-}
 
 func flattenExclDSGroupSet(ctx context.Context, items *[]proclassic.VppInvitationScopeExclusionsUserGroupsUserGroupItem) types.Set {
 	out, _ := scope.FlattenNameSlice(ctx, items, func(i proclassic.VppInvitationScopeExclusionsUserGroupsUserGroupItem) *string { return i.Name })

--- a/internal/testhelpers/acceptance_assertions.go
+++ b/internal/testhelpers/acceptance_assertions.go
@@ -47,7 +47,7 @@ func RequireSingletonStillExists(t *testing.T, label string, get func(context.Co
 		if got == nil {
 			return fmt.Errorf("expected non-nil %s record post-destroy", label)
 		}
-		if rv := reflect.ValueOf(got); rv.Kind() == reflect.Ptr && rv.IsNil() {
+		if rv := reflect.ValueOf(got); rv.Kind() == reflect.Pointer && rv.IsNil() {
 			return fmt.Errorf("expected non-nil %s record post-destroy", label)
 		}
 		return nil

--- a/internal/testhelpers/acceptance_assertions.go
+++ b/internal/testhelpers/acceptance_assertions.go
@@ -1,0 +1,78 @@
+// Copyright Jamf Software LLC 2026
+// SPDX-License-Identifier: MPL-2.0
+
+//go:build acceptance
+
+package testhelpers
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"reflect"
+	"strconv"
+	"testing"
+
+	"github.com/Jamf-Concepts/jamfplatform-go-sdk/jamfplatform/pro"
+	"github.com/Jamf-Concepts/jamfplatform-go-sdk/jamfplatform/proclassic"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+
+	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/common/criteria"
+	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/common/ldapgroups"
+)
+
+// envDSGroupValue is the optional acceptance oracle: when set, ResolveDSGroupWireValue
+// cross-checks the provider's encoded directory-service group value against it.
+const envDSGroupValue = "JAMFPLATFORM_ACC_CRITERIA_DS_GROUP_VALUE"
+
+// NewProClassicClient builds a ProClassic SDK client from the acceptance client.
+func NewProClassicClient(t *testing.T) *proclassic.Client {
+	t.Helper()
+	return proclassic.New(NewAcceptanceClient(t))
+}
+
+// RequireSingletonStillExists returns a CheckDestroy that asserts a Pro singleton
+// record still exists on the tenant after Terraform destroy — the convention for
+// update-only singleton resources whose Delete is a no-op. label names the record
+// in failure messages; get performs the resource-specific SDK read. A nil record
+// (including a typed-nil pointer) or a read error fails the check.
+func RequireSingletonStillExists(t *testing.T, label string, get func(context.Context) (any, error)) resource.TestCheckFunc {
+	t.Helper()
+	return func(_ *terraform.State) error {
+		got, err := get(context.Background())
+		if err != nil {
+			return fmt.Errorf("expected %s record to persist on tenant after destroy, got error: %w", label, err)
+		}
+		if got == nil {
+			return fmt.Errorf("expected non-nil %s record post-destroy", label)
+		}
+		if rv := reflect.ValueOf(got); rv.Kind() == reflect.Ptr && rv.IsNil() {
+			return fmt.Errorf("expected non-nil %s record post-destroy", label)
+		}
+		return nil
+	}
+}
+
+// ResolveDSGroupWireValue resolves a directory-service group by name to its encoded
+// wire value (uuid + ldap server id). Fails the test unless the name resolves to
+// exactly one group with a uuid mapping. When envDSGroupValue is set, the resolved
+// value is cross-checked against it as an independent oracle.
+func ResolveDSGroupWireValue(t *testing.T, name string) string {
+	t.Helper()
+	groups, err := ldapgroups.ResolveByName(context.Background(), pro.New(NewAcceptanceClient(t)), name)
+	if err != nil {
+		t.Fatalf("resolving %q: %v", name, err)
+	}
+	if len(groups) != 1 {
+		t.Fatalf("group %q must resolve to exactly one directory group (got %d) — pick an unambiguous name", name, len(groups))
+	}
+	if groups[0].UUID == "" {
+		t.Fatalf("group %q resolved with no uuid mapping", name)
+	}
+	wire := criteria.EncodeDSGroupValue(groups[0].UUID, strconv.Itoa(groups[0].LdapServerID))
+	if want := os.Getenv(envDSGroupValue); want != "" && wire != want {
+		t.Fatalf("provider resolved %q to %q, but %s=%q — name/value mismatch or an encoding bug", name, wire, envDSGroupValue, want)
+	}
+	return wire
+}


### PR DESCRIPTION
## What

Phase 10 **Helper Consolidation** audit — tier 2 of 3. Promotes the four byte-identical, `proclassic`-typed flatten/build wrappers into `internal/common/scope`, migrates call sites, deletes local copies.

These take `proclassic.*` types, so they belong in `common/scope` (which owns the generic `FlattenIDSlice`/`BuildIDSlice` they wrap) — **not** `common/helpers`, which must stay free of the SDK `proclassic` subpackage import.

| New export | Replaces | Sites |
|---|---|---|
| `FlattenIDNameSet` | `flattenIDNameSet` | 8 |
| `FlattenNameSet` | `flattenNameSet` | 7 |
| `FlattenSiteObject` | `flattenSite` | 4 |
| `BuildSiteObject` | `buildSiteObject` | 4 |

**Pure dedup — no behaviour change.** Net **−322 / +122** across 20 files.

## Notes

- `bigInt`/`bigIntStringOrNull` (2 sites) intentionally **not** promoted — below the dedup threshold.
- Resource-pinned wrappers (`*Slice` accessors, `flattenExcl*Set`, `flatten/buildGeneral`, `flattenDisplayFields`) stay local — incompatible SDK types / resource-specific shapes.

## Stacking

Based on `chore/helper-consolidation-scalars` (tier 1, #242). Retarget to `feat/pro-expansion` once tier 1 merges.

## Verify

`make fmt lint test` clean; `go build`/`go vet` clean; all unit-test packages pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)