### PR TITLE
fix(pro): snake_case policy script parameter attrs + v0→v1 upgrader

### DIFF
--- a/docs/resources/pro_policy.md
+++ b/docs/resources/pro_policy.md
@@ -507,14 +507,14 @@ Required:
 Optional:
 
 - `name` (String) Script display name. Returned by Jamf Pro.
-- `parameter10` (String) Parameter 10 passed to the script.
-- `parameter11` (String) Parameter 11 passed to the script.
-- `parameter4` (String) Parameter 4 passed to the script.
-- `parameter5` (String) Parameter 5 passed to the script.
-- `parameter6` (String) Parameter 6 passed to the script.
-- `parameter7` (String) Parameter 7 passed to the script.
-- `parameter8` (String) Parameter 8 passed to the script.
-- `parameter9` (String) Parameter 9 passed to the script.
+- `parameter_10` (String) Parameter 10 passed to the script.
+- `parameter_11` (String) Parameter 11 passed to the script.
+- `parameter_4` (String) Parameter 4 passed to the script.
+- `parameter_5` (String) Parameter 5 passed to the script.
+- `parameter_6` (String) Parameter 6 passed to the script.
+- `parameter_7` (String) Parameter 7 passed to the script.
+- `parameter_8` (String) Parameter 8 passed to the script.
+- `parameter_9` (String) Parameter 9 passed to the script.
 - `priority` (String) Run order.
 
 

--- a/internal/resources/pro/policy/model_types.go
+++ b/internal/resources/pro/policy/model_types.go
@@ -176,14 +176,14 @@ type PolicyScriptItemModel struct {
 	ID          types.String `tfsdk:"id"`
 	Name        types.String `tfsdk:"name"`
 	Priority    types.String `tfsdk:"priority"`
-	Parameter4  types.String `tfsdk:"parameter4"`
-	Parameter5  types.String `tfsdk:"parameter5"`
-	Parameter6  types.String `tfsdk:"parameter6"`
-	Parameter7  types.String `tfsdk:"parameter7"`
-	Parameter8  types.String `tfsdk:"parameter8"`
-	Parameter9  types.String `tfsdk:"parameter9"`
-	Parameter10 types.String `tfsdk:"parameter10"`
-	Parameter11 types.String `tfsdk:"parameter11"`
+	Parameter4  types.String `tfsdk:"parameter_4"`
+	Parameter5  types.String `tfsdk:"parameter_5"`
+	Parameter6  types.String `tfsdk:"parameter_6"`
+	Parameter7  types.String `tfsdk:"parameter_7"`
+	Parameter8  types.String `tfsdk:"parameter_8"`
+	Parameter9  types.String `tfsdk:"parameter_9"`
+	Parameter10 types.String `tfsdk:"parameter_10"`
+	Parameter11 types.String `tfsdk:"parameter_11"`
 }
 
 // PolicyPrintersModel models <policy><printers>.

