### PR TITLE
fix(ldap_server): defer config validator on unknown account block (Phase 10 validator audit)

### DIFF
--- a/internal/common/helpers/promoted_test.go
+++ b/internal/common/helpers/promoted_test.go
@@ -9,10 +9,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
-func intPtr(i int) *int         { return &i }
-func strPtr(s string) *string   { return &s }
-func boolPtrLocal(b bool) *bool { return &b }
-
 func TestStringIDPtr(t *testing.T) {
 	tests := []struct {
 		name  string
@@ -23,7 +19,7 @@ func TestStringIDPtr(t *testing.T) {
 		{"unknown", types.StringUnknown(), nil},
 		{"empty", types.StringValue(""), nil},
 		{"non-numeric", types.StringValue("abc"), nil},
-		{"numeric", types.StringValue("42"), intPtr(42)},
+		{"numeric", types.StringValue("42"), new(42)},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -42,7 +38,7 @@ func TestStringFromIntPtr(t *testing.T) {
 	if got := StringFromIntPtr(nil); got != nil {
 		t.Errorf("StringFromIntPtr(nil) = %v, want nil", got)
 	}
-	if got := StringFromIntPtr(intPtr(7)); got == nil || *got != "7" {
+	if got := StringFromIntPtr(new(7)); got == nil || *got != "7" {
 		t.Errorf("StringFromIntPtr(7) = %v, want \"7\"", got)
 	}
 }
@@ -51,18 +47,18 @@ func TestInt64FromIntPtr(t *testing.T) {
 	if got := Int64FromIntPtr(nil); !got.IsNull() {
 		t.Errorf("Int64FromIntPtr(nil) should be null")
 	}
-	if got := Int64FromIntPtr(intPtr(9)); got.IsNull() || got.ValueInt64() != 9 {
+	if got := Int64FromIntPtr(new(9)); got.IsNull() || got.ValueInt64() != 9 {
 		t.Errorf("Int64FromIntPtr(9) = %v, want 9", got)
 	}
 }
 
 func TestPreferCurrentStringPointer(t *testing.T) {
 	// Configured current always wins, even when the API echoes a different value.
-	if got := PreferCurrentStringPointer(strPtr("api"), types.StringValue("cfg")); got.ValueString() != "cfg" {
+	if got := PreferCurrentStringPointer(new("api"), types.StringValue("cfg")); got.ValueString() != "cfg" {
 		t.Errorf("configured current should win, got %v", got)
 	}
 	// Unset current adopts the API value.
-	if got := PreferCurrentStringPointer(strPtr("api"), types.StringNull()); got.ValueString() != "api" {
+	if got := PreferCurrentStringPointer(new("api"), types.StringNull()); got.ValueString() != "api" {
 		t.Errorf("unset current should adopt API value, got %v", got)
 	}
 	// Nil API with unset current is null.
@@ -72,10 +68,10 @@ func TestPreferCurrentStringPointer(t *testing.T) {
 }
 
 func TestPreferCurrentBoolPointer(t *testing.T) {
-	if got := PreferCurrentBoolPointer(boolPtrLocal(false), types.BoolValue(true)); got.ValueBool() != true {
+	if got := PreferCurrentBoolPointer(new(false), types.BoolValue(true)); got.ValueBool() != true {
 		t.Errorf("configured current should win, got %v", got)
 	}
-	if got := PreferCurrentBoolPointer(boolPtrLocal(true), types.BoolNull()); got.ValueBool() != true {
+	if got := PreferCurrentBoolPointer(new(true), types.BoolNull()); got.ValueBool() != true {
 		t.Errorf("unset current should adopt API value, got %v", got)
 	}
 	if got := PreferCurrentBoolPointer(nil, types.BoolNull()); !got.IsNull() {

--- a/internal/common/scope/proclassic_test.go
+++ b/internal/common/scope/proclassic_test.go
@@ -11,15 +11,12 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
-func iptr(i int) *int       { return &i }
-func sptr(s string) *string { return &s }
-
 func TestFlattenIDNameSet(t *testing.T) {
 	ctx := context.Background()
 	if got := FlattenIDNameSet(ctx, nil); !got.IsNull() {
 		t.Errorf("nil items should be null set, got %v", got)
 	}
-	items := &[]proclassic.IDName{{ID: iptr(1), Name: sptr("a")}, {ID: iptr(2), Name: sptr("b")}}
+	items := &[]proclassic.IDName{{ID: new(1), Name: new("a")}, {ID: new(2), Name: new("b")}}
 	got := FlattenIDNameSet(ctx, items)
 	if got.IsNull() || len(got.Elements()) != 2 {
 		t.Errorf("expected 2-element set, got %v", got)
@@ -31,7 +28,7 @@ func TestFlattenNameSet(t *testing.T) {
 	if got := FlattenNameSet(ctx, nil); !got.IsNull() {
 		t.Errorf("nil items should be null set, got %v", got)
 	}
-	items := &[]proclassic.IDName{{ID: iptr(1), Name: sptr("alpha")}}
+	items := &[]proclassic.IDName{{ID: new(1), Name: new("alpha")}}
 	got := FlattenNameSet(ctx, items)
 	if got.IsNull() || len(got.Elements()) != 1 {
 		t.Errorf("expected 1-element set, got %v", got)
@@ -43,7 +40,7 @@ func TestFlattenSiteObject(t *testing.T) {
 	if id != nil || name != nil {
 		t.Errorf("nil site should yield (nil,nil)")
 	}
-	id, name = FlattenSiteObject(&proclassic.SiteObject{ID: iptr(7), Name: sptr("HQ")})
+	id, name = FlattenSiteObject(&proclassic.SiteObject{ID: new(7), Name: new("HQ")})
 	if id == nil || *id != "7" || name == nil || *name != "HQ" {
 		t.Errorf("got (%v,%v), want (\"7\",\"HQ\")", id, name)
 	}

--- a/internal/resources/pro/inventory/computer_extension_attribute/validators_test.go
+++ b/internal/resources/pro/inventory/computer_extension_attribute/validators_test.go
@@ -54,6 +54,30 @@ func validateComputer(t *testing.T, attrs map[string]tftypes.Value) resource.Val
 	return resp
 }
 
+// TestInputTypeValidator_Computer_DefersOnUnknownCompanion is the §436
+// regression guard: when input_type is known but the required companion
+// (script / directory_service_attribute) is unknown — sourced from a variable,
+// for_each, or another resource — the validator MUST defer, not treat unknown
+// as missing and error. See STYLE_GUIDE "Config-time validators MUST defer on
+// unknown values".
+func TestInputTypeValidator_Computer_DefersOnUnknownCompanion(t *testing.T) {
+	unknown := tftypes.NewValue(tftypes.String, tftypes.UnknownValue)
+	cases := []struct {
+		name  string
+		attrs map[string]tftypes.Value
+	}{
+		{"SCRIPT with unknown script", map[string]tftypes.Value{"input_type": str("SCRIPT"), "script": unknown}},
+		{"DSAM with unknown directory_service_attribute", map[string]tftypes.Value{"input_type": str("DIRECTORY_SERVICE_ATTRIBUTE_MAPPING"), "directory_service_attribute": unknown}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if resp := validateComputer(t, tc.attrs); resp.Diagnostics.HasError() {
+				t.Errorf("validator must defer on unknown companion, got %v", resp.Diagnostics)
+			}
+		})
+	}
+}
+
 func TestInputTypeValidator_Computer(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/internal/resources/pro/inventory/ibeacon/validators_test.go
+++ b/internal/resources/pro/inventory/ibeacon/validators_test.go
@@ -6,6 +6,10 @@ package ibeacon
 import (
 	"context"
 	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
 )
 
 // TestValidator_Descriptions confirms the ConfigValidator implements the
@@ -23,5 +27,57 @@ func TestValidator_Descriptions(t *testing.T) {
 	}
 	if v.MarkdownDescription(context.Background()) == "" {
 		t.Errorf("MarkdownDescription must not be empty")
+	}
+}
+
+// ibeaconConfig builds a tfsdk.Config from the real resource schema, filling
+// every attribute null except those supplied in attrs (keyed by attribute
+// name).
+func ibeaconConfig(t *testing.T, attrs map[string]tftypes.Value) tfsdk.Config {
+	t.Helper()
+	r := NewIbeaconResource()
+	var sr resource.SchemaResponse
+	r.(*IbeaconResource).Schema(context.Background(), resource.SchemaRequest{}, &sr)
+	if sr.Diagnostics.HasError() {
+		t.Fatalf("schema diagnostics: %v", sr.Diagnostics)
+	}
+	objType := sr.Schema.Type().TerraformType(context.Background()).(tftypes.Object)
+	values := map[string]tftypes.Value{}
+	for name, typ := range objType.AttributeTypes {
+		if v, ok := attrs[name]; ok {
+			values[name] = v
+			continue
+		}
+		values[name] = tftypes.NewValue(typ, nil)
+	}
+	return tfsdk.Config{Schema: sr.Schema, Raw: tftypes.NewValue(objType, values)}
+}
+
+// TestIncludeAnyMajorMinorConfigValidator_DefersOnUnknown is the §436 regression
+// guard: with include_any_*_value = false (known) and the corresponding major /
+// minor UNKNOWN (variable/for_each/resource-driven), the validator MUST defer,
+// not treat unknown as missing and error. See STYLE_GUIDE "Config-time
+// validators MUST defer on unknown values".
+func TestIncludeAnyMajorMinorConfigValidator_DefersOnUnknown(t *testing.T) {
+	unknownNum := tftypes.NewValue(tftypes.Number, tftypes.UnknownValue)
+	anyTrue := tftypes.NewValue(tftypes.Bool, true)
+	// Each case keeps the OTHER axis in a valid state (include_any = true) so
+	// only the axis under test — with its value unknown — is exercised.
+	cases := []struct {
+		name  string
+		attrs map[string]tftypes.Value
+	}{
+		{"major unknown", map[string]tftypes.Value{"include_any_major_value": tftypes.NewValue(tftypes.Bool, false), "major": unknownNum, "include_any_minor_value": anyTrue}},
+		{"minor unknown", map[string]tftypes.Value{"include_any_minor_value": tftypes.NewValue(tftypes.Bool, false), "minor": unknownNum, "include_any_major_value": anyTrue}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := resource.ValidateConfigRequest{Config: ibeaconConfig(t, tc.attrs)}
+			var resp resource.ValidateConfigResponse
+			includeAnyMajorMinorConfigValidator{}.ValidateResource(context.Background(), req, &resp)
+			if resp.Diagnostics.HasError() {
+				t.Errorf("validator must defer on unknown axis value, got %v", resp.Diagnostics)
+			}
+		})
 	}
 }

--- a/internal/resources/pro/inventory/mobile_device_extension_attribute/validators_test.go
+++ b/internal/resources/pro/inventory/mobile_device_extension_attribute/validators_test.go
@@ -42,6 +42,24 @@ func popup(vs ...string) tftypes.Value {
 	return tftypes.NewValue(tftypes.Set{ElementType: tftypes.String}, elems)
 }
 
+// TestInputTypeValidator_Mobile_DefersOnUnknownCompanion is the §436 regression
+// guard: when input_type = DIRECTORY_SERVICE_ATTRIBUTE_MAPPING (known) but the
+// required directory_service_attribute is unknown (variable/for_each/resource-
+// driven), the validator MUST defer, not treat unknown as missing and error.
+// See STYLE_GUIDE "Config-time validators MUST defer on unknown values".
+func TestInputTypeValidator_Mobile_DefersOnUnknownCompanion(t *testing.T) {
+	unknown := tftypes.NewValue(tftypes.String, tftypes.UnknownValue)
+	req := resource.ValidateConfigRequest{Config: configFromAttrs(t, map[string]tftypes.Value{
+		"input_type":                  str("DIRECTORY_SERVICE_ATTRIBUTE_MAPPING"),
+		"directory_service_attribute": unknown,
+	})}
+	var resp resource.ValidateConfigResponse
+	inputTypeConfigValidator{}.ValidateResource(context.Background(), req, &resp)
+	if resp.Diagnostics.HasError() {
+		t.Errorf("validator must defer when directory_service_attribute is unknown, got %v", resp.Diagnostics)
+	}
+}
+
 func TestInputTypeValidator_Mobile(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/internal/resources/pro/inventory/printer/validators_test.go
+++ b/internal/resources/pro/inventory/printer/validators_test.go
@@ -8,9 +8,52 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
 )
+
+// printerConfig builds a tfsdk.Config from the real resource schema, filling
+// every attribute null except those supplied in attrs (keyed by attribute
+// name), so useGenericPPDConfigValidator can be driven end-to-end.
+func printerConfig(t *testing.T, attrs map[string]tftypes.Value) tfsdk.Config {
+	t.Helper()
+	r := NewPrinterResource()
+	var sr resource.SchemaResponse
+	r.(*PrinterResource).Schema(context.Background(), resource.SchemaRequest{}, &sr)
+	if sr.Diagnostics.HasError() {
+		t.Fatalf("schema diagnostics: %v", sr.Diagnostics)
+	}
+	objType := sr.Schema.Type().TerraformType(context.Background()).(tftypes.Object)
+	values := map[string]tftypes.Value{}
+	for name, typ := range objType.AttributeTypes {
+		if v, ok := attrs[name]; ok {
+			values[name] = v
+			continue
+		}
+		values[name] = tftypes.NewValue(typ, nil)
+	}
+	return tfsdk.Config{Schema: sr.Schema, Raw: tftypes.NewValue(objType, values)}
+}
+
+// TestUseGenericPPDConfigValidator_DefersOnUnknownPPDPath is the §436 regression
+// guard: with use_generic = false (known) and ppd_path UNKNOWN (variable /
+// for_each / resource-driven), the validator MUST defer, not treat unknown as
+// missing and error. See STYLE_GUIDE "Config-time validators MUST defer on
+// unknown values".
+func TestUseGenericPPDConfigValidator_DefersOnUnknownPPDPath(t *testing.T) {
+	req := resource.ValidateConfigRequest{Config: printerConfig(t, map[string]tftypes.Value{
+		"use_generic": tftypes.NewValue(tftypes.Bool, false),
+		"ppd_path":    tftypes.NewValue(tftypes.String, tftypes.UnknownValue),
+	})}
+	var resp resource.ValidateConfigResponse
+	useGenericPPDConfigValidator{}.ValidateResource(context.Background(), req, &resp)
+	if resp.Diagnostics.HasError() {
+		t.Errorf("validator must defer when ppd_path is unknown, got %v", resp.Diagnostics)
+	}
+}
 
 // Constructing a tfsdk.Config to drive the resource.ConfigValidator at unit
 // scope is brittle (requires hand-rolling a tftypes.Object that matches the

--- a/internal/resources/pro/settings/ldap_server/validators.go
+++ b/internal/resources/pro/settings/ldap_server/validators.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
 // accountAuthConfigValidator enforces the relationship between
@@ -34,24 +35,39 @@ func (v accountAuthConfigValidator) MarkdownDescription(ctx context.Context) str
 }
 
 // ValidateResource implements the plan-time cross-field check.
+//
+// Every attribute it reads is fetched as its typed value via GetAttribute and
+// guarded on IsUnknown before absence is treated as an error. A decode into the
+// Go model (`req.Config.Get`) would collapse an unknown `account` block to a nil
+// pointer, false-erroring "account required" whenever the block is sourced from
+// a variable / another resource. (STYLE_GUIDE §"Config-time validators MUST
+// defer on unknown values".)
 func (accountAuthConfigValidator) ValidateResource(ctx context.Context, req resource.ValidateConfigRequest, resp *resource.ValidateConfigResponse) {
-	var data LdapServerResourceModel
-	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+	connPath := path.Root("connection_settings")
+	accountPath := connPath.AtName("account")
+
+	var authAttr types.String
+	resp.Diagnostics.Append(req.Config.GetAttribute(ctx, connPath.AtName("authentication_type"), &authAttr)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	if data.Connection == nil {
-		return
-	}
-
-	authAttr := data.Connection.AuthenticationType
 	if authAttr.IsNull() || authAttr.IsUnknown() {
 		return
 	}
 	auth := authAttr.ValueString()
-	hasAccount := data.Connection.Account != nil
 
-	accountPath := path.Root("connection_settings").AtName("account")
+	var account types.Object
+	resp.Diagnostics.Append(req.Config.GetAttribute(ctx, accountPath, &account)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	// Defer when the account block itself is unknown — its eventual presence is
+	// unknowable at plan time, so neither the "required" nor the "forbidden"
+	// branch can fire safely.
+	if account.IsUnknown() {
+		return
+	}
+	hasAccount := !account.IsNull()
 
 	if auth == authTypeNone {
 		if hasAccount {
@@ -73,8 +89,15 @@ func (accountAuthConfigValidator) ValidateResource(ctx context.Context, req reso
 		return
 	}
 
-	dn := data.Connection.Account.DistinguishedUsername
-	if dn.IsNull() || (!dn.IsUnknown() && dn.ValueString() == "") {
+	var dn types.String
+	resp.Diagnostics.Append(req.Config.GetAttribute(ctx, accountPath.AtName("distinguished_username"), &dn)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	if dn.IsUnknown() {
+		return
+	}
+	if dn.IsNull() || dn.ValueString() == "" {
 		resp.Diagnostics.AddAttributeError(
 			accountPath.AtName("distinguished_username"),
 			"distinguished_username required for authenticated bind",

--- a/internal/resources/pro/settings/ldap_server/validators_test.go
+++ b/internal/resources/pro/settings/ldap_server/validators_test.go
@@ -1,0 +1,142 @@
+// Copyright Jamf Software LLC 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package ldap_server
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+)
+
+// ldapSchemaTypes returns the top-level, connection_settings, and account
+// tftypes.Object shapes from the real resource schema, so the validator can be
+// driven against a config matching the production schema.
+func ldapSchemaTypes(t *testing.T) (sr resource.SchemaResponse, objType, connType, accountType tftypes.Object) {
+	t.Helper()
+	r := NewLdapServerResource()
+	r.(*LdapServerResource).Schema(context.Background(), resource.SchemaRequest{}, &sr)
+	if sr.Diagnostics.HasError() {
+		t.Fatalf("schema diagnostics: %v", sr.Diagnostics)
+	}
+	objType = sr.Schema.Type().TerraformType(context.Background()).(tftypes.Object)
+	connType = objType.AttributeTypes["connection_settings"].(tftypes.Object)
+	accountType = connType.AttributeTypes["account"].(tftypes.Object)
+	return sr, objType, connType, accountType
+}
+
+// ldapConfig builds a tfsdk.Config with the given authentication_type value and
+// account block value, filling every other attribute null.
+func ldapConfig(t *testing.T, authVal, account tftypes.Value) tfsdk.Config {
+	t.Helper()
+	sr, objType, connType, _ := ldapSchemaTypes(t)
+
+	connVals := map[string]tftypes.Value{}
+	for n, ty := range connType.AttributeTypes {
+		connVals[n] = tftypes.NewValue(ty, nil)
+	}
+	connVals["authentication_type"] = authVal
+	connVals["account"] = account
+
+	topVals := map[string]tftypes.Value{}
+	for n, ty := range objType.AttributeTypes {
+		topVals[n] = tftypes.NewValue(ty, nil)
+	}
+	topVals["connection_settings"] = tftypes.NewValue(connType, connVals)
+	return tfsdk.Config{Schema: sr.Schema, Raw: tftypes.NewValue(objType, topVals)}
+}
+
+// ldapAccount builds an account block value with the supplied
+// distinguished_username and every other sub-attribute null.
+func ldapAccount(t *testing.T, dn tftypes.Value) tftypes.Value {
+	t.Helper()
+	_, _, _, accountType := ldapSchemaTypes(t)
+	vals := map[string]tftypes.Value{}
+	for n, ty := range accountType.AttributeTypes {
+		vals[n] = tftypes.NewValue(ty, nil)
+	}
+	vals["distinguished_username"] = dn
+	return tftypes.NewValue(accountType, vals)
+}
+
+func runLdapAccountValidator(t *testing.T, cfg tfsdk.Config) resource.ValidateConfigResponse {
+	t.Helper()
+	var resp resource.ValidateConfigResponse
+	accountAuthConfigValidator{}.ValidateResource(context.Background(), resource.ValidateConfigRequest{Config: cfg}, &resp)
+	return resp
+}
+
+func ldapStr(s string) tftypes.Value { return tftypes.NewValue(tftypes.String, s) }
+
+// TestAccountAuthValidator_DefersOnUnknownAccount is the §436 regression guard:
+// with authentication_type known (non-"none") and the account block UNKNOWN
+// (e.g. `account = var.x`), the validator MUST defer — a decode into the Go
+// model would collapse the unknown block to a nil pointer and false-error
+// "account required". See STYLE_GUIDE "Config-time validators MUST defer on
+// unknown values".
+func TestAccountAuthValidator_DefersOnUnknownAccount(t *testing.T) {
+	_, _, _, accountType := ldapSchemaTypes(t)
+	cfg := ldapConfig(t, ldapStr("simple"), tftypes.NewValue(accountType, tftypes.UnknownValue))
+	if resp := runLdapAccountValidator(t, cfg); resp.Diagnostics.HasError() {
+		t.Errorf("validator must defer when the account block is unknown, got %v", resp.Diagnostics)
+	}
+}
+
+// TestAccountAuthValidator_DefersOnUnknownAuthType confirms an unknown
+// authentication_type also defers.
+func TestAccountAuthValidator_DefersOnUnknownAuthType(t *testing.T) {
+	_, _, _, accountType := ldapSchemaTypes(t)
+	cfg := ldapConfig(t, tftypes.NewValue(tftypes.String, tftypes.UnknownValue), tftypes.NewValue(accountType, nil))
+	if resp := runLdapAccountValidator(t, cfg); resp.Diagnostics.HasError() {
+		t.Errorf("validator must defer when authentication_type is unknown, got %v", resp.Diagnostics)
+	}
+}
+
+// TestAccountAuthValidator_DefersOnUnknownDN confirms an unknown
+// distinguished_username (account present) defers.
+func TestAccountAuthValidator_DefersOnUnknownDN(t *testing.T) {
+	cfg := ldapConfig(t, ldapStr("simple"), ldapAccount(t, tftypes.NewValue(tftypes.String, tftypes.UnknownValue)))
+	if resp := runLdapAccountValidator(t, cfg); resp.Diagnostics.HasError() {
+		t.Errorf("validator must defer when distinguished_username is unknown, got %v", resp.Diagnostics)
+	}
+}
+
+func TestAccountAuthValidator_AccountRequiredForAuthenticated(t *testing.T) {
+	_, _, _, accountType := ldapSchemaTypes(t)
+	cfg := ldapConfig(t, ldapStr("simple"), tftypes.NewValue(accountType, nil))
+	if resp := runLdapAccountValidator(t, cfg); !resp.Diagnostics.HasError() {
+		t.Error("expected error: account required when authentication_type != none")
+	}
+}
+
+func TestAccountAuthValidator_AccountForbiddenForNone(t *testing.T) {
+	cfg := ldapConfig(t, ldapStr(authTypeNone), ldapAccount(t, ldapStr("CN=svc,DC=example,DC=com")))
+	if resp := runLdapAccountValidator(t, cfg); !resp.Diagnostics.HasError() {
+		t.Error("expected error: account forbidden when authentication_type = none")
+	}
+}
+
+func TestAccountAuthValidator_DNRequiredForAuthenticated(t *testing.T) {
+	cfg := ldapConfig(t, ldapStr("simple"), ldapAccount(t, tftypes.NewValue(tftypes.String, nil)))
+	if resp := runLdapAccountValidator(t, cfg); !resp.Diagnostics.HasError() {
+		t.Error("expected error: distinguished_username required when authentication_type != none")
+	}
+}
+
+func TestAccountAuthValidator_HappyAnonymous(t *testing.T) {
+	_, _, _, accountType := ldapSchemaTypes(t)
+	cfg := ldapConfig(t, ldapStr(authTypeNone), tftypes.NewValue(accountType, nil))
+	if resp := runLdapAccountValidator(t, cfg); resp.Diagnostics.HasError() {
+		t.Errorf("anonymous bind with no account must pass, got %v", resp.Diagnostics)
+	}
+}
+
+func TestAccountAuthValidator_HappyAuthenticated(t *testing.T) {
+	cfg := ldapConfig(t, ldapStr("simple"), ldapAccount(t, ldapStr("CN=svc,DC=example,DC=com")))
+	if resp := runLdapAccountValidator(t, cfg); resp.Diagnostics.HasError() {
+		t.Errorf("authenticated bind with account+dn must pass, got %v", resp.Diagnostics)
+	}
+}

--- a/internal/resources/pro/volume_purchasing/vpp_invitation/validators_test.go
+++ b/internal/resources/pro/volume_purchasing/vpp_invitation/validators_test.go
@@ -82,3 +82,34 @@ func TestEmailValidator_SelfServiceNoRequirement(t *testing.T) {
 		t.Errorf("non-email mode must not require email fields, got %d errors", errs)
 	}
 }
+
+// TestEmailValidator_DefersOnUnknownFields is the §436 regression guard: with
+// distribution_method = "Send emails" (known) but the required sender / subject
+// / message fields UNKNOWN (variable/for_each/resource-driven), the validator
+// MUST defer, not treat unknown as missing and error. (buildConfig's setStr
+// cannot represent unknown, so this builds the config directly.) See
+// STYLE_GUIDE "Config-time validators MUST defer on unknown values".
+func TestEmailValidator_DefersOnUnknownFields(t *testing.T) {
+	r := NewVPPInvitationResource()
+	var sr resource.SchemaResponse
+	r.(*VPPInvitationResource).Schema(context.Background(), resource.SchemaRequest{}, &sr)
+	if sr.Diagnostics.HasError() {
+		t.Fatalf("schema diags: %v", sr.Diagnostics)
+	}
+	objType := sr.Schema.Type().TerraformType(context.Background()).(tftypes.Object)
+	vals := map[string]tftypes.Value{}
+	for name, ty := range objType.AttributeTypes {
+		vals[name] = tftypes.NewValue(ty, nil)
+	}
+	vals["distribution_method"] = tftypes.NewValue(tftypes.String, distributionMethodSendEmails)
+	for _, f := range []string{"sender_name", "sender_email_address", "subject", "message"} {
+		vals[f] = tftypes.NewValue(tftypes.String, tftypes.UnknownValue)
+	}
+	cfg := tfsdk.Config{Raw: tftypes.NewValue(objType, vals), Schema: sr.Schema}
+
+	resp := &resource.ValidateConfigResponse{}
+	emailModeRequiresFieldsValidator{}.ValidateResource(context.Background(), resource.ValidateConfigRequest{Config: cfg}, resp)
+	if errs := len(resp.Diagnostics.Errors()); errs != 0 {
+		t.Errorf("validator must defer when required email fields are unknown, got %d errors: %v", errs, resp.Diagnostics)
+	}
+}


### PR DESCRIPTION
## Phase 10 — STYLE_GUIDE compliance sweep (validator slice)

First slice of the [Audit] STYLE_GUIDE compliance sweep card. Covers the config-time validator rules (§397 cross-field validation, §436/§441 defer-on-unknown) across every Jamf Pro construct.

### Audit result
- **Deterministic rules clean provider-wide** (all 93 resource dirs + actions): `crud.go` SDK-endpoints annotation + `Last reviewed` date (none stale vs quarterly cadence), `minJamfProVersion` const, `ConfigurePro` funnel.
- **21 resources carry hand-rolled config validators** → each checked against §397/§436. Net: **1 code bug + 6 missing regression tests**. Three candidates were ruled out: `vpp_invitation` & `directory_binding` are forbidden-when / scalar-`IsNull` safe, `webhook` is fully compliant, `cloud_distribution_point` already has unknown-defer coverage via `types.StringUnknown()`.

### Changes
| File | Change |
|---|---|
| `ldap_server/validators.go` | **§441 fix** — read `authentication_type` / `account` / `distinguished_username` via `GetAttribute` as typed values and defer on `IsUnknown` before the required-when branch. Previously decoded into the Go model, collapsing an unknown `account` block to a nil pointer and false-erroring "account required" when `account` was sourced from a variable / another resource. |
| `ldap_server/validators_test.go` | **new** — 3 unknown-defer regressions + 5 firing/happy cases |
| computer/mobile_device `extension_attribute`, `printer`, `ibeacon`, `vpp_invitation` `validators_test.go` | §436 unknown-defer regression tests added |

### Incidental
`helpers/promoted_test.go` + `scope/proclassic_test.go`: `make fix` modernized the trivial pointer helpers to `new(expr)` + `//go:fix inline` (Go 1.26) and inlined all call sites; removed the now-unused wrapper defs that tripped the unused linter. Split into its own commit.

### Verification
- `make fix fmt lint test` — lint 0 issues, all unit tests pass.
- `make testacc-run` across the 6 affected packages — all acceptance tests pass.

### Not in this PR (remaining on the card)
The broad judgment-rule sweep — `types.List` vs `[]Model` for Computed nested, `UseNonNullStateForUnknown` on Optional+Computed nested, omit-vs-clear documentation, MarkdownDescription tone, `OneOf` single-source — across all 93 constructs. Tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)