### PR TITLE
test(account): un-skip base-field update acc test + refresh stale gateway-403 docs

### DIFF
--- a/docs/resources/pro_account.md
+++ b/docs/resources/pro_account.md
@@ -3,12 +3,12 @@
 page_title: "jamfplatform_pro_account Resource - terraform-provider-jamfplatform"
 subcategory: ""
 description: |-
-  Manages a Jamf Pro administrator login account — a person who signs in to Jamf Pro. This is NOT the jamfplatform_pro_user inventory construct (end-user/device records). A Custom privilege grid can be assigned via the privileges block. In-place updates to base account fields (username, full name, email, access level, etc.) are not currently accepted by Jamf Pro and will return an error; only privilege changes can be applied to an existing account. Changing account_type forces the account to be replaced.
+  Manages a Jamf Pro administrator login account — a person who signs in to Jamf Pro. This is NOT the jamfplatform_pro_user inventory construct (end-user/device records). A Custom privilege grid can be assigned via the privileges block. In-place updates to base account fields (username, full name, email, access level, etc.) are applied via the Jamf Pro API. Changing account_type forces the account to be replaced.
 ---
 
 # jamfplatform_pro_account (Resource)
 
-Manages a Jamf Pro **administrator login account** — a person who signs in to Jamf Pro. This is NOT the `jamfplatform_pro_user` inventory construct (end-user/device records). A Custom privilege grid can be assigned via the `privileges` block. **In-place updates to base account fields (username, full name, email, access level, etc.) are not currently accepted by Jamf Pro and will return an error; only privilege changes can be applied to an existing account.** Changing `account_type` forces the account to be replaced.
+Manages a Jamf Pro **administrator login account** — a person who signs in to Jamf Pro. This is NOT the `jamfplatform_pro_user` inventory construct (end-user/device records). A Custom privilege grid can be assigned via the `privileges` block. In-place updates to base account fields (username, full name, email, access level, etc.) are applied via the Jamf Pro API. Changing `account_type` forces the account to be replaced.
 
 ## Example Usage
 

--- a/internal/resources/pro/account/crud.go
+++ b/internal/resources/pro/account/crud.go
@@ -4,14 +4,14 @@
 // SDK endpoints used:
 //   pro.CreateAccountV1               (POST /accounts; sets accountType incl. FEDERATED)
 //   pro.GetAccountV1                  (base-field read)
-//   pro.UpdateAccountV1              (PUT base fields; gateway-403 until perm lands)
+//   pro.UpdateAccountV1               (PUT base fields)
 //   pro.DeleteAccountV1
 //   pro.ResolveAccountV1IDByName      (data source username lookup)
 //   proclassic.GetAccountByUserID     (Custom privilege grid read)
 //   proclassic.UpdateAccountByUserID  (Custom privilege grid write — merge)
 //   proclassic.ListAccounts           (privilege-catalog discovery, ModifyPlan)
 //
-// Status: current. Last reviewed 2026-06-12.
+// Status: current. Last reviewed 2026-06-24.
 
 package account
 
@@ -170,10 +170,10 @@ func (r *AccountResource) Read(ctx context.Context, req resource.ReadRequest, re
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 }
 
-// Update applies base-field changes via Pro PUT (currently gateway-403 until the
-// permission lands) and Custom privilege changes via the classic API. Each side
-// is called only when its inputs actually changed, so a privilege-only edit does
-// not trip the Pro PUT permission gap.
+// Update applies base-field changes via Pro PUT and Custom privilege changes via
+// the classic API. Each side is called only when its inputs actually changed, so
+// a privilege-only edit skips the Pro PUT and a base-only edit skips the classic
+// write.
 func (r *AccountResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
 	var plan, state, cfg AccountResourceModel
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)

