### PR TITLE
chore(ci): drop acceptance job timeout, add go test -timeout=120m

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -62,7 +62,9 @@ jobs:
     name: Acceptance Tests
     needs: unit
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    # No job timeout-minutes: serial (-p=1) tenant suites can exceed an hour;
+    # rely on the GitHub default 6h job ceiling. Per-package limit is enforced
+    # by `go test -timeout` below (matches `make testacc`).
     environment: acceptance
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -83,7 +85,7 @@ jobs:
         id: acc
         run: |
           set -o pipefail
-          go test -v -cover -count=1 -tags=acceptance -p=1 ./... 2>&1 | tee test-output.log
+          go test -v -cover -count=1 -tags=acceptance -timeout=120m -p=1 ./... 2>&1 | tee test-output.log
         env:
           TF_ACC: "1"
 


### PR DESCRIPTION
Since #246 wired all gated env vars, serial (`-p=1`) tenant suites can run over an hour. The job's `timeout-minutes: 30` would hard-kill that.

- Remove `timeout-minutes` from the `acceptance` job → falls back to GitHub's default 6h job ceiling.
- Add `-timeout=120m` to `go test` so individual packages don't die at Go's 10m per-package default. Matches `make testacc`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)