--- a/internal/resources/pro/policy/resource.go
+++ b/internal/resources/pro/policy/resource.go
@@ -86,6 +86,7 @@ func (r *PolicyResource) IdentitySchema(ctx context.Context, req resource.Identi
 // element names are noted in attribute descriptions where they differ.
 func (r *PolicyResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = schema.Schema{
+		Version:             1,
 		MarkdownDescription: "Manages a Jamf Pro policy. Top-level blocks mirror the admin UI's tabs and Options sidebar: `general`, `scope`, `self_service`, `user_interaction`, and the Options payloads `packages`, `scripts`, `printers`, `disk_encryption`, `dock_items`, `local_accounts`, `management_account`, `directory_bindings`, `efi_password`, `restart_options`, `maintenance`, `files_and_processes`. Scope targets are flat sets of Jamf Pro IDs — interpolate `jamfplatform_device_group.x.jamf_pro_id` to bridge from Platform Services. The four account-maintenance payloads (`local_accounts`, `management_account`, `directory_bindings`, `efi_password`) are flattened peers of the UI sections; internally Jamf Pro stores them as a single `account_maintenance` object. The legacy Software Update and Conditional Access policy sections are **intentionally not modelled** — both are obsolete in Jamf Pro, superseded by MDM-driven app installs / OS update scheduling and the patch-management surface. If you need to drive OS or app updates from Terraform, reach for the patch / DDM resources instead.",
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
@@ -325,17 +326,17 @@ func (r *PolicyResource) Schema(ctx context.Context, req resource.SchemaRequest,
 						Optional:            true,
 						NestedObject: schema.NestedAttributeObject{
 							Attributes: map[string]schema.Attribute{
-								"id":          schema.StringAttribute{MarkdownDescription: "Script ID.", Required: true},
-								"name":        optComputedString("Script display name. Returned by Jamf Pro."),
-								"priority":    optComputedString("Run order."),
-								"parameter4":  optComputedString("Parameter 4 passed to the script."),
-								"parameter5":  optComputedString("Parameter 5 passed to the script."),
-								"parameter6":  optComputedString("Parameter 6 passed to the script."),
-								"parameter7":  optComputedString("Parameter 7 passed to the script."),
-								"parameter8":  optComputedString("Parameter 8 passed to the script."),
-								"parameter9":  optComputedString("Parameter 9 passed to the script."),
-								"parameter10": optComputedString("Parameter 10 passed to the script."),
-								"parameter11": optComputedString("Parameter 11 passed to the script."),
+								"id":           schema.StringAttribute{MarkdownDescription: "Script ID.", Required: true},
+								"name":         optComputedString("Script display name. Returned by Jamf Pro."),
+								"priority":     optComputedString("Run order."),
+								"parameter_4":  optComputedString("Parameter 4 passed to the script."),
+								"parameter_5":  optComputedString("Parameter 5 passed to the script."),
+								"parameter_6":  optComputedString("Parameter 6 passed to the script."),
+								"parameter_7":  optComputedString("Parameter 7 passed to the script."),
+								"parameter_8":  optComputedString("Parameter 8 passed to the script."),
+								"parameter_9":  optComputedString("Parameter 9 passed to the script."),
+								"parameter_10": optComputedString("Parameter 10 passed to the script."),
+								"parameter_11": optComputedString("Parameter 11 passed to the script."),
 							},
 						},
 					},

--- a/internal/resources/pro/policy/resource_acceptance_test.go
+++ b/internal/resources/pro/policy/resource_acceptance_test.go
@@ -922,9 +922,9 @@ resource "jamfplatform_pro_policy" "test" {
   scripts = {
     scripts = [
       {
-        id         = jamfplatform_pro_script.fixture.id
-        priority   = %q
-        parameter4 = %q
+        id          = jamfplatform_pro_script.fixture.id
+        priority    = %q
+        parameter_4 = %q
       },
     ]
   }
@@ -937,7 +937,7 @@ resource "jamfplatform_pro_policy" "test" {
 // references its ID from policy.scripts.scripts. The policy's wire form for
 // `priority` is `Before`/`After`/`At Reboot`, distinct from the fixture's
 // enum. Step 2 swaps priority and
-// parameter4 to exercise the Update path on the scripts set without
+// parameter_4 to exercise the Update path on the scripts set without
 // recreating the fixture.
 func TestAccPolicyResource_ScriptsFullCoverage(t *testing.T) {
 	testhelpers.AccPreCheck(t)
@@ -964,7 +964,7 @@ func TestAccPolicyResource_ScriptsFullCoverage(t *testing.T) {
 					),
 					statecheck.ExpectKnownValue(
 						"jamfplatform_pro_policy.test",
-						tfjsonpath.New("scripts").AtMapKey("scripts").AtSliceIndex(0).AtMapKey("parameter4"),
+						tfjsonpath.New("scripts").AtMapKey("scripts").AtSliceIndex(0).AtMapKey("parameter_4"),
 						knownvalue.StringExact("tf-acc-p4-initial"),
 					),
 				},
@@ -979,7 +979,7 @@ func TestAccPolicyResource_ScriptsFullCoverage(t *testing.T) {
 					),
 					statecheck.ExpectKnownValue(
 						"jamfplatform_pro_policy.test",
-						tfjsonpath.New("scripts").AtMapKey("scripts").AtSliceIndex(0).AtMapKey("parameter4"),
+						tfjsonpath.New("scripts").AtMapKey("scripts").AtSliceIndex(0).AtMapKey("parameter_4"),
 						knownvalue.StringExact("tf-acc-p4-updated"),
 					),
 				},

--- a/internal/resources/pro/policy/state_upgrader.go
+++ b/internal/resources/pro/policy/state_upgrader.go
@@ -1,0 +1,129 @@
+// Copyright Jamf Software LLC 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package policy
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
+)
+
+var _ resource.ResourceWithUpgradeState = &PolicyResource{}
+
+// UpgradeState migrates prior state versions to the current schema.
+//
+// v0 → v1: the script-assignment parameter attributes were renamed from
+// `parameter4`…`parameter11` to snake_case `parameter_4`…`parameter_11` to
+// align with the jamfplatform_pro_script resource and the provider-wide
+// snake_case attribute convention. The rename is a nested-object attribute
+// name change, which the framework cannot decode against the v1 schema
+// without an explicit migration, so we rewrite the affected keys in the raw
+// prior state JSON and re-emit it through the current schema type. Every
+// other attribute is carried across verbatim as raw JSON, so no value is
+// reinterpreted or lost.
+func (r *PolicyResource) UpgradeState(ctx context.Context) map[int64]resource.StateUpgrader {
+	return map[int64]resource.StateUpgrader{
+		0: {
+			StateUpgrader: func(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
+				if req.RawState == nil {
+					return
+				}
+
+				rewritten, err := renameScriptParameterKeys(req.RawState.JSON)
+				if err != nil {
+					resp.Diagnostics.AddError(
+						"Unable to upgrade jamfplatform_pro_policy state from v0 to v1",
+						fmt.Sprintf("Could not rewrite the renamed script parameter keys in prior state: %s", err),
+					)
+					return
+				}
+
+				var schemaResp resource.SchemaResponse
+				r.Schema(ctx, resource.SchemaRequest{}, &schemaResp)
+				schemaType := schemaResp.Schema.Type().TerraformType(ctx)
+
+				upgraded := tfprotov6.RawState{JSON: rewritten}
+				value, err := upgraded.Unmarshal(schemaType)
+				if err != nil {
+					resp.Diagnostics.AddError(
+						"Unable to upgrade jamfplatform_pro_policy state from v0 to v1",
+						fmt.Sprintf("Could not decode rewritten prior state against the current schema: %s", err),
+					)
+					return
+				}
+
+				dynamicValue, err := tfprotov6.NewDynamicValue(schemaType, value)
+				if err != nil {
+					resp.Diagnostics.AddError(
+						"Unable to upgrade jamfplatform_pro_policy state from v0 to v1",
+						fmt.Sprintf("Could not encode upgraded state: %s", err),
+					)
+					return
+				}
+
+				resp.DynamicValue = &dynamicValue
+			},
+		},
+	}
+}
+
+// renameScriptParameterKeys rewrites the prior-state JSON, renaming each
+// scripts.scripts[*].parameterN key to parameter_N (N = 4..11). All other
+// state is preserved as raw JSON bytes — only the eight affected keys are
+// touched — so numeric IDs and other values keep their exact representation.
+func renameScriptParameterKeys(rawJSON []byte) ([]byte, error) {
+	var top map[string]json.RawMessage
+	if err := json.Unmarshal(rawJSON, &top); err != nil {
+		return nil, err
+	}
+
+	scriptsRaw, ok := top["scripts"]
+	if !ok || string(scriptsRaw) == "null" {
+		return rawJSON, nil
+	}
+
+	var scriptsBlock map[string]json.RawMessage
+	if err := json.Unmarshal(scriptsRaw, &scriptsBlock); err != nil {
+		return nil, err
+	}
+
+	itemsRaw, ok := scriptsBlock["scripts"]
+	if !ok || string(itemsRaw) == "null" {
+		return rawJSON, nil
+	}
+
+	var items []map[string]json.RawMessage
+	if err := json.Unmarshal(itemsRaw, &items); err != nil {
+		return nil, err
+	}
+
+	for _, item := range items {
+		for n := 4; n <= 11; n++ {
+			oldKey := fmt.Sprintf("parameter%d", n)
+			value, present := item[oldKey]
+			if !present {
+				continue
+			}
+			item[fmt.Sprintf("parameter_%d", n)] = value
+			delete(item, oldKey)
+		}
+	}
+
+	newItems, err := json.Marshal(items)
+	if err != nil {
+		return nil, err
+	}
+	scriptsBlock["scripts"] = newItems
+
+	newScripts, err := json.Marshal(scriptsBlock)
+	if err != nil {
+		return nil, err
+	}
+	top["scripts"] = newScripts
+
+	return json.Marshal(top)
+}

--- a/internal/resources/pro/policy/state_upgrader_test.go
+++ b/internal/resources/pro/policy/state_upgrader_test.go
@@ -1,0 +1,98 @@
+// Copyright Jamf Software LLC 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package policy
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+)
+
+// TestRenameScriptParameterKeys verifies the v0→v1 key rename rewrites every
+// parameterN key under scripts.scripts[*] to parameter_N, leaves all other
+// state untouched, and is a no-op when the scripts block is absent or null.
+func TestRenameScriptParameterKeys(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		in   string
+		want string // canonical-compared as JSON; "" means equal to in
+	}{
+		{
+			name: "renames populated parameters and preserves siblings",
+			in: `{
+				"id": "123",
+				"general": {"name": "p", "frequency": "Ongoing"},
+				"scripts": {"scripts": [
+					{"id": "9", "priority": "Before", "parameter4": "a", "parameter11": "b"}
+				]}
+			}`,
+			want: `{
+				"id": "123",
+				"general": {"name": "p", "frequency": "Ongoing"},
+				"scripts": {"scripts": [
+					{"id": "9", "priority": "Before", "parameter_4": "a", "parameter_11": "b"}
+				]}
+			}`,
+		},
+		{
+			name: "preserves null-valued parameters as null under the new key",
+			in: `{"scripts": {"scripts": [
+				{"id": "9", "parameter4": null, "parameter5": "set"}
+			]}}`,
+			want: `{"scripts": {"scripts": [
+				{"id": "9", "parameter_4": null, "parameter_5": "set"}
+			]}}`,
+		},
+		{
+			name: "handles multiple script items independently",
+			in: `{"scripts": {"scripts": [
+				{"id": "1", "parameter4": "x"},
+				{"id": "2", "parameter10": "y"}
+			]}}`,
+			want: `{"scripts": {"scripts": [
+				{"id": "1", "parameter_4": "x"},
+				{"id": "2", "parameter_10": "y"}
+			]}}`,
+		},
+		{
+			name: "no-op when scripts is null",
+			in:   `{"id": "1", "scripts": null}`,
+			want: `{"id": "1", "scripts": null}`,
+		},
+		{
+			name: "no-op when scripts.scripts is null",
+			in:   `{"scripts": {"scripts": null}}`,
+			want: `{"scripts": {"scripts": null}}`,
+		},
+		{
+			name: "no-op when scripts block absent",
+			in:   `{"id": "1", "general": {"name": "p"}}`,
+			want: `{"id": "1", "general": {"name": "p"}}`,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := renameScriptParameterKeys([]byte(tc.in))
+			if err != nil {
+				t.Fatalf("renameScriptParameterKeys returned error: %s", err)
+			}
+
+			var gotVal, wantVal any
+			if err := json.Unmarshal(got, &gotVal); err != nil {
+				t.Fatalf("output is not valid JSON: %s", err)
+			}
+			if err := json.Unmarshal([]byte(tc.want), &wantVal); err != nil {
+				t.Fatalf("want fixture is not valid JSON: %s", err)
+			}
+			if !reflect.DeepEqual(gotVal, wantVal) {
+				t.Errorf("rewritten state mismatch:\n got: %s\nwant: %s", got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What

Renames the `jamfplatform_pro_policy` `scripts.scripts[*]` parameter attributes from `parameter4`…`parameter11` to **`parameter_4`…`parameter_11`**.

This aligns the policy resource with the `jamfplatform_pro_script` resource (which already uses `parameter_4`…`parameter_11`) and the provider-wide snake_case attribute convention. The glued `parameter4` form was the outlier — a real footgun when copying a label between the two resources.

## Breaking change + state migration

This is a breaking attribute rename. Since prerelease tags are now published, existing state can carry the old nested keys, which would **fail to decode** against the new schema (a renamed nested-object attribute, not a silent drop).

- Schema `Version` bumped `0 → 1`.
- New `state_upgrader.go` migrates v0 → v1 by rewriting only the affected keys in the raw prior-state JSON (`map[string]json.RawMessage`), then re-emitting through the current schema type via `tfprotov6.RawState{JSON:...}.Unmarshal` → `NewDynamicValue`. Every other attribute is carried across verbatim as raw JSON — no value is reinterpreted or lost.

> ⚠️ The upgrader fixes **state** only. Configs (`.tf`) referencing the old `parameter4` names must be updated to `parameter_4`.

## Testing

- Unit test (`TestRenameScriptParameterKeys`) covers populated params, null params, multiple items, and the no-op cases (scripts absent / null / scripts.scripts null).
- An `ExternalProviders` → factory **acceptance** test was evaluated and dropped: it fails at step-2 `terraform init` on the stale dependency lock written by the registry-installed prior version (locked `0.18.0-rc.1` vs empty constraint, no `init -upgrade` knob between steps) — a known terraform-plugin-testing limitation. This matches the two existing upgraders (`blueprint`, `device_group`), which are unit-tested only.
- `go build ./...`, `go vet -tags acceptance`, `go fix`/`fmt`, `golangci-lint` (0 issues), unit tests, and `make generate` (docs) all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)