--- a/internal/resources/pro/account/model_types.go
+++ b/internal/resources/pro/account/model_types.go
@@ -17,8 +17,7 @@ import (
 // hybrid: created via the Pro v1 /accounts API (the only path that can set
 // accountType, including FEDERATED), with the Custom privilege grid carried via
 // the ProClassic /accounts/userid endpoint. Base-field updates route through Pro
-// PUT (currently gateway-403 until the permission lands); privilege updates route
-// through classic.
+// PUT; privilege updates route through classic.
 type AccountResourceModel struct {
 	ID                  types.String             `tfsdk:"id"`
 	Username            types.String             `tfsdk:"username"`

--- a/internal/resources/pro/account/resource.go
+++ b/internal/resources/pro/account/resource.go
@@ -12,10 +12,9 @@
 //   - ProClassic /accounts/userid: the Custom privilege grid (read + write),
 //     which the Pro API cannot express.
 //
-// Base-field updates route through Pro PUT, which is currently rejected by the
-// platform gateway (403 BAD_PERMISSIONS) until that permission is granted;
-// privilege-only updates route through classic and work today. account_type is
-// RequiresReplace (classic cannot change it; only Pro create sets it).
+// Base-field updates route through Pro PUT; privilege-only updates route through
+// classic. account_type is RequiresReplace (classic cannot change it; only Pro
+// create sets it).
 package account
 
 import (
@@ -87,7 +86,7 @@ func (r *AccountResource) IdentitySchema(ctx context.Context, req resource.Ident
 // Schema returns the Terraform schema for the account resource.
 func (r *AccountResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = schema.Schema{
-		MarkdownDescription: "Manages a Jamf Pro **administrator login account** — a person who signs in to Jamf Pro. This is NOT the `jamfplatform_pro_user` inventory construct (end-user/device records). A Custom privilege grid can be assigned via the `privileges` block. **In-place updates to base account fields (username, full name, email, access level, etc.) are not currently accepted by Jamf Pro and will return an error; only privilege changes can be applied to an existing account.** Changing `account_type` forces the account to be replaced.",
+		MarkdownDescription: "Manages a Jamf Pro **administrator login account** — a person who signs in to Jamf Pro. This is NOT the `jamfplatform_pro_user` inventory construct (end-user/device records). A Custom privilege grid can be assigned via the `privileges` block. In-place updates to base account fields (username, full name, email, access level, etc.) are applied via the Jamf Pro API. Changing `account_type` forces the account to be replaced.",
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
 				MarkdownDescription: "Account ID assigned by Jamf Pro.",

--- a/internal/resources/pro/account/resource_acceptance_test.go
+++ b/internal/resources/pro/account/resource_acceptance_test.go
@@ -5,8 +5,8 @@
 
 // Tests in this file create real Jamf Pro administrator accounts via the Pro API
 // and write the privilege grid via the classic API. Base-field updates route
-// through Pro PUT, which the platform gateway currently rejects (403); that path
-// is covered by a separately-skipped test until the permission lands.
+// through Pro PUT (now accepted via the platform gateway) and are exercised by
+// TestAccResource_ProAccount_BaseUpdate.
 
 package account_test
 
@@ -114,9 +114,65 @@ func TestAccResource_ProAccount(t *testing.T) {
 	})
 }
 
-// TestAccResource_ProAccount_BaseUpdate exercises an in-place base-field update,
-// which routes through Pro PUT. This is currently rejected by the platform
-// gateway (403 BAD_PERMISSIONS); un-skip when that permission is granted.
+// baseAccountConfig renders a non-Custom (Auditor) account so the base-update
+// path is exercised in isolation: no Custom privilege grid means no classic
+// write, so only the Pro PUT base-field path runs.
+func baseAccountConfig(suffix, fullName, accessStatus string, passwordWOVersion int) string {
+	return fmt.Sprintf(`
+resource "jamfplatform_pro_account" "test" {
+  username      = "tf-acc-base-%[1]s"
+  full_name     = %[2]q
+  email_address = "tf-acc-base-%[1]s@example.invalid"
+  access_level  = "Full Access"
+  privilege_set = "Auditor"
+  access_status = %[3]q
+
+  password            = "Pr0bePassw0rd-%[1]s-v%[4]d"
+  password_wo_version = %[4]d
+}
+`, suffix, fullName, accessStatus, passwordWOVersion)
+}
+
+// TestAccResource_ProAccount_BaseUpdate exercises in-place base-field updates,
+// which route through Pro PUT. Step 2 changes plain base fields (full name,
+// access status); step 3 rotates the WriteOnly password (bumped wo_version →
+// password re-sent on the same PUT). Both confirm the gateway now accepts the
+// Pro update that previously returned 403 BAD_PERMISSIONS.
 func TestAccResource_ProAccount_BaseUpdate(t *testing.T) {
-	t.Skip("base-field updates route through Pro PUT, which the platform gateway currently rejects with 403; un-skip when the Pro update permission lands")
+	suffix := testhelpers.RunSuffix()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testhelpers.AccPreCheck(t) },
+		ProtoV6ProviderFactories: testhelpers.AccTestProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckAccountDestroy(t),
+		Steps: []resource.TestStep{
+			{
+				Config: baseAccountConfig(suffix, "TF Acc Base", "Enabled", 1),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("jamfplatform_pro_account.test", "id"),
+					resource.TestCheckResourceAttr("jamfplatform_pro_account.test", "full_name", "TF Acc Base"),
+					resource.TestCheckResourceAttr("jamfplatform_pro_account.test", "access_status", "Enabled"),
+					resource.TestCheckResourceAttr("jamfplatform_pro_account.test", "privilege_set", "Auditor"),
+				),
+			},
+			{
+				// In-place base-field update (no password change ⇒ Pro PUT without
+				// re-sending the password).
+				Config: baseAccountConfig(suffix, "TF Acc Base Renamed", "Disabled", 1),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("jamfplatform_pro_account.test", "full_name", "TF Acc Base Renamed"),
+					resource.TestCheckResourceAttr("jamfplatform_pro_account.test", "access_status", "Disabled"),
+				),
+			},
+			{
+				// Password rotation: bump password_wo_version ⇒ password re-sent on
+				// the Pro PUT.
+				Config: baseAccountConfig(suffix, "TF Acc Base Renamed", "Disabled", 2),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("jamfplatform_pro_account.test", "password_wo_version", "2"),
+					resource.TestCheckResourceAttr("jamfplatform_pro_account.test", "full_name", "TF Acc Base Renamed"),
+				),
+			},
+		},
+	})
 }

