### PR TITLE
chore(testhelpers): consolidate duplicated acceptance test helpers (Phase 10, tier 3)

### DIFF
--- a/internal/resources/pro/configuration_profiles/macos_configuration_profile/resource_acceptance_test.go
+++ b/internal/resources/pro/configuration_profiles/macos_configuration_profile/resource_acceptance_test.go
@@ -213,17 +213,9 @@ resource "jamfplatform_pro_macos_configuration_profile" "test" {
 `, name, payload, jssUserID)
 }
 
-// newSDKClient returns a ProClassic SDK client wired to the acceptance-test
-// credentials. Used for setting up + tearing down fixture computers/users
-// the scope tests reference by classic ID.
-func newSDKClient(t *testing.T) *proclassic.Client {
-	t.Helper()
-	return proclassic.New(testhelpers.NewAcceptanceClient(t))
-}
-
 func createDummyComputer(t *testing.T, name string) string {
 	t.Helper()
-	c := newSDKClient(t)
+	c := testhelpers.NewProClassicClient(t)
 	ctx := context.Background()
 	if err := c.CreateComputerByID(ctx, "0", &proclassic.ComputerPost{
 		General: &proclassic.ComputerPostGeneral{Name: &name},
@@ -245,7 +237,7 @@ func createDummyComputer(t *testing.T, name string) string {
 
 func createDummyUser(t *testing.T, name string) string {
 	t.Helper()
-	c := newSDKClient(t)
+	c := testhelpers.NewProClassicClient(t)
 	ctx := context.Background()
 	got, err := c.CreateUserByID(ctx, "0", &proclassic.UserPost{Name: &name})
 	if err != nil || got == nil || got.ID == nil {
@@ -632,7 +624,7 @@ func TestAccResource_MacOSConfigurationProfile_ImportState(t *testing.T) {
 // survive the round-trip and surface as drift on the next plan.
 func mutatePPPCProfileChangeIdentifier(t *testing.T, profileID, newIdentifierValue string) {
 	t.Helper()
-	c := newSDKClient(t)
+	c := testhelpers.NewProClassicClient(t)
 	ctx := context.Background()
 
 	got, err := c.GetOSXConfigurationProfileByID(ctx, profileID)
@@ -785,7 +777,7 @@ func TestAccResource_MacOSConfigurationProfile_AdminUIEdit_SurfacesAsDrift(t *te
 // trip when the entry dict is well-formed.
 func mutatePPPCProfileAddValidService(t *testing.T, profileID, serviceKey string) {
 	t.Helper()
-	c := newSDKClient(t)
+	c := testhelpers.NewProClassicClient(t)
 	ctx := context.Background()
 
 	got, err := c.GetOSXConfigurationProfileByID(ctx, profileID)
@@ -827,7 +819,7 @@ func mutatePPPCProfileAddValidService(t *testing.T, profileID, serviceKey string
 // from PayloadContent[0].Services.
 func mutatePPPCProfileRemoveFirstService(t *testing.T, profileID string) {
 	t.Helper()
-	c := newSDKClient(t)
+	c := testhelpers.NewProClassicClient(t)
 	ctx := context.Background()
 
 	got, err := c.GetOSXConfigurationProfileByID(ctx, profileID)

--- a/internal/resources/pro/configuration_profiles/mobile_device_configuration_profile/resource_acceptance_test.go
+++ b/internal/resources/pro/configuration_profiles/mobile_device_configuration_profile/resource_acceptance_test.go
@@ -93,14 +93,9 @@ func freshPayload(t *testing.T, fixture string) string {
 
 // ── SDK helpers ───────────────────────────────────────────────────────────────
 
-func newSDKClient(t *testing.T) *proclassic.Client {
-	t.Helper()
-	return proclassic.New(testhelpers.NewAcceptanceClient(t))
-}
-
 func checkDestroy(t *testing.T) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		c := newSDKClient(t)
+		c := testhelpers.NewProClassicClient(t)
 		ctx := context.Background()
 		for _, rs := range s.RootModule().Resources {
 			if rs.Type != "jamfplatform_pro_mobile_device_configuration_profile" {
@@ -121,7 +116,7 @@ func checkDestroy(t *testing.T) resource.TestCheckFunc {
 
 func createDummyUser(t *testing.T, name string) string {
 	t.Helper()
-	c := newSDKClient(t)
+	c := testhelpers.NewProClassicClient(t)
 	ctx := context.Background()
 	got, err := c.CreateUserByID(ctx, "0", &proclassic.UserPost{Name: &name})
 	if err != nil || got == nil || got.ID == nil {
@@ -138,7 +133,7 @@ func createDummyUser(t *testing.T, name string) string {
 
 func createDummyMobileDeviceGroup(t *testing.T, name string) string {
 	t.Helper()
-	c := newSDKClient(t)
+	c := testhelpers.NewProClassicClient(t)
 	ctx := context.Background()
 	isSmart := false
 	got, err := c.CreateMobileDeviceGroupByID(ctx, "0", &proclassic.MobileDeviceGroup{

--- a/internal/resources/pro/policies/policy/resource_acceptance_test.go
+++ b/internal/resources/pro/policies/policy/resource_acceptance_test.go
@@ -30,16 +30,6 @@ import (
 	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/testhelpers"
 )
 
-// newSDKClient returns a real ProClassic SDK client wired to the same
-// acceptance-test credentials the provider factory uses. Used for setup +
-// teardown of fixture records (computer, user) that the project does not yet
-// expose as Terraform resources but the policy resource's scope sub-blocks
-// reference by classic ID.
-func newSDKClient(t *testing.T) *proclassic.Client {
-	t.Helper()
-	return proclassic.New(testhelpers.NewAcceptanceClient(t))
-}
-
 // createDummyComputer creates a minimal classic computer record via the SDK
 // and returns its server-assigned ID as a string. Cleanup runs at test end
 // via t.Cleanup.
@@ -49,7 +39,7 @@ func newSDKClient(t *testing.T) *proclassic.Client {
 // by name to discover the assigned ID.
 func createDummyComputer(t *testing.T, name string) string {
 	t.Helper()
-	c := newSDKClient(t)
+	c := testhelpers.NewProClassicClient(t)
 	ctx := context.Background()
 	if err := c.CreateComputerByID(ctx, "0", &proclassic.ComputerPost{
 		General: &proclassic.ComputerPostGeneral{Name: &name},
@@ -74,7 +64,7 @@ func createDummyComputer(t *testing.T, name string) string {
 // t.Cleanup.
 func createDummyUser(t *testing.T, name string) string {
 	t.Helper()
-	c := newSDKClient(t)
+	c := testhelpers.NewProClassicClient(t)
 	ctx := context.Background()
 	got, err := c.CreateUserByID(ctx, "0", &proclassic.UserPost{Name: &name})
 	if err != nil || got == nil || got.ID == nil {

--- a/internal/resources/pro/searches/advanced_computer_search/dsgroup_acceptance_test.go
+++ b/internal/resources/pro/searches/advanced_computer_search/dsgroup_acceptance_test.go
@@ -6,18 +6,13 @@
 package advanced_computer_search_test
 
 import (
-	"context"
 	"fmt"
 	"os"
-	"strconv"
 	"testing"
 
-	"github.com/Jamf-Concepts/jamfplatform-go-sdk/jamfplatform/pro"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 
-	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/common/criteria"
-	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/common/ldapgroups"
 	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/testhelpers"
 )
 
@@ -28,32 +23,9 @@ import (
 // the real wire base64 as an independent encoding oracle. Real group names are
 // never committed — see memory: no real LDAP names in public files.
 const (
-	envDSGroupGate  = "JAMFPLATFORM_ACC_CRITERIA_DS_GROUP"
-	envDSGroupName  = "JAMFPLATFORM_ACC_CRITERIA_DS_GROUP_NAME"
-	envDSGroupValue = "JAMFPLATFORM_ACC_CRITERIA_DS_GROUP_VALUE" // optional independent oracle
+	envDSGroupGate = "JAMFPLATFORM_ACC_CRITERIA_DS_GROUP"
+	envDSGroupName = "JAMFPLATFORM_ACC_CRITERIA_DS_GROUP_NAME"
 )
-
-// resolveDSGroupWireValue resolves a directory-service group by name exactly as
-// the provider does and returns the base64 {uuid,serverId} wire value, honouring
-// the optional _VALUE oracle. Fails loudly on an ambiguous / unmapped name.
-func resolveDSGroupWireValue(t *testing.T, name string) string {
-	t.Helper()
-	groups, err := ldapgroups.ResolveByName(context.Background(), pro.New(testhelpers.NewAcceptanceClient(t)), name)
-	if err != nil {
-		t.Fatalf("resolving %q: %v", name, err)
-	}
-	if len(groups) != 1 {
-		t.Fatalf("group %q must resolve to exactly one directory group (got %d) — pick an unambiguous name", name, len(groups))
-	}
-	if groups[0].UUID == "" {
-		t.Fatalf("group %q resolved with no uuid mapping", name)
-	}
-	wire := criteria.EncodeDSGroupValue(groups[0].UUID, strconv.Itoa(groups[0].LdapServerID))
-	if want := os.Getenv(envDSGroupValue); want != "" && wire != want {
-		t.Fatalf("provider resolved %q to %q, but %s=%q — name/value mismatch or an encoding bug", name, wire, envDSGroupValue, want)
-	}
-	return wire
-}
 
 // TestAccResource_ACS_DSGroupCriteria authors a directory-service group criterion
 // by NAME, asserts state round-trips back to the NAME, and asserts swapping the
@@ -68,7 +40,7 @@ func TestAccResource_ACS_DSGroupCriteria(t *testing.T) {
 		t.Skipf("%s must be set", envDSGroupName)
 	}
 	testhelpers.AccPreCheck(t)
-	groupValue := resolveDSGroupWireValue(t, groupName)
+	groupValue := testhelpers.ResolveDSGroupWireValue(t, groupName)
 
 	suffix := testhelpers.RunSuffix()
 	name := "tf-acc-acs-dsgroup-" + suffix

--- a/internal/resources/pro/searches/advanced_mobile_device_search/dsgroup_acceptance_test.go
+++ b/internal/resources/pro/searches/advanced_mobile_device_search/dsgroup_acceptance_test.go
@@ -6,18 +6,13 @@
 package advanced_mobile_device_search_test
 
 import (
-	"context"
 	"fmt"
 	"os"
-	"strconv"
 	"testing"
 
-	"github.com/Jamf-Concepts/jamfplatform-go-sdk/jamfplatform/pro"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 
-	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/common/criteria"
-	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/common/ldapgroups"
 	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/testhelpers"
 )
 
@@ -27,29 +22,9 @@ import (
 // readback / suppress paths bridge types.List <-> []CriterionModel — exercise
 // that round-trip end to end. See the computer-search counterpart for rationale.
 const (
-	envDSGroupGate  = "JAMFPLATFORM_ACC_CRITERIA_DS_GROUP"
-	envDSGroupName  = "JAMFPLATFORM_ACC_CRITERIA_DS_GROUP_NAME"
-	envDSGroupValue = "JAMFPLATFORM_ACC_CRITERIA_DS_GROUP_VALUE" // optional independent oracle
+	envDSGroupGate = "JAMFPLATFORM_ACC_CRITERIA_DS_GROUP"
+	envDSGroupName = "JAMFPLATFORM_ACC_CRITERIA_DS_GROUP_NAME"
 )
-
-func resolveDSGroupWireValue(t *testing.T, name string) string {
-	t.Helper()
-	groups, err := ldapgroups.ResolveByName(context.Background(), pro.New(testhelpers.NewAcceptanceClient(t)), name)
-	if err != nil {
-		t.Fatalf("resolving %q: %v", name, err)
-	}
-	if len(groups) != 1 {
-		t.Fatalf("group %q must resolve to exactly one directory group (got %d) — pick an unambiguous name", name, len(groups))
-	}
-	if groups[0].UUID == "" {
-		t.Fatalf("group %q resolved with no uuid mapping", name)
-	}
-	wire := criteria.EncodeDSGroupValue(groups[0].UUID, strconv.Itoa(groups[0].LdapServerID))
-	if want := os.Getenv(envDSGroupValue); want != "" && wire != want {
-		t.Fatalf("provider resolved %q to %q, but %s=%q — name/value mismatch or an encoding bug", name, wire, envDSGroupValue, want)
-	}
-	return wire
-}
 
 // TestAccResource_AMDS_DSGroupCriteria mirrors the computer-search test on the
 // mobile (Pro v1, types.List) surface.
@@ -62,7 +37,7 @@ func TestAccResource_AMDS_DSGroupCriteria(t *testing.T) {
 		t.Skipf("%s must be set", envDSGroupName)
 	}
 	testhelpers.AccPreCheck(t)
-	groupValue := resolveDSGroupWireValue(t, groupName)
+	groupValue := testhelpers.ResolveDSGroupWireValue(t, groupName)
 
 	suffix := testhelpers.RunSuffix()
 	name := "tf-acc-amds-dsgroup-" + suffix

--- a/internal/resources/pro/searches/advanced_user_search/dsgroup_acceptance_test.go
+++ b/internal/resources/pro/searches/advanced_user_search/dsgroup_acceptance_test.go
@@ -6,18 +6,13 @@
 package advanced_user_search_test
 
 import (
-	"context"
 	"fmt"
 	"os"
-	"strconv"
 	"testing"
 
-	"github.com/Jamf-Concepts/jamfplatform-go-sdk/jamfplatform/pro"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 
-	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/common/criteria"
-	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/common/ldapgroups"
 	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/testhelpers"
 )
 
@@ -26,29 +21,9 @@ import (
 // name). The user surface accepts only the Username directory-service group
 // criterion. See the computer-search counterpart for the full rationale.
 const (
-	envDSGroupGate  = "JAMFPLATFORM_ACC_CRITERIA_DS_GROUP"
-	envDSGroupName  = "JAMFPLATFORM_ACC_CRITERIA_DS_GROUP_NAME"
-	envDSGroupValue = "JAMFPLATFORM_ACC_CRITERIA_DS_GROUP_VALUE" // optional independent oracle
+	envDSGroupGate = "JAMFPLATFORM_ACC_CRITERIA_DS_GROUP"
+	envDSGroupName = "JAMFPLATFORM_ACC_CRITERIA_DS_GROUP_NAME"
 )
-
-func resolveDSGroupWireValue(t *testing.T, name string) string {
-	t.Helper()
-	groups, err := ldapgroups.ResolveByName(context.Background(), pro.New(testhelpers.NewAcceptanceClient(t)), name)
-	if err != nil {
-		t.Fatalf("resolving %q: %v", name, err)
-	}
-	if len(groups) != 1 {
-		t.Fatalf("group %q must resolve to exactly one directory group (got %d) — pick an unambiguous name", name, len(groups))
-	}
-	if groups[0].UUID == "" {
-		t.Fatalf("group %q resolved with no uuid mapping", name)
-	}
-	wire := criteria.EncodeDSGroupValue(groups[0].UUID, strconv.Itoa(groups[0].LdapServerID))
-	if want := os.Getenv(envDSGroupValue); want != "" && wire != want {
-		t.Fatalf("provider resolved %q to %q, but %s=%q — name/value mismatch or an encoding bug", name, wire, envDSGroupValue, want)
-	}
-	return wire
-}
 
 // TestAccResource_AUS_DSGroupCriteria mirrors the computer-search test on the
 // user surface (Username criterion only).
@@ -61,7 +36,7 @@ func TestAccResource_AUS_DSGroupCriteria(t *testing.T) {
 		t.Skipf("%s must be set", envDSGroupName)
 	}
 	testhelpers.AccPreCheck(t)
-	groupValue := resolveDSGroupWireValue(t, groupName)
+	groupValue := testhelpers.ResolveDSGroupWireValue(t, groupName)
 
 	suffix := testhelpers.RunSuffix()
 	name := "tf-acc-aus-dsgroup-" + suffix

--- a/internal/resources/pro/settings/access_management_settings/resource_acceptance_test.go
+++ b/internal/resources/pro/settings/access_management_settings/resource_acceptance_test.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/Jamf-Concepts/jamfplatform-go-sdk/jamfplatform/pro"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
 	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/testhelpers"
 )
@@ -44,17 +43,9 @@ func adeFixture(name, token string, woVersion int) string {
 // on the tenant after Terraform destroys the resources from state. The remote Delete is a
 // no-op, so the API must still return the record post-destroy.
 func checkSingletonRecordStillExists(t *testing.T) resource.TestCheckFunc {
-	return func(_ *terraform.State) error {
-		c := pro.New(testhelpers.NewAcceptanceClient(t))
-		got, err := c.GetEnrollmentAccessManagementV4(context.Background())
-		if err != nil {
-			return fmt.Errorf("expected Access Management settings record to persist on tenant after destroy, got error: %w", err)
-		}
-		if got == nil {
-			return fmt.Errorf("expected non-nil Access Management settings record post-destroy")
-		}
-		return nil
-	}
+	return testhelpers.RequireSingletonStillExists(t, "Access Management settings", func(ctx context.Context) (any, error) {
+		return pro.New(testhelpers.NewAcceptanceClient(t)).GetEnrollmentAccessManagementV4(ctx)
+	})
 }
 
 // TestAccResource_ProAccessManagementSettings_Basic creates an ADE server object from the

--- a/internal/resources/pro/settings/activation_code/resource_acceptance_test.go
+++ b/internal/resources/pro/settings/activation_code/resource_acceptance_test.go
@@ -24,7 +24,6 @@ import (
 
 	"github.com/Jamf-Concepts/jamfplatform-go-sdk/jamfplatform/proclassic"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
 	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/testhelpers"
 )
@@ -49,17 +48,9 @@ func currentActivationCode(t *testing.T) (org, code string) {
 // checkSingletonRecordStillExists verifies the activation code record persists on the
 // tenant after Terraform destroys the resource from state (the remote Delete is a no-op).
 func checkSingletonRecordStillExists(t *testing.T) resource.TestCheckFunc {
-	return func(_ *terraform.State) error {
-		c := proclassic.New(testhelpers.NewAcceptanceClient(t))
-		got, err := c.GetActivationCode(context.Background())
-		if err != nil {
-			return fmt.Errorf("expected activation code record to persist on tenant after destroy, got error: %w", err)
-		}
-		if got == nil {
-			return fmt.Errorf("expected non-nil activation code record post-destroy")
-		}
-		return nil
-	}
+	return testhelpers.RequireSingletonStillExists(t, "activation code", func(ctx context.Context) (any, error) {
+		return proclassic.New(testhelpers.NewAcceptanceClient(t)).GetActivationCode(ctx)
+	})
 }
 
 func configFor(org, code string) string {

--- a/internal/resources/pro/settings/app_installer_settings/resource_acceptance_test.go
+++ b/internal/resources/pro/settings/app_installer_settings/resource_acceptance_test.go
@@ -21,17 +21,9 @@ import (
 // checkSingletonRecordStillExists verifies the App Installer global settings record
 // persists on the tenant after Terraform destroys the resource from state.
 func checkSingletonRecordStillExists(t *testing.T) resource.TestCheckFunc {
-	return func(_ *terraform.State) error {
-		c := pro.New(testhelpers.NewAcceptanceClient(t))
-		got, err := c.GetAppInstallerGlobalSettingsV1(context.Background())
-		if err != nil {
-			return fmt.Errorf("expected App Installer settings to persist after destroy: %w", err)
-		}
-		if got == nil {
-			return fmt.Errorf("expected non-nil App Installer settings post-destroy")
-		}
-		return nil
-	}
+	return testhelpers.RequireSingletonStillExists(t, "App Installer settings", func(ctx context.Context) (any, error) {
+		return pro.New(testhelpers.NewAcceptanceClient(t)).GetAppInstallerGlobalSettingsV1(ctx)
+	})
 }
 
 // TestAccResource_ProAppInstallerSettings_Basic creates settings with both blocks,

--- a/internal/resources/pro/settings/computer_check_in_settings/resource_acceptance_test.go
+++ b/internal/resources/pro/settings/computer_check_in_settings/resource_acceptance_test.go
@@ -7,13 +7,11 @@ package computer_check_in_settings_test
 
 import (
 	"context"
-	"fmt"
 	"regexp"
 	"testing"
 
 	"github.com/Jamf-Concepts/jamfplatform-go-sdk/jamfplatform/pro"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
 	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/testhelpers"
 )
@@ -23,17 +21,9 @@ import (
 // Canonical singleton acceptance check: the remote Delete is a no-op, so the API
 // must still return the record (with whatever value was last applied) post-destroy.
 func checkSingletonRecordStillExists(t *testing.T) resource.TestCheckFunc {
-	return func(_ *terraform.State) error {
-		c := pro.New(testhelpers.NewAcceptanceClient(t))
-		got, err := c.GetCheckInSettingsV3(context.Background())
-		if err != nil {
-			return fmt.Errorf("expected Client Check-In settings record to persist on tenant after destroy, got error: %w", err)
-		}
-		if got == nil {
-			return fmt.Errorf("expected non-nil Client Check-In settings record post-destroy")
-		}
-		return nil
-	}
+	return testhelpers.RequireSingletonStillExists(t, "Client Check-In settings", func(ctx context.Context) (any, error) {
+		return pro.New(testhelpers.NewAcceptanceClient(t)).GetCheckInSettingsV3(ctx)
+	})
 }
 
 // TestAccResource_ProComputerCheckInSettings_Basic mutates every attribute across two Update

--- a/internal/resources/pro/settings/computer_inventory_collection_settings/resource_acceptance_test.go
+++ b/internal/resources/pro/settings/computer_inventory_collection_settings/resource_acceptance_test.go
@@ -7,13 +7,11 @@ package computer_inventory_collection_settings_test
 
 import (
 	"context"
-	"fmt"
 	"regexp"
 	"testing"
 
 	"github.com/Jamf-Concepts/jamfplatform-go-sdk/jamfplatform/pro"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
 	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/testhelpers"
 )
@@ -23,17 +21,9 @@ const resName = "jamfplatform_pro_computer_inventory_collection_settings.test"
 // checkSingletonRecordStillExists verifies the settings record persists on the tenant
 // after Terraform destroys the resource from state. The remote Delete is a no-op.
 func checkSingletonRecordStillExists(t *testing.T) resource.TestCheckFunc {
-	return func(_ *terraform.State) error {
-		c := pro.New(testhelpers.NewAcceptanceClient(t))
-		got, err := c.GetComputerInventoryCollectionSettingsV2(context.Background())
-		if err != nil {
-			return fmt.Errorf("expected computer inventory collection settings to persist on tenant after destroy, got error: %w", err)
-		}
-		if got == nil {
-			return fmt.Errorf("expected non-nil settings record post-destroy")
-		}
-		return nil
-	}
+	return testhelpers.RequireSingletonStillExists(t, "computer inventory collection settings", func(ctx context.Context) (any, error) {
+		return pro.New(testhelpers.NewAcceptanceClient(t)).GetComputerInventoryCollectionSettingsV2(ctx)
+	})
 }
 
 // TestAccResource_ProComputerInventoryCollectionSettings_Basic exercises a full Update

--- a/internal/resources/pro/settings/gsx_connection/resource_acceptance_test.go
+++ b/internal/resources/pro/settings/gsx_connection/resource_acceptance_test.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/Jamf-Concepts/jamfplatform-go-sdk/jamfplatform/pro"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
 	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/testhelpers"
 )
@@ -64,17 +63,9 @@ func requireGsxCreds(t *testing.T) gsxCreds {
 // checkSingletonRecordStillExists verifies the GSX Connection record persists on the tenant
 // after Terraform destroys the resource from state (Delete is a no-op for singletons).
 func checkSingletonRecordStillExists(t *testing.T) resource.TestCheckFunc {
-	return func(_ *terraform.State) error {
-		c := pro.New(testhelpers.NewAcceptanceClient(t))
-		got, err := c.GetGSXConnectionV1(context.Background())
-		if err != nil {
-			return fmt.Errorf("expected GSX Connection record to persist on tenant after destroy: %w", err)
-		}
-		if got == nil {
-			return fmt.Errorf("expected non-nil GSX Connection record post-destroy")
-		}
-		return nil
-	}
+	return testhelpers.RequireSingletonStillExists(t, "GSX Connection", func(ctx context.Context) (any, error) {
+		return pro.New(testhelpers.NewAcceptanceClient(t)).GetGSXConnectionV1(ctx)
+	})
 }
 
 func gsxConfig(c gsxCreds, enabled bool) string {

--- a/internal/resources/pro/settings/impact_alert_notification_settings/resource_acceptance_test.go
+++ b/internal/resources/pro/settings/impact_alert_notification_settings/resource_acceptance_test.go
@@ -7,13 +7,11 @@ package impact_alert_notification_settings_test
 
 import (
 	"context"
-	"fmt"
 	"regexp"
 	"testing"
 
 	"github.com/Jamf-Concepts/jamfplatform-go-sdk/jamfplatform/pro"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
 	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/testhelpers"
 )
@@ -23,17 +21,9 @@ import (
 // Canonical singleton acceptance check: the remote Delete is a no-op, so the API must
 // still return the record (with whatever value was last applied) post-destroy.
 func checkSingletonRecordStillExists(t *testing.T) resource.TestCheckFunc {
-	return func(_ *terraform.State) error {
-		c := pro.New(testhelpers.NewAcceptanceClient(t))
-		got, err := c.GetImpactAlertNotificationSettingsV1(context.Background())
-		if err != nil {
-			return fmt.Errorf("expected Impact Alert Notification settings record to persist on tenant after destroy, got error: %w", err)
-		}
-		if got == nil {
-			return fmt.Errorf("expected non-nil Impact Alert Notification settings record post-destroy")
-		}
-		return nil
-	}
+	return testhelpers.RequireSingletonStillExists(t, "Impact Alert Notification settings", func(ctx context.Context) (any, error) {
+		return pro.New(testhelpers.NewAcceptanceClient(t)).GetImpactAlertNotificationSettingsV1(ctx)
+	})
 }
 
 // TestAccResource_ProImpactAlertNotificationSettings_Basic mutates every toggle across two

--- a/internal/resources/pro/settings/login_page/resource_acceptance_test.go
+++ b/internal/resources/pro/settings/login_page/resource_acceptance_test.go
@@ -7,13 +7,11 @@ package login_page_test
 
 import (
 	"context"
-	"fmt"
 	"regexp"
 	"testing"
 
 	"github.com/Jamf-Concepts/jamfplatform-go-sdk/jamfplatform/pro"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
 	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/testhelpers"
 )
@@ -25,17 +23,9 @@ func strptr(s string) *string { return &s }
 // on the tenant after Terraform destroys the resource from state. Canonical singleton
 // acceptance check: the remote Delete is a no-op, so the API must still return the record.
 func checkSingletonRecordStillExists(t *testing.T) resource.TestCheckFunc {
-	return func(_ *terraform.State) error {
-		c := pro.New(testhelpers.NewAcceptanceClient(t))
-		got, err := c.GetLoginCustomizationV1(context.Background())
-		if err != nil {
-			return fmt.Errorf("expected login page settings record to persist on tenant after destroy, got error: %w", err)
-		}
-		if got == nil {
-			return fmt.Errorf("expected non-nil login page settings record post-destroy")
-		}
-		return nil
-	}
+	return testhelpers.RequireSingletonStillExists(t, "login page settings", func(ctx context.Context) (any, error) {
+		return pro.New(testhelpers.NewAcceptanceClient(t)).GetLoginCustomizationV1(ctx)
+	})
 }
 
 // TestAccResource_ProLoginPageSettings_Basic mutates every field across two Update steps

--- a/internal/resources/pro/settings/macos_onboarding/resource_acceptance_test.go
+++ b/internal/resources/pro/settings/macos_onboarding/resource_acceptance_test.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/Jamf-Concepts/jamfplatform-go-sdk/jamfplatform/pro"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
 	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/testhelpers"
 )
@@ -111,17 +110,9 @@ func snapshotAndRestoreOnboarding(t *testing.T) {
 // checkSingletonRecordStillExists verifies the onboarding record persists on the tenant
 // after Terraform destroys the resource from state (singleton — remote delete is a no-op).
 func checkSingletonRecordStillExists(t *testing.T) resource.TestCheckFunc {
-	return func(_ *terraform.State) error {
-		c := pro.New(testhelpers.NewAcceptanceClient(t))
-		got, err := c.GetOnboardingV1(context.Background())
-		if err != nil {
-			return fmt.Errorf("expected onboarding record to persist on tenant after destroy, got error: %w", err)
-		}
-		if got == nil {
-			return fmt.Errorf("expected non-nil onboarding record post-destroy")
-		}
-		return nil
-	}
+	return testhelpers.RequireSingletonStillExists(t, "onboarding", func(ctx context.Context) (any, error) {
+		return pro.New(testhelpers.NewAcceptanceClient(t)).GetOnboardingV1(ctx)
+	})
 }
 
 const (

--- a/internal/resources/pro/settings/managed_software_updates/resource_acceptance_test.go
+++ b/internal/resources/pro/settings/managed_software_updates/resource_acceptance_test.go
@@ -7,13 +7,11 @@ package managed_software_updates_test
 
 import (
 	"context"
-	"fmt"
 	"regexp"
 	"testing"
 
 	"github.com/Jamf-Concepts/jamfplatform-go-sdk/jamfplatform/pro"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
 	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/testhelpers"
 )
@@ -21,17 +19,9 @@ import (
 // checkSingletonRecordStillExists verifies the feature-toggle record persists on the tenant
 // after Terraform destroys the resource from state — the remote Delete is a no-op.
 func checkSingletonRecordStillExists(t *testing.T) resource.TestCheckFunc {
-	return func(_ *terraform.State) error {
-		c := pro.New(testhelpers.NewAcceptanceClient(t))
-		got, err := c.GetManagedSoftwareUpdateFeatureToggleV1(context.Background())
-		if err != nil {
-			return fmt.Errorf("expected Managed Software Updates feature toggle to persist on tenant after destroy, got error: %w", err)
-		}
-		if got == nil {
-			return fmt.Errorf("expected non-nil feature toggle record post-destroy")
-		}
-		return nil
-	}
+	return testhelpers.RequireSingletonStillExists(t, "Managed Software Updates feature toggle", func(ctx context.Context) (any, error) {
+		return pro.New(testhelpers.NewAcceptanceClient(t)).GetManagedSoftwareUpdateFeatureToggleV1(ctx)
+	})
 }
 
 // TestAccResource_ProManagedSoftwareUpdateFeatureToggle_Basic flips the toggle across two

--- a/internal/resources/pro/settings/mdm_profile_settings/resource_acceptance_test.go
+++ b/internal/resources/pro/settings/mdm_profile_settings/resource_acceptance_test.go
@@ -7,13 +7,11 @@ package mdm_profile_settings_test
 
 import (
 	"context"
-	"fmt"
 	"regexp"
 	"testing"
 
 	"github.com/Jamf-Concepts/jamfplatform-go-sdk/jamfplatform/pro"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
 	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/testhelpers"
 )
@@ -23,17 +21,9 @@ import (
 // Canonical singleton acceptance check: the remote Delete is a no-op, so the API
 // must still return the record (with whatever value was last applied) post-destroy.
 func checkSingletonRecordStillExists(t *testing.T) resource.TestCheckFunc {
-	return func(_ *terraform.State) error {
-		c := pro.New(testhelpers.NewAcceptanceClient(t))
-		got, err := c.GetDeviceCommunicationSettingsV1(context.Background())
-		if err != nil {
-			return fmt.Errorf("expected device communication settings record to persist on tenant after destroy, got error: %w", err)
-		}
-		if got == nil {
-			return fmt.Errorf("expected non-nil device communication settings record post-destroy")
-		}
-		return nil
-	}
+	return testhelpers.RequireSingletonStillExists(t, "device communication settings", func(ctx context.Context) (any, error) {
+		return pro.New(testhelpers.NewAcceptanceClient(t)).GetDeviceCommunicationSettingsV1(ctx)
+	})
 }
 
 // TestAccResource_ProMDMProfileSettings_Basic mutates all six settings on, then

--- a/internal/resources/pro/settings/self_service_macos_settings/resource_acceptance_test.go
+++ b/internal/resources/pro/settings/self_service_macos_settings/resource_acceptance_test.go
@@ -7,14 +7,12 @@ package self_service_macos_settings_test
 
 import (
 	"context"
-	"fmt"
 	"os"
 	"regexp"
 	"testing"
 
 	"github.com/Jamf-Concepts/jamfplatform-go-sdk/jamfplatform/pro"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
 	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/testhelpers"
 )
@@ -66,17 +64,9 @@ func snapshotAndRestoreSettings(t *testing.T) {
 // singleton acceptance check: the remote Delete is a no-op, so the API must still return
 // the record (with whatever value was last applied) post-destroy.
 func checkSingletonRecordStillExists(t *testing.T) resource.TestCheckFunc {
-	return func(_ *terraform.State) error {
-		c := pro.New(testhelpers.NewAcceptanceClient(t))
-		got, err := c.GetSelfServiceSettingsV1(context.Background())
-		if err != nil {
-			return fmt.Errorf("expected Self Service settings record to persist on tenant after destroy, got error: %w", err)
-		}
-		if got == nil {
-			return fmt.Errorf("expected non-nil Self Service settings record post-destroy")
-		}
-		return nil
-	}
+	return testhelpers.RequireSingletonStillExists(t, "Self Service settings", func(ctx context.Context) (any, error) {
+		return pro.New(testhelpers.NewAcceptanceClient(t)).GetSelfServiceSettingsV1(ctx)
+	})
 }
 
 // TestAccResource_ProSelfServiceMacosSettings_Basic drives every attribute across two Update

--- a/internal/resources/pro/settings/self_service_plus_settings/resource_acceptance_test.go
+++ b/internal/resources/pro/settings/self_service_plus_settings/resource_acceptance_test.go
@@ -7,13 +7,11 @@ package self_service_plus_settings_test
 
 import (
 	"context"
-	"fmt"
 	"regexp"
 	"testing"
 
 	"github.com/Jamf-Concepts/jamfplatform-go-sdk/jamfplatform/pro"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
 	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/testhelpers"
 )
@@ -23,17 +21,9 @@ import (
 // Canonical singleton acceptance check: the remote Delete is a no-op, so the API
 // must still return the record (with whatever value was last applied) post-destroy.
 func checkSingletonRecordStillExists(t *testing.T) resource.TestCheckFunc {
-	return func(_ *terraform.State) error {
-		c := pro.New(testhelpers.NewAcceptanceClient(t))
-		got, err := c.GetSelfServicePlusSettingsV1(context.Background())
-		if err != nil {
-			return fmt.Errorf("expected Self Service Plus settings record to persist on tenant after destroy, got error: %w", err)
-		}
-		if got == nil {
-			return fmt.Errorf("expected non-nil Self Service Plus settings record post-destroy")
-		}
-		return nil
-	}
+	return testhelpers.RequireSingletonStillExists(t, "Self Service Plus settings", func(ctx context.Context) (any, error) {
+		return pro.New(testhelpers.NewAcceptanceClient(t)).GetSelfServicePlusSettingsV1(ctx)
+	})
 }
 
 // TestAccResource_ProSelfServicePlusSettings_Basic toggles Self Service Plus on, then

--- a/internal/resources/pro/settings/service_discovery_enrollment/resource_acceptance_test.go
+++ b/internal/resources/pro/settings/service_discovery_enrollment/resource_acceptance_test.go
@@ -62,17 +62,9 @@ func serviceDiscoveryConfig(adeName, token string, enrollmentType string) string
 // checkSingletonRecordStillExists verifies the well-known settings record persists on the
 // tenant after Terraform destroys the resources from state (singleton — no remote delete).
 func checkSingletonRecordStillExists(t *testing.T) resource.TestCheckFunc {
-	return func(_ *terraform.State) error {
-		c := pro.New(testhelpers.NewAcceptanceClient(t))
-		got, err := c.GetServiceDiscoveryEnrollmentWellKnownSettingsV1(context.Background())
-		if err != nil {
-			return fmt.Errorf("expected service discovery well-known settings to persist post-destroy, got error: %w", err)
-		}
-		if got == nil {
-			return fmt.Errorf("expected non-nil well-known settings record post-destroy")
-		}
-		return nil
-	}
+	return testhelpers.RequireSingletonStillExists(t, "service discovery well-known settings", func(ctx context.Context) (any, error) {
+		return pro.New(testhelpers.NewAcceptanceClient(t)).GetServiceDiscoveryEnrollmentWellKnownSettingsV1(ctx)
+	})
 }
 
 // TestAccResource_ProServiceDiscoveryEnrollment_Basic creates an ADE server object from

--- a/internal/resources/pro/settings/smtp_server/resource_acceptance_test.go
+++ b/internal/resources/pro/settings/smtp_server/resource_acceptance_test.go
@@ -7,14 +7,12 @@ package smtp_server_test
 
 import (
 	"context"
-	"fmt"
 	"os"
 	"regexp"
 	"testing"
 
 	"github.com/Jamf-Concepts/jamfplatform-go-sdk/jamfplatform/pro"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
 	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/testhelpers"
 )
@@ -25,17 +23,9 @@ const smtpAddr = "jamfplatform_pro_smtp_server.test"
 // persists on the tenant after Terraform destroys the resource from state. The
 // remote Delete is a no-op, so the API must still return the record post-destroy.
 func checkSingletonRecordStillExists(t *testing.T) resource.TestCheckFunc {
-	return func(_ *terraform.State) error {
-		c := pro.New(testhelpers.NewAcceptanceClient(t))
-		got, err := c.GetSmtpServerV2(context.Background())
-		if err != nil {
-			return fmt.Errorf("expected SMTP Server record to persist on tenant after destroy, got error: %w", err)
-		}
-		if got == nil {
-			return fmt.Errorf("expected non-nil SMTP Server record post-destroy")
-		}
-		return nil
-	}
+	return testhelpers.RequireSingletonStillExists(t, "SMTP Server", func(ctx context.Context) (any, error) {
+		return pro.New(testhelpers.NewAcceptanceClient(t)).GetSmtpServerV2(ctx)
+	})
 }
 
 // TestAccResource_ProSmtpServer_Basic exercises the BASIC happy-path plus a

--- a/internal/resources/pro/users/user_group/dsgroup_acceptance_test.go
+++ b/internal/resources/pro/users/user_group/dsgroup_acceptance_test.go
@@ -6,18 +6,13 @@
 package user_group_test
 
 import (
-	"context"
 	"fmt"
 	"os"
-	"strconv"
 	"testing"
 
-	"github.com/Jamf-Concepts/jamfplatform-go-sdk/jamfplatform/pro"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 
-	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/common/criteria"
-	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/common/ldapgroups"
 	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/testhelpers"
 )
 
@@ -26,29 +21,9 @@ import (
 // own-model path (to/fromCriterionModels converters + member_count restore on a
 // representation swap). The user surface accepts only the Username criterion.
 const (
-	envDSGroupGate  = "JAMFPLATFORM_ACC_CRITERIA_DS_GROUP"
-	envDSGroupName  = "JAMFPLATFORM_ACC_CRITERIA_DS_GROUP_NAME"
-	envDSGroupValue = "JAMFPLATFORM_ACC_CRITERIA_DS_GROUP_VALUE" // optional independent oracle
+	envDSGroupGate = "JAMFPLATFORM_ACC_CRITERIA_DS_GROUP"
+	envDSGroupName = "JAMFPLATFORM_ACC_CRITERIA_DS_GROUP_NAME"
 )
-
-func resolveDSGroupWireValue(t *testing.T, name string) string {
-	t.Helper()
-	groups, err := ldapgroups.ResolveByName(context.Background(), pro.New(testhelpers.NewAcceptanceClient(t)), name)
-	if err != nil {
-		t.Fatalf("resolving %q: %v", name, err)
-	}
-	if len(groups) != 1 {
-		t.Fatalf("group %q must resolve to exactly one directory group (got %d) — pick an unambiguous name", name, len(groups))
-	}
-	if groups[0].UUID == "" {
-		t.Fatalf("group %q resolved with no uuid mapping", name)
-	}
-	wire := criteria.EncodeDSGroupValue(groups[0].UUID, strconv.Itoa(groups[0].LdapServerID))
-	if want := os.Getenv(envDSGroupValue); want != "" && wire != want {
-		t.Fatalf("provider resolved %q to %q, but %s=%q — name/value mismatch or an encoding bug", name, wire, envDSGroupValue, want)
-	}
-	return wire
-}
 
 // TestAccResource_ProUserGroup_DSGroupCriteria mirrors the search tests on the
 // classic user-group surface (smart group, Username criterion only).
@@ -61,7 +36,7 @@ func TestAccResource_ProUserGroup_DSGroupCriteria(t *testing.T) {
 		t.Skipf("%s must be set", envDSGroupName)
 	}
 	testhelpers.AccPreCheck(t)
-	groupValue := resolveDSGroupWireValue(t, groupName)
+	groupValue := testhelpers.ResolveDSGroupWireValue(t, groupName)
 
 	suffix := testhelpers.RunSuffix()
 	name := "tf-acc-ug-dsgroup-" + suffix

--- a/internal/testhelpers/acceptance_assertions.go
+++ b/internal/testhelpers/acceptance_assertions.go
@@ -47,7 +47,7 @@ func RequireSingletonStillExists(t *testing.T, label string, get func(context.Co
 		if got == nil {
 			return fmt.Errorf("expected non-nil %s record post-destroy", label)
 		}
-		if rv := reflect.ValueOf(got); rv.Kind() == reflect.Ptr && rv.IsNil() {
+		if rv := reflect.ValueOf(got); rv.Kind() == reflect.Pointer && rv.IsNil() {
 			return fmt.Errorf("expected non-nil %s record post-destroy", label)
 		}
 		return nil

--- a/internal/testhelpers/acceptance_assertions.go
+++ b/internal/testhelpers/acceptance_assertions.go
@@ -1,0 +1,78 @@
+// Copyright Jamf Software LLC 2026
+// SPDX-License-Identifier: MPL-2.0
+
+//go:build acceptance
+
+package testhelpers
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"reflect"
+	"strconv"
+	"testing"
+
+	"github.com/Jamf-Concepts/jamfplatform-go-sdk/jamfplatform/pro"
+	"github.com/Jamf-Concepts/jamfplatform-go-sdk/jamfplatform/proclassic"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+
+	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/common/criteria"
+	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/common/ldapgroups"
+)
+
+// envDSGroupValue is the optional acceptance oracle: when set, ResolveDSGroupWireValue
+// cross-checks the provider's encoded directory-service group value against it.
+const envDSGroupValue = "JAMFPLATFORM_ACC_CRITERIA_DS_GROUP_VALUE"
+
+// NewProClassicClient builds a ProClassic SDK client from the acceptance client.
+func NewProClassicClient(t *testing.T) *proclassic.Client {
+	t.Helper()
+	return proclassic.New(NewAcceptanceClient(t))
+}
+
+// RequireSingletonStillExists returns a CheckDestroy that asserts a Pro singleton
+// record still exists on the tenant after Terraform destroy — the convention for
+// update-only singleton resources whose Delete is a no-op. label names the record
+// in failure messages; get performs the resource-specific SDK read. A nil record
+// (including a typed-nil pointer) or a read error fails the check.
+func RequireSingletonStillExists(t *testing.T, label string, get func(context.Context) (any, error)) resource.TestCheckFunc {
+	t.Helper()
+	return func(_ *terraform.State) error {
+		got, err := get(context.Background())
+		if err != nil {
+			return fmt.Errorf("expected %s record to persist on tenant after destroy, got error: %w", label, err)
+		}
+		if got == nil {
+			return fmt.Errorf("expected non-nil %s record post-destroy", label)
+		}
+		if rv := reflect.ValueOf(got); rv.Kind() == reflect.Ptr && rv.IsNil() {
+			return fmt.Errorf("expected non-nil %s record post-destroy", label)
+		}
+		return nil
+	}
+}
+
+// ResolveDSGroupWireValue resolves a directory-service group by name to its encoded
+// wire value (uuid + ldap server id). Fails the test unless the name resolves to
+// exactly one group with a uuid mapping. When envDSGroupValue is set, the resolved
+// value is cross-checked against it as an independent oracle.
+func ResolveDSGroupWireValue(t *testing.T, name string) string {
+	t.Helper()
+	groups, err := ldapgroups.ResolveByName(context.Background(), pro.New(NewAcceptanceClient(t)), name)
+	if err != nil {
+		t.Fatalf("resolving %q: %v", name, err)
+	}
+	if len(groups) != 1 {
+		t.Fatalf("group %q must resolve to exactly one directory group (got %d) — pick an unambiguous name", name, len(groups))
+	}
+	if groups[0].UUID == "" {
+		t.Fatalf("group %q resolved with no uuid mapping", name)
+	}
+	wire := criteria.EncodeDSGroupValue(groups[0].UUID, strconv.Itoa(groups[0].LdapServerID))
+	if want := os.Getenv(envDSGroupValue); want != "" && wire != want {
+		t.Fatalf("provider resolved %q to %q, but %s=%q — name/value mismatch or an encoding bug", name, wire, envDSGroupValue, want)
+	}
+	return wire
+}


### PR DESCRIPTION
## What

Phase 10 **Helper Consolidation** audit — tier 3 of 3 (test helpers). Promotes the identical / parameterizable acceptance helpers into `internal/testhelpers`.

| New export | Replaces | Sites |
|---|---|---|
| `NewProClassicClient` | `newSDKClient` | 3 |
| `ResolveDSGroupWireValue` | `resolveDSGroupWireValue` | 4 |
| `RequireSingletonStillExists` | `checkSingletonRecordStillExists` | 15 |

`RequireSingletonStillExists` centralizes the error/nil-check assertion (incl. typed-nil via reflection); each singleton test keeps a one-line adapter supplying its resource-specific SDK `Get` + label — the read genuinely differs per resource, so the adapter is irreducible.

**Pure dedup — no behaviour change** (failure-message wording standardized; only visible on failure). Net **−335 / +67** across 22 files + 1 new.

## Left local

- **`mustStringSet`** (3 unit sites) — moving it into `testhelpers` forms an import cycle under `-tags acceptance`: the *untagged* unit test would pull `testhelpers` → `provider` → the resource under test. Not worth a dedicated package for 3 sites.
- `applyAndRefresh` / `fullResponse` / `readFixture` / `lifecycleConfig` — divergent signatures / resource-specific fixtures (per audit).

## Stacking

Based on `chore/helper-consolidation-scope` (tier 2, #243). Retarget to `feat/pro-expansion` once tiers 1–2 merge.

## Verify

`make lint` clean; `go build`/`go vet ./...` clean; **`go vet -tags acceptance ./...` clean** (whole tree compiles under the acceptance tag); all unit-test packages pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)