--- a/internal/resources/pro/account_group/crud.go
+++ b/internal/resources/pro/account_group/crud.go
@@ -1,17 +1,16 @@
 // Copyright Jamf Software LLC 2026
 // SPDX-License-Identifier: MPL-2.0
 
-// SDK endpoints used:
+// SDK endpoints used (Pro v1 /account-groups is read-only AND gateway-blocked,
+// so every surface — resource, data source, list — goes through ProClassic):
 //   proclassic.CreateAccountGroupByID   (POST id="0")
-//   proclassic.GetAccountGroupByID
+//   proclassic.GetAccountGroupByID      (read; data source id lookup; list expand)
+//   proclassic.GetAccountGroupByName    (data source name lookup)
 //   proclassic.UpdateAccountGroupByID   (PUT, 201 empty body)
 //   proclassic.DeleteAccountGroupByID
-//   proclassic.ListAccounts             (privilege-catalog discovery, ModifyPlan)
-//   pro.ListAccountGroupsV1             (data source / list resource)
-//   pro.GetAccountGroupV1               (data source id lookup)
-//   pro.ResolveAccountGroupV1IDByName   (data source name lookup)
+//   proclassic.ListAccounts             (list-resource enumeration; privilege-catalog discovery in ModifyPlan)
 //
-// Status: current. Last reviewed 2026-06-12.
+// Status: current. Last reviewed 2026-06-24.
 
 package account_group
 


### PR DESCRIPTION
## What

The platform gateway now accepts **Pro v1 `PUT /accounts`**, which previously returned `403 BAD_PERMISSIONS`. This was the only thing keeping `jamfplatform_pro_account` in-place base-field updates dark.

- **Un-skip + write the real `TestAccResource_ProAccount_BaseUpdate`** (was a `t.Skip` stub):
  1. create a non-Custom (`Auditor` + `Full Access`) account — isolates the Pro PUT path, no classic privilege write,
  2. change base fields (`full_name`, `access_status`) **without** re-sending the password,
  3. rotate the password via `password_wo_version` bump.
- **Refresh stale "gateway-403 / not currently accepted" framing** in `resource.go` (package doc + the user-facing schema description that wrongly told users base updates would error), `crud.go`, `model_types.go`, and the acc-test header. Regenerated `docs/resources/pro_account.md`.
- **Fix the `account_group` `crud.go` SDK-endpoints annotation** — it listed three `pro.*` v1 endpoints the code no longer calls; the data source and list resource were re-sourced to ProClassic (the Pro v1 `/account-groups` read is itself gateway-blocked). Comment-only.

## Wire probe

Verified the one behaviour the new test can't assert (a wiped password leaves the account present, so assertions would still pass). Against the platform gateway → `nmartin.jamfcloud.com`:

| step | correct pw | wrong pw (control) |
|---|---|---|
| baseline (after create) | `200` token | `401` |
| after base-field PUT **omitting** `plainPassword` | `200` token | `401` |

A password-less PUT **preserves** the password — so the resource is correct to skip re-sending the password when it hasn't rotated. The negative control proves the token endpoint genuinely validates (not a false-positive 200).

## Testing

- `make fix fmt lint test` ✅ · `make generate` (only `pro_account.md` changed) ✅ · `go vet -tags acceptance` ✅
- `TestAccResource_ProAccount_BaseUpdate` — **acc passing** (confirmed by maintainer).
- `account_group` change is comment-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)