### PR TITLE
fix(pro_package): stop blanking server-managed size on update

### DIFF
--- a/docs/data-sources/pro_package.md
+++ b/docs/data-sources/pro_package.md
@@ -3,12 +3,12 @@
 page_title: "jamfplatform_pro_package Data Source - terraform-provider-jamfplatform"
 subcategory: ""
 description: |-
-  Look up a Jamf Pro package by ID or by exact display name. Exactly one of id or display_name must be supplied. Returns the full record including manifest body, every hash populated by Jamf Pro, and JCDS transfer status.
+  Look up a Jamf Pro package by ID or by exact display name. Exactly one of id or display_name must be supplied. Returns the full record including manifest body, every hash populated by Jamf Pro, and cloud distribution point transfer status.
 ---
 
 # jamfplatform_pro_package (Data Source)
 
-Look up a Jamf Pro package by ID or by exact display name. Exactly one of `id` or `display_name` must be supplied. Returns the full record including manifest body, every hash populated by Jamf Pro, and JCDS transfer status.
+Look up a Jamf Pro package by ID or by exact display name. Exactly one of `id` or `display_name` must be supplied. Returns the full record including manifest body, every hash populated by Jamf Pro, and cloud distribution point transfer status.
 
 ## Example Usage
 
@@ -37,7 +37,7 @@ data "jamfplatform_pro_package" "by_name" {
 
 - `available_in_software_update` (Boolean) Available in Software Update flag.
 - `category_id` (String) Category ID (`"-1"` sentinel for None).
-- `cloud_transfer_status` (String) JCDS transfer status.
+- `cloud_transfer_status` (String) Cloud distribution point transfer status.
 - `file_name` (String) On-disk filename Jamf Pro associates with the binary.
 - `fill_existing_users` (Boolean) Fill Existing User home directories (FEU) flag.
 - `fill_user_template` (Boolean) Fill User Template (FUT) flag.

--- a/docs/resources/pro_package.md
+++ b/docs/resources/pro_package.md
@@ -3,44 +3,44 @@
 page_title: "jamfplatform_pro_package Resource - terraform-provider-jamfplatform"
 subcategory: ""
 description: |-
-  Manages a Jamf Pro package. A package record carries the metadata (name, category, restart requirement, OS requirement, info/notes, optional manifest, optional hashes) that Jamf Pro joins with a binary on a distribution point.
-  Three operating modes are inferred from the configuration:
-  JCDS upload — set package_file_source (local path or https?:// URL). The provider creates the metadata record, streams the binary to the Jamf Cloud Distribution Point, then polls until JCDS finishes computing every hash and cloud_transfer_status becomes READY. In this mode the hash attributes (sha3_512, sha256, md5, size, hash_type, hash_value) are populated by Jamf Pro — supplying any of them in config errors at plan time (ConflictsWith).File-share DP with user-supplied hashes (FSDP-with-hashes) — omit package_file_source and supply the hash attributes directly. The provider sends them verbatim; Jamf Pro stores whatever the user supplies without validation. Use this when the binary lives on a customer-managed share and hashes are computed off-cluster.Pure metadata-only (FSDP) — omit package_file_source and all hash attributes. The provider manages only the package metadata record; no upload, no hash compute, no verification poll.
-  Hash behaviour notes:
-  package_file_source_checksum (optional) is a user-supplied SHA-3-512 hint validated locally before any bytes leave the workstation. A mismatch errors out without uploading — useful for guarding against on-disk corruption.size is Computed-only. Jamf Pro rejects user-supplied size updates even on FSDP records.Re-uploads are hash-aware: changing only metadata (info, notes, priority, ...) issues one metadata update; the binary is not re-uploaded.
-  Manifest sub-resource: manifest_file_source (Optional) uploads a .plist manifest associated with the package. Setting the source after a state without one uploads; clearing the source deletes the manifest in Jamf Pro. Re-upload only fires when the freshly-loaded source content differs from the stored manifest body.
-  URL sources: both package_file_source and manifest_file_source accept http(s):// URLs. The provider streams the URL into a sanitised tempfile under the OS tempdir, enforces an 8 GiB download cap, and follows up to 10 redirects.
+  Manages a Jamf Pro package. A package record carries the metadata (name, category, restart requirement, operating system requirement, info/notes, optional manifest, optional hashes) that Jamf Pro pairs with a file on a distribution point.
+  The operating mode is inferred from the configuration:
+  Cloud distribution point upload — set package_file_source (a local path or https?:// URL). The provider creates the package record, uploads the file to the Jamf Cloud Distribution Point, and waits until Jamf Pro finishes calculating the file hashes and cloud_transfer_status becomes READY. In this mode Jamf Pro populates the hash attributes (sha3_512, sha256, md5, size, hash_type, hash_value); setting any of them in configuration is rejected before the change runs.Distribution point with supplied hashes — omit package_file_source and set the hash attributes directly. Jamf Pro stores the values as given, without validating them. Use this when the file lives on a distribution point you manage and the hashes are calculated elsewhere.Metadata only — omit package_file_source and all hash attributes. The provider manages only the package record; no file is uploaded.
+  Notes:
+  package_file_source_checksum (optional) is a SHA-3-512 value checked against the file locally before anything is uploaded. A mismatch fails the apply without uploading — useful for catching on-disk corruption.size is read-only — Jamf Pro calculates it from the uploaded file and ignores any value set in configuration, including on metadata-only records.Changing only metadata (info, notes, priority, ...) updates the record without re-uploading the file; the file is re-uploaded only when its contents change.
+  Manifest: manifest_file_source (optional) uploads a .plist manifest for the package. Setting it uploads the manifest; clearing it removes the manifest from Jamf Pro. The manifest is re-uploaded only when its contents change.
+  URL sources: both package_file_source and manifest_file_source accept http(s):// URLs. The provider downloads the URL to a temporary file (8 GiB limit, up to 10 redirects) before uploading.
 ---
 
 # jamfplatform_pro_package (Resource)
 
-Manages a Jamf Pro package. A package record carries the metadata (name, category, restart requirement, OS requirement, info/notes, optional manifest, optional hashes) that Jamf Pro joins with a binary on a distribution point.
+Manages a Jamf Pro package. A package record carries the metadata (name, category, restart requirement, operating system requirement, info/notes, optional manifest, optional hashes) that Jamf Pro pairs with a file on a distribution point.
 
-**Three operating modes are inferred from the configuration**:
+**The operating mode is inferred from the configuration**:
 
-- **JCDS upload** — set `package_file_source` (local path or `https?://` URL). The provider creates the metadata record, streams the binary to the Jamf Cloud Distribution Point, then polls until JCDS finishes computing every hash and `cloud_transfer_status` becomes `READY`. In this mode the hash attributes (`sha3_512`, `sha256`, `md5`, `size`, `hash_type`, `hash_value`) are populated by Jamf Pro — supplying any of them in config errors at plan time (`ConflictsWith`).
-- **File-share DP with user-supplied hashes (FSDP-with-hashes)** — omit `package_file_source` and supply the hash attributes directly. The provider sends them verbatim; Jamf Pro stores whatever the user supplies without validation. Use this when the binary lives on a customer-managed share and hashes are computed off-cluster.
-- **Pure metadata-only (FSDP)** — omit `package_file_source` and all hash attributes. The provider manages only the package metadata record; no upload, no hash compute, no verification poll.
+- **Cloud distribution point upload** — set `package_file_source` (a local path or `https?://` URL). The provider creates the package record, uploads the file to the Jamf Cloud Distribution Point, and waits until Jamf Pro finishes calculating the file hashes and `cloud_transfer_status` becomes `READY`. In this mode Jamf Pro populates the hash attributes (`sha3_512`, `sha256`, `md5`, `size`, `hash_type`, `hash_value`); setting any of them in configuration is rejected before the change runs.
+- **Distribution point with supplied hashes** — omit `package_file_source` and set the hash attributes directly. Jamf Pro stores the values as given, without validating them. Use this when the file lives on a distribution point you manage and the hashes are calculated elsewhere.
+- **Metadata only** — omit `package_file_source` and all hash attributes. The provider manages only the package record; no file is uploaded.
 
-**Hash behaviour notes:**
+**Notes:**
 
-- `package_file_source_checksum` (optional) is a user-supplied SHA-3-512 hint validated locally before any bytes leave the workstation. A mismatch errors out without uploading — useful for guarding against on-disk corruption.
-- `size` is **Computed-only**. Jamf Pro rejects user-supplied size updates even on FSDP records.
-- Re-uploads are hash-aware: changing only metadata (`info`, `notes`, `priority`, ...) issues one metadata update; the binary is not re-uploaded.
+- `package_file_source_checksum` (optional) is a SHA-3-512 value checked against the file locally before anything is uploaded. A mismatch fails the apply without uploading — useful for catching on-disk corruption.
+- `size` is read-only — Jamf Pro calculates it from the uploaded file and ignores any value set in configuration, including on metadata-only records.
+- Changing only metadata (`info`, `notes`, `priority`, ...) updates the record without re-uploading the file; the file is re-uploaded only when its contents change.
 
-**Manifest sub-resource**: `manifest_file_source` (Optional) uploads a `.plist` manifest associated with the package. Setting the source after a state without one uploads; clearing the source deletes the manifest in Jamf Pro. Re-upload only fires when the freshly-loaded source content differs from the stored `manifest` body.
+**Manifest**: `manifest_file_source` (optional) uploads a `.plist` manifest for the package. Setting it uploads the manifest; clearing it removes the manifest from Jamf Pro. The manifest is re-uploaded only when its contents change.
 
-**URL sources**: both `package_file_source` and `manifest_file_source` accept `http(s)://` URLs. The provider streams the URL into a sanitised tempfile under the OS tempdir, enforces an 8 GiB download cap, and follows up to 10 redirects.
+**URL sources**: both `package_file_source` and `manifest_file_source` accept `http(s)://` URLs. The provider downloads the URL to a temporary file (8 GiB limit, up to 10 redirects) before uploading.
 
 ## Example Usage
 
 ```terraform
-# JCDS mode: local-path upload. The provider streams the binary to the
-# cloud distribution point, then polls until JCDS has computed every hash
-# and `cloud_transfer_status` becomes "READY". Hash attributes are
-# Computed in this mode — supplying any of them in config is a plan-time
-# error (`ConflictsWith(package_file_source)`).
-resource "jamfplatform_pro_package" "jcds_local" {
+# Cloud distribution point upload from a local path. The provider uploads
+# the file to the Jamf Cloud Distribution Point, then waits until Jamf Pro
+# has calculated every hash and `cloud_transfer_status` becomes "READY".
+# The hash attributes are read-only in this mode — setting any of them in
+# configuration is rejected before the change runs.
+resource "jamfplatform_pro_package" "cloud_dp_local" {
   display_name        = "MyApp 1.0.0"
   file_name           = "MyApp-1.0.0.pkg"
   category_id         = "-1"
@@ -49,50 +49,47 @@ resource "jamfplatform_pro_package" "jcds_local" {
   priority            = 10
   package_file_source = "/path/to/MyApp-1.0.0.pkg"
 
-  # Optional integrity hint: validated against the locally-computed
-  # SHA-3-512 before any bytes leave the workstation. A mismatch errors
-  # out and skips the upload — useful for guarding against on-disk
-  # corruption.
+  # Optional integrity check: verified against the file locally before
+  # anything is uploaded. A mismatch fails the apply and skips the upload —
+  # useful for catching on-disk corruption.
   package_file_source_checksum = "0123456789abcdef..." # hex sha3-512
 
-  # JCDS uploads can take minutes for multi-GB binaries. The verification
-  # poll inherits this deadline through context.
+  # Uploads can take minutes for very large files. The upload inherits this
+  # deadline.
   timeouts {
     create = "30m"
     update = "30m"
   }
 }
 
-# JCDS mode: HTTPS URL upload. The provider downloads the URL into a
-# sanitised tempfile (8 GiB cap, 10-redirect cap, filename resolved
-# post-redirect), hashes it, uploads it, then runs the same verification
-# poll as the local-path example.
-resource "jamfplatform_pro_package" "jcds_url" {
+# Cloud distribution point upload from an HTTPS URL. The provider downloads
+# the URL to a temporary file (8 GiB limit, up to 10 redirects), then uploads
+# it the same way as the local-path example.
+resource "jamfplatform_pro_package" "cloud_dp_url" {
   display_name        = "MyApp 1.0.0 (URL)"
   file_name           = "MyApp-1.0.0.pkg"
   package_file_source = "https://artifacts.example.com/packages/MyApp-1.0.0.pkg"
 }
 
-# JCDS mode with a manifest sub-resource. `manifest_file_source` accepts
-# either a local path or a URL. Idempotency on the manifest body uses
-# direct equality with the server-stored `manifest` string, so changing
-# only the on-disk filename without changing the body does NOT re-upload.
-resource "jamfplatform_pro_package" "jcds_with_manifest" {
+# Upload with a manifest. `manifest_file_source` accepts either a local path
+# or a URL. The manifest is re-uploaded only when its contents change, so
+# changing only the on-disk filename without changing the body does not
+# re-upload.
+resource "jamfplatform_pro_package" "cloud_dp_with_manifest" {
   display_name         = "MyApp 1.0.0 (with manifest)"
   file_name            = "MyApp-1.0.0.pkg"
   package_file_source  = "/path/to/MyApp-1.0.0.pkg"
   manifest_file_source = "/path/to/MyApp-1.0.0.plist"
 }
 
-# File-share DP with user-supplied hashes (FSDP-with-hashes mode). The
-# binary lives on a customer-managed share; hashes are computed off
-# Terraform's workstation and declared here. The server stores whatever
-# the user PUTs without validation.
-resource "jamfplatform_pro_package" "fsdp_with_hashes" {
+# Distribution point with supplied hashes. The file lives on a distribution
+# point you manage; the hashes are calculated elsewhere and declared here.
+# Jamf Pro stores the values as given, without validating them.
+resource "jamfplatform_pro_package" "supplied_hashes" {
   display_name = "Legacy installer"
   file_name    = "LegacyInstaller.pkg"
   category_id  = "5"
-  info         = "Lives on the corp file-share DP"
+  info         = "Lives on a self-managed distribution point"
 
   hash_type  = "MD5"
   hash_value = "d41d8cd98f00b204e9800998ecf8427e"
@@ -102,9 +99,9 @@ resource "jamfplatform_pro_package" "fsdp_with_hashes" {
   # sha3_512 omitted: only declare the hashes you have.
 }
 
-# Pure metadata-only (FSDP). No upload, no hash compute, no verification
-# poll. Useful when the file lives on a customer-managed share and hash
-# management happens entirely outside Terraform's view.
+# Metadata only. No file is uploaded. Useful when the file lives on a
+# self-managed distribution point and hash management happens entirely
+# outside Terraform.
 resource "jamfplatform_pro_package" "meta_only" {
   display_name                 = "Customer-managed installer"
   file_name                    = "CustomerInstaller.pkg"
@@ -129,35 +126,35 @@ resource "jamfplatform_pro_package" "meta_only" {
 - `category_id` (String) **"Category"** in the Jamf Pro admin UI. Defaults to `"-1"` (None).
 - `fill_existing_users` (Boolean) **"Fill existing user home directories (FEU)"** in the Jamf Pro admin UI. Defaults to `false`.
 - `fill_user_template` (Boolean) **"Fill user templates (FUT)"** in the Jamf Pro admin UI. Defaults to `false`.
-- `hash_type` (String) Hash algorithm advertised for the package. Allowed user-set values: `"MD5"`, `"SHA_256"`, `"SHA3_512"`. Jamf Pro may also return the legacy default `"SHA_512"` on records that have never been uploaded — this value is accepted on read but not on write. Mutually exclusive with `package_file_source` (JCDS mode populates `"SHA3_512"` post-verification).
-- `hash_value` (String) Primary hash value used by Jamf Pro to match the package on a distribution point. JCDS mode populates this with the SHA-3-512 of the verified upload; FSDP mode users may supply a digest matching `hash_type`. Mutually exclusive with `package_file_source`. Requires `hash_type` to be set when user-supplied.
+- `hash_type` (String) Hash algorithm for the package. Values you can set: `"MD5"`, `"SHA_256"`, `"SHA3_512"`. Jamf Pro may also return the legacy default `"SHA_512"` on records that have never had a file uploaded — that value is accepted on read but cannot be set. Cannot be combined with `package_file_source` (a cloud distribution point upload sets this to `"SHA3_512"`).
+- `hash_value` (String) Primary hash Jamf Pro uses to match the package on a distribution point. Set to the SHA-3-512 of the file after a cloud distribution point upload, or supply a digest matching `hash_type` when managing the record directly. Cannot be combined with `package_file_source`, and requires `hash_type` when set.
 - `info` (String) **"Info"** in the Jamf Pro admin UI. Free-form metadata field. Jamf Pro returns `""` when null — the provider reconciles to keep state stable.
 - `manifest_file_source` (String) **"Manifest file"** in the Jamf Pro admin UI. Optional local path or `http(s)://` URL to a `.plist` manifest. The provider uploads when this is set and the stored `manifest` body differs from the freshly-loaded source content. Clearing this attribute deletes the manifest in Jamf Pro.
-- `md5` (String) MD5 hex digest of the package binary. JCDS uploads populate this in Jamf Pro; FSDP-mode users may supply it. Mutually exclusive with `package_file_source`.
+- `md5` (String) MD5 hex digest of the package file. Calculated by Jamf Pro after a cloud distribution point upload, or set directly when managing the record without an uploaded file. Cannot be combined with `package_file_source`.
 - `notes` (String) **"Notes"** in the Jamf Pro admin UI. Free-form notes field. Jamf Pro returns `""` when null — the provider reconciles to keep state stable.
 - `os_requirements` (String) **"Operating system requirement"** in the Jamf Pro admin UI (Limitations tab). Comma-separated string, e.g. `"13.5.2, 13.6.x, 14.3"`.
-- `package_file_source` (String) Optional local filesystem path or `http(s)://` URL pointing to the package binary. Setting this triggers a JCDS upload during create/update and gates the verification poll. When omitted, the resource manages only the package metadata record (FSDP modes). Mutually exclusive with the hash attributes — supplying both errors at plan time.
-- `package_file_source_checksum` (String) Optional user-supplied SHA-3-512 hex digest validated against the locally-computed hash before upload. Mismatch errors out without uploading. Mutually exclusive with `stream_url_directly`.
+- `package_file_source` (String) Optional local path or `http(s)://` URL pointing to the package file. Set it to upload the file to the Jamf Cloud Distribution Point on create or update. When omitted, the resource manages only the package record. Cannot be combined with the hash attributes — setting both is rejected before the change runs.
+- `package_file_source_checksum` (String) Optional SHA-3-512 hex digest checked against the file locally before it is uploaded. A mismatch fails the apply without uploading. Cannot be combined with `stream_url_directly`.
 - `priority` (Number) **"Priority"** in the Jamf Pro admin UI. Defaults to `10`. Lower values install first when multiple packages are queued.
 - `reboot_required` (Boolean) **"Requires restart"** in the Jamf Pro admin UI. Defaults to `false`.
-- `sha256` (String) SHA-256 hex digest of the package binary. JCDS uploads populate this in Jamf Pro; FSDP-mode users may supply it. Mutually exclusive with `package_file_source`.
-- `sha3_512` (String) SHA-3-512 hex digest of the package binary. JCDS uploads populate this in Jamf Pro after verification; FSDP-mode users may supply it. Mutually exclusive with `package_file_source`.
-- `stream_url_directly` (Boolean) When `true` and `package_file_source` is an `http(s)://` URL, stream the body straight to JCDS instead of staging to a tempfile. Skips disk usage at the cost of: no 429 retry, no pre-upload checksum validation (`ConflictsWith` `package_file_source_checksum`), no `Content-Length` precompute (chunked transfer encoding), and no recovery from mid-stream origin failure. Use on disk-constrained runners with multi-GB binaries. Ignored for local-path sources.
+- `sha256` (String) SHA-256 hex digest of the package file. Calculated by Jamf Pro after a cloud distribution point upload, or set directly when managing the record without an uploaded file. Cannot be combined with `package_file_source`.
+- `sha3_512` (String) SHA-3-512 hex digest of the package file. Calculated by Jamf Pro after a cloud distribution point upload, or set directly when managing the record without an uploaded file. Cannot be combined with `package_file_source`.
+- `stream_url_directly` (Boolean) When `true` and `package_file_source` is an `http(s)://` URL, the file is sent straight to the Jamf Cloud Distribution Point as it downloads, instead of being saved to a temporary file first. This avoids using local disk, but disables retry on rate-limiting, pre-upload checksum validation (so it cannot be combined with `package_file_source_checksum`), and recovery if the download is interrupted partway. Use it on disk-constrained machines with very large files. Ignored for local-path sources.
 - `timeouts` (Attributes) (see [below for nested schema](#nestedatt--timeouts))
 
 ### Read-Only
 
-- `cloud_transfer_status` (String) JCDS transfer status — populated as the cloud distribution point processes an upload. The verification poll converges on `"READY"` for JCDS uploads; FSDP records leave this empty.
+- `cloud_transfer_status` (String) Cloud distribution point transfer status — updated as Jamf Pro processes an uploaded file, reaching `"READY"` once the upload is complete. Empty for records with no uploaded file.
 - `format` (String) Distribution-point format string. Returned by Jamf Pro; not user-settable.
 - `id` (String) Package ID assigned by Jamf Pro.
 - `indexed` (Boolean) Distribution-point indexing telemetry. Returned by Jamf Pro; not user-settable.
-- `install_language` (String) Locale tag, default `"en_US"`. Returned by Jamf Pro; not user-settable. Not exposed in the Jamf Pro admin UI; surfaced Computed-only to avoid drift on refresh.
+- `install_language` (String) Locale tag, default `"en_US"`. Returned by Jamf Pro; not user-settable. Not exposed in the Jamf Pro admin UI; surfaced as read-only to avoid drift on refresh.
 - `manifest` (String) The raw plist body Jamf Pro stores for the package manifest. Empty when no manifest is uploaded. Direct-equality compared against the freshly-loaded `manifest_file_source` to decide whether to re-upload.
 - `manifest_file_name` (String) The filename Jamf Pro echoed back for the most recent manifest upload.
 - `parent_package_id` (String) Parent package ID, default `"-1"` (no parent). Returned by Jamf Pro; not user-settable.
 - `self_heal_notify` (Boolean) Self-healing notification flag. Default `false`. Returned by Jamf Pro; not user-settable.
 - `self_healing_action` (String) Self-healing action, default `"nothing"`. Returned by Jamf Pro; not user-settable.
-- `size` (String) Package binary size in bytes. Returned by Jamf Pro; not user-settable. Populated automatically by JCDS uploads — Jamf Pro silently drops user-supplied size values on update.
+- `size` (String) Package binary size in bytes. Read-only — Jamf Pro calculates this from the uploaded package file, so any value set in configuration is ignored. Packages managed as metadata only (no uploaded file) leave this empty. Shown as `(known after apply)` on any update that changes the package, because Jamf Pro recalculates the size after the change is saved.
 
 <a id="nestedatt--timeouts"></a>
 ### Nested Schema for `timeouts`

--- a/examples/resources/jamfplatform_pro_package/resource.tf
+++ b/examples/resources/jamfplatform_pro_package/resource.tf
@@ -1,9 +1,9 @@
-# JCDS mode: local-path upload. The provider streams the binary to the
-# cloud distribution point, then polls until JCDS has computed every hash
-# and `cloud_transfer_status` becomes "READY". Hash attributes are
-# Computed in this mode — supplying any of them in config is a plan-time
-# error (`ConflictsWith(package_file_source)`).
-resource "jamfplatform_pro_package" "jcds_local" {
+# Cloud distribution point upload from a local path. The provider uploads
+# the file to the Jamf Cloud Distribution Point, then waits until Jamf Pro
+# has calculated every hash and `cloud_transfer_status` becomes "READY".
+# The hash attributes are read-only in this mode — setting any of them in
+# configuration is rejected before the change runs.
+resource "jamfplatform_pro_package" "cloud_dp_local" {
   display_name        = "MyApp 1.0.0"
   file_name           = "MyApp-1.0.0.pkg"
   category_id         = "-1"
@@ -12,50 +12,47 @@ resource "jamfplatform_pro_package" "jcds_local" {
   priority            = 10
   package_file_source = "/path/to/MyApp-1.0.0.pkg"
 
-  # Optional integrity hint: validated against the locally-computed
-  # SHA-3-512 before any bytes leave the workstation. A mismatch errors
-  # out and skips the upload — useful for guarding against on-disk
-  # corruption.
+  # Optional integrity check: verified against the file locally before
+  # anything is uploaded. A mismatch fails the apply and skips the upload —
+  # useful for catching on-disk corruption.
   package_file_source_checksum = "0123456789abcdef..." # hex sha3-512
 
-  # JCDS uploads can take minutes for multi-GB binaries. The verification
-  # poll inherits this deadline through context.
+  # Uploads can take minutes for very large files. The upload inherits this
+  # deadline.
   timeouts {
     create = "30m"
     update = "30m"
   }
 }
 
-# JCDS mode: HTTPS URL upload. The provider downloads the URL into a
-# sanitised tempfile (8 GiB cap, 10-redirect cap, filename resolved
-# post-redirect), hashes it, uploads it, then runs the same verification
-# poll as the local-path example.
-resource "jamfplatform_pro_package" "jcds_url" {
+# Cloud distribution point upload from an HTTPS URL. The provider downloads
+# the URL to a temporary file (8 GiB limit, up to 10 redirects), then uploads
+# it the same way as the local-path example.
+resource "jamfplatform_pro_package" "cloud_dp_url" {
   display_name        = "MyApp 1.0.0 (URL)"
   file_name           = "MyApp-1.0.0.pkg"
   package_file_source = "https://artifacts.example.com/packages/MyApp-1.0.0.pkg"
 }
 
-# JCDS mode with a manifest sub-resource. `manifest_file_source` accepts
-# either a local path or a URL. Idempotency on the manifest body uses
-# direct equality with the server-stored `manifest` string, so changing
-# only the on-disk filename without changing the body does NOT re-upload.
-resource "jamfplatform_pro_package" "jcds_with_manifest" {
+# Upload with a manifest. `manifest_file_source` accepts either a local path
+# or a URL. The manifest is re-uploaded only when its contents change, so
+# changing only the on-disk filename without changing the body does not
+# re-upload.
+resource "jamfplatform_pro_package" "cloud_dp_with_manifest" {
   display_name         = "MyApp 1.0.0 (with manifest)"
   file_name            = "MyApp-1.0.0.pkg"
   package_file_source  = "/path/to/MyApp-1.0.0.pkg"
   manifest_file_source = "/path/to/MyApp-1.0.0.plist"
 }
 
-# File-share DP with user-supplied hashes (FSDP-with-hashes mode). The
-# binary lives on a customer-managed share; hashes are computed off
-# Terraform's workstation and declared here. The server stores whatever
-# the user PUTs without validation.
-resource "jamfplatform_pro_package" "fsdp_with_hashes" {
+# Distribution point with supplied hashes. The file lives on a distribution
+# point you manage; the hashes are calculated elsewhere and declared here.
+# Jamf Pro stores the values as given, without validating them.
+resource "jamfplatform_pro_package" "supplied_hashes" {
   display_name = "Legacy installer"
   file_name    = "LegacyInstaller.pkg"
   category_id  = "5"
-  info         = "Lives on the corp file-share DP"
+  info         = "Lives on a self-managed distribution point"
 
   hash_type  = "MD5"
   hash_value = "d41d8cd98f00b204e9800998ecf8427e"
@@ -65,9 +62,9 @@ resource "jamfplatform_pro_package" "fsdp_with_hashes" {
   # sha3_512 omitted: only declare the hashes you have.
 }
 
-# Pure metadata-only (FSDP). No upload, no hash compute, no verification
-# poll. Useful when the file lives on a customer-managed share and hash
-# management happens entirely outside Terraform's view.
+# Metadata only. No file is uploaded. Useful when the file lives on a
+# self-managed distribution point and hash management happens entirely
+# outside Terraform.
 resource "jamfplatform_pro_package" "meta_only" {
   display_name                 = "Customer-managed installer"
   file_name                    = "CustomerInstaller.pkg"

--- a/internal/resources/pro/package/crud.go
+++ b/internal/resources/pro/package/crud.go
@@ -98,7 +98,7 @@ func (r *PackageResource) Create(ctx context.Context, req resource.CreateRequest
 		}
 	}
 
-	got, err := r.client.GetPackageV1(createCtx, plan.ID.ValueString())
+	got, err := finalReadRestoringSize(createCtx, r.client, plan.ID.ValueString(), plan.FileName.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError("Error reading created Jamf Pro package", err.Error())
 		return
@@ -385,14 +385,9 @@ func (r *PackageResource) Update(ctx context.Context, req resource.UpdateRequest
 				return
 			}
 		}
-		// DeletePackageManifestV1 clears the package's server-derived
-		// `size` field (observed via ManifestLifecycle acc trace). Nudge
-		// the cloud distribution point so JCDS re-derives size from the
-		// binary that's still attached to this package id. Errors are
-		// non-fatal — the worst case is a slightly stale state.
-		if state.FileName.ValueString() != "" {
-			_ = r.client.RefreshCloudDistributionPointInventoryV1(updateCtx, state.FileName.ValueString())
-		}
+		// Deleting the manifest clears the package's server-derived `size` —
+		// but so does the metadata update below; finalReadRestoringSize
+		// re-derives it from the cloud distribution point after the update.
 	}
 
 	// Metadata PUT (full-replace) — runs after upload+poll AND manifest
@@ -404,13 +399,13 @@ func (r *PackageResource) Update(ctx context.Context, req resource.UpdateRequest
 		resp.Diagnostics.AddError("Error reading post-reconcile Jamf Pro package", err.Error())
 		return
 	}
+	// No hash override on re-upload: the upload + convergence poll above
+	// already left Jamf Pro's own SHA3_512/SHA-256/MD5 on the record (and a
+	// metadata update does not blank them), so the freshly-fetched
+	// postReconcile carries the correct, converged values. Forcing them here
+	// would re-send identical data — and the gold-standard upload flow treats
+	// the upload as the sole source of truth for hashes.
 	input := mergePlanIntoServerState(plan, postReconcile)
-	if willReupload {
-		sha3TypeTag := hashTypeSHA3512
-		input.HashType = &sha3TypeTag
-		input.HashValue = &localSha3
-		input.Sha3512 = &localSha3
-	}
 	tflog.Info(ctx, "package metadata PUT body", map[string]any{
 		"id":          plan.ID.ValueString(),
 		"input_info":  helpers.DerefString(input.Info),
@@ -431,7 +426,7 @@ func (r *PackageResource) Update(ctx context.Context, req resource.UpdateRequest
 		"resp_size":  helpers.DerefString(putResp.Size),
 	})
 
-	got, err := r.client.GetPackageV1(updateCtx, plan.ID.ValueString())
+	got, err := finalReadRestoringSize(updateCtx, r.client, plan.ID.ValueString(), plan.FileName.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError("Error reading updated Jamf Pro package", err.Error())
 		return
@@ -715,7 +710,7 @@ func reconcileManifestAndFinalise(updateCtx, identityCtx context.Context, client
 		}
 	}
 
-	got, err := client.GetPackageV1(updateCtx, plan.ID.ValueString())
+	got, err := finalReadRestoringSize(updateCtx, client, plan.ID.ValueString(), plan.FileName.ValueString())
 	if err != nil {
 		return errorDiag("Error reading updated Jamf Pro package", err.Error())
 	}

--- a/internal/resources/pro/package/data_source.go
+++ b/internal/resources/pro/package/data_source.go
@@ -45,7 +45,7 @@ func (d *PackageDataSource) Metadata(ctx context.Context, req datasource.Metadat
 // (apart from the id/display_name selectors, which are Optional+Computed).
 func (d *PackageDataSource) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
 	resp.Schema = schema.Schema{
-		MarkdownDescription: "Look up a Jamf Pro package by ID or by exact display name. Exactly one of `id` or `display_name` must be supplied. Returns the full record including manifest body, every hash populated by Jamf Pro, and JCDS transfer status.",
+		MarkdownDescription: "Look up a Jamf Pro package by ID or by exact display name. Exactly one of `id` or `display_name` must be supplied. Returns the full record including manifest body, every hash populated by Jamf Pro, and cloud distribution point transfer status.",
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
 				MarkdownDescription: "Package ID. Mutually exclusive with `display_name`.",
@@ -79,7 +79,7 @@ func (d *PackageDataSource) Schema(ctx context.Context, req datasource.SchemaReq
 			"parent_package_id":            schema.StringAttribute{MarkdownDescription: "Parent package ID (`\"-1\"` for no parent).", Computed: true},
 			"self_healing_action":          schema.StringAttribute{MarkdownDescription: "Self-healing action.", Computed: true},
 			"self_heal_notify":             schema.BoolAttribute{MarkdownDescription: "Self-healing notify flag.", Computed: true},
-			"cloud_transfer_status":        schema.StringAttribute{MarkdownDescription: "JCDS transfer status.", Computed: true},
+			"cloud_transfer_status":        schema.StringAttribute{MarkdownDescription: "Cloud distribution point transfer status.", Computed: true},
 			"indexed":                      schema.BoolAttribute{MarkdownDescription: "Indexing telemetry.", Computed: true},
 			"format":                       schema.StringAttribute{MarkdownDescription: "Distribution-point format.", Computed: true},
 			"timeouts":                     timeouts.Attributes(ctx),

--- a/internal/resources/pro/package/helpers.go
+++ b/internal/resources/pro/package/helpers.go
@@ -171,6 +171,67 @@ func PollPackageVerification(ctx context.Context, client *pro.Client, id, fileNa
 	}
 }
 
+// sizeRestorePollBudget bounds the post-PUT poll that re-derives the
+// server-managed `size`. The binary is already committed to the cloud
+// distribution point, so refresh-inventory repopulates size within a tick
+// or two; a longer wait means the CDP is busy, and we proceed with whatever
+// the server reports rather than failing an otherwise-successful apply.
+const sizeRestorePollBudget = 2 * time.Minute
+
+// finalReadRestoringSize performs the final post-write GET, re-deriving the
+// server-managed `size` for cloud-distribution-point-backed packages.
+//
+// `size` is read-only on /v1/packages and is computed only from CDP
+// inventory: wire-confirmed (platform-nmartin, 2026-06-25) that the server
+// drops a user-supplied size on POST and that ANY metadata PUT — whether it
+// echoes size back or omits it — blanks the server-managed size to "". For a
+// package whose binary lives on the CDP (cloudTransferStatus non-empty) this
+// nudges refresh-inventory and polls until size repopulates, then returns the
+// refreshed record. For metadata-only / FSDP packages (no CDP binary) size is
+// legitimately empty and would never repopulate, so the first GET is returned
+// unchanged. A poll timeout is non-fatal: the write itself succeeded and the
+// next refresh (or read) will populate size — failing the apply over a
+// derived field would be the worse outcome.
+func finalReadRestoringSize(ctx context.Context, client *pro.Client, id, fileName string) (*pro.Package, error) {
+	got, err := client.GetPackageV1(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	// No CDP binary (metadata-only / FSDP), size already populated (e.g.
+	// Create, where no PUT blanked it), or no file name to target a refresh:
+	// nothing to restore.
+	if helpers.DerefString(got.CloudTransferStatus) == "" || helpers.DerefString(got.Size) != "" || fileName == "" {
+		return got, nil
+	}
+
+	pollCtx, cancel := context.WithTimeout(ctx, sizeRestorePollBudget)
+	defer cancel()
+	ticker := time.NewTicker(pollInterval)
+	defer ticker.Stop()
+	for {
+		// Nudge the CDP, then re-read. The first iteration runs immediately;
+		// in practice size returns on this first refresh.
+		_ = client.RefreshCloudDistributionPointInventoryV1(pollCtx, fileName)
+		if refreshed, getErr := client.GetPackageV1(pollCtx, id); getErr == nil {
+			got = refreshed
+			if helpers.DerefString(got.Size) != "" {
+				return got, nil
+			}
+		}
+		select {
+		case <-pollCtx.Done():
+			// Non-fatal — return the latest record (size still empty) rather
+			// than failing the apply over a server-derived field.
+			tflog.Warn(ctx, "package size did not repopulate after write; proceeding with empty size", map[string]any{
+				"id":        id,
+				"file_name": fileName,
+			})
+			return got, nil
+		case <-ticker.C:
+		}
+	}
+}
+
 // ManifestBodiesEqual compares the manifest body stored in state with the
 // content found at the supplied manifest file source. Returns true when
 // stored already matches the file source content — re-upload is unnecessary.

--- a/internal/resources/pro/package/input_builders.go
+++ b/internal/resources/pro/package/input_builders.go
@@ -80,13 +80,13 @@ func buildPackageInput(plan PackageResourceModel) *pro.Package {
 	input.Sha256 = helpers.OptionalStringPointer(plan.Sha256)
 	input.Md5 = helpers.OptionalStringPointer(plan.Md5)
 
-	// Size: emit from plan when known so the full-replace PUT preserves the
-	// server-derived value. Audit §13.8 A.7 confirmed the server ignores
-	// user-supplied size on never-uploaded records — but on records with an
-	// uploaded binary, omitting size from the PUT body clears the field
-	// (see ManifestLifecycle Step 2 regression). Echoing state's value back
-	// keeps the field stable.
-	input.Size = helpers.OptionalStringPointer(plan.Size)
+	// Size is never sent. It is server-derived from the cloud-distribution-point
+	// binary and read-only on the write endpoints: wire-confirmed
+	// (platform-nmartin, 2026-06-25) that the server drops a user-supplied size
+	// on POST, and that ANY metadata PUT — whether it echoes size back or omits
+	// it — blanks the server-managed size to "". The value is restored only by a
+	// CDP inventory refresh, which Update performs after the PUT (see
+	// finalReadRestoringSize). input.Size therefore stays nil.
 
 	return input
 }
@@ -108,6 +108,12 @@ func mergePlanIntoServerState(plan PackageResourceModel, server *pro.Package) *p
 	// Indexed, InstallLanguage, ParentPackageID, SelfHeal*, ...) survive
 	// the PUT.
 	merged := *server
+
+	// Never send size: it is server-derived and read-only on PUT — wire-confirmed
+	// that ANY PUT blanks the server-managed size regardless of the value sent.
+	// The post-PUT cloud-distribution-point refresh in Update re-derives it
+	// (see finalReadRestoringSize).
+	merged.Size = nil
 
 	// User-managed metadata: take from plan.
 	merged.PackageName = plan.DisplayName.ValueString()

--- a/internal/resources/pro/package/resource.go
+++ b/internal/resources/pro/package/resource.go
@@ -76,7 +76,7 @@ func (r *PackageResource) IdentitySchema(ctx context.Context, req resource.Ident
 // Schema returns the Terraform schema for the package resource.
 func (r *PackageResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = schema.Schema{
-		MarkdownDescription: "Manages a Jamf Pro package. A package record carries the metadata (name, category, restart requirement, OS requirement, info/notes, optional manifest, optional hashes) that Jamf Pro joins with a binary on a distribution point.\n\n**Three operating modes are inferred from the configuration**:\n\n- **JCDS upload** — set `package_file_source` (local path or `https?://` URL). The provider creates the metadata record, streams the binary to the Jamf Cloud Distribution Point, then polls until JCDS finishes computing every hash and `cloud_transfer_status` becomes `READY`. In this mode the hash attributes (`sha3_512`, `sha256`, `md5`, `size`, `hash_type`, `hash_value`) are populated by Jamf Pro — supplying any of them in config errors at plan time (`ConflictsWith`).\n- **File-share DP with user-supplied hashes (FSDP-with-hashes)** — omit `package_file_source` and supply the hash attributes directly. The provider sends them verbatim; Jamf Pro stores whatever the user supplies without validation. Use this when the binary lives on a customer-managed share and hashes are computed off-cluster.\n- **Pure metadata-only (FSDP)** — omit `package_file_source` and all hash attributes. The provider manages only the package metadata record; no upload, no hash compute, no verification poll.\n\n**Hash behaviour notes:**\n\n- `package_file_source_checksum` (optional) is a user-supplied SHA-3-512 hint validated locally before any bytes leave the workstation. A mismatch errors out without uploading — useful for guarding against on-disk corruption.\n- `size` is **Computed-only**. Jamf Pro rejects user-supplied size updates even on FSDP records.\n- Re-uploads are hash-aware: changing only metadata (`info`, `notes`, `priority`, ...) issues one metadata update; the binary is not re-uploaded.\n\n**Manifest sub-resource**: `manifest_file_source` (Optional) uploads a `.plist` manifest associated with the package. Setting the source after a state without one uploads; clearing the source deletes the manifest in Jamf Pro. Re-upload only fires when the freshly-loaded source content differs from the stored `manifest` body.\n\n**URL sources**: both `package_file_source` and `manifest_file_source` accept `http(s)://` URLs. The provider streams the URL into a sanitised tempfile under the OS tempdir, enforces an 8 GiB download cap, and follows up to 10 redirects.",
+		MarkdownDescription: "Manages a Jamf Pro package. A package record carries the metadata (name, category, restart requirement, operating system requirement, info/notes, optional manifest, optional hashes) that Jamf Pro pairs with a file on a distribution point.\n\n**The operating mode is inferred from the configuration**:\n\n- **Cloud distribution point upload** — set `package_file_source` (a local path or `https?://` URL). The provider creates the package record, uploads the file to the Jamf Cloud Distribution Point, and waits until Jamf Pro finishes calculating the file hashes and `cloud_transfer_status` becomes `READY`. In this mode Jamf Pro populates the hash attributes (`sha3_512`, `sha256`, `md5`, `size`, `hash_type`, `hash_value`); setting any of them in configuration is rejected before the change runs.\n- **Distribution point with supplied hashes** — omit `package_file_source` and set the hash attributes directly. Jamf Pro stores the values as given, without validating them. Use this when the file lives on a distribution point you manage and the hashes are calculated elsewhere.\n- **Metadata only** — omit `package_file_source` and all hash attributes. The provider manages only the package record; no file is uploaded.\n\n**Notes:**\n\n- `package_file_source_checksum` (optional) is a SHA-3-512 value checked against the file locally before anything is uploaded. A mismatch fails the apply without uploading — useful for catching on-disk corruption.\n- `size` is read-only — Jamf Pro calculates it from the uploaded file and ignores any value set in configuration, including on metadata-only records.\n- Changing only metadata (`info`, `notes`, `priority`, ...) updates the record without re-uploading the file; the file is re-uploaded only when its contents change.\n\n**Manifest**: `manifest_file_source` (optional) uploads a `.plist` manifest for the package. Setting it uploads the manifest; clearing it removes the manifest from Jamf Pro. The manifest is re-uploaded only when its contents change.\n\n**URL sources**: both `package_file_source` and `manifest_file_source` accept `http(s)://` URLs. The provider downloads the URL to a temporary file (8 GiB limit, up to 10 redirects) before uploading.",
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
 				MarkdownDescription: "Package ID assigned by Jamf Pro.",
@@ -177,18 +177,18 @@ func (r *PackageResource) Schema(ctx context.Context, req resource.SchemaRequest
 
 			// Upload-source inputs (no wire field — pure provider plumbing).
 			"package_file_source": schema.StringAttribute{
-				MarkdownDescription: "Optional local filesystem path or `http(s)://` URL pointing to the package binary. Setting this triggers a JCDS upload during create/update and gates the verification poll. When omitted, the resource manages only the package metadata record (FSDP modes). Mutually exclusive with the hash attributes — supplying both errors at plan time.",
+				MarkdownDescription: "Optional local path or `http(s)://` URL pointing to the package file. Set it to upload the file to the Jamf Cloud Distribution Point on create or update. When omitted, the resource manages only the package record. Cannot be combined with the hash attributes — setting both is rejected before the change runs.",
 				Optional:            true,
 			},
 			"package_file_source_checksum": schema.StringAttribute{
-				MarkdownDescription: "Optional user-supplied SHA-3-512 hex digest validated against the locally-computed hash before upload. Mismatch errors out without uploading. Mutually exclusive with `stream_url_directly`.",
+				MarkdownDescription: "Optional SHA-3-512 hex digest checked against the file locally before it is uploaded. A mismatch fails the apply without uploading. Cannot be combined with `stream_url_directly`.",
 				Optional:            true,
 				Validators: []validator.String{
 					stringvalidator.ConflictsWith(path.MatchRoot("stream_url_directly")),
 				},
 			},
 			"stream_url_directly": schema.BoolAttribute{
-				MarkdownDescription: "When `true` and `package_file_source` is an `http(s)://` URL, stream the body straight to JCDS instead of staging to a tempfile. Skips disk usage at the cost of: no 429 retry, no pre-upload checksum validation (`ConflictsWith` `package_file_source_checksum`), no `Content-Length` precompute (chunked transfer encoding), and no recovery from mid-stream origin failure. Use on disk-constrained runners with multi-GB binaries. Ignored for local-path sources.",
+				MarkdownDescription: "When `true` and `package_file_source` is an `http(s)://` URL, the file is sent straight to the Jamf Cloud Distribution Point as it downloads, instead of being saved to a temporary file first. This avoids using local disk, but disables retry on rate-limiting, pre-upload checksum validation (so it cannot be combined with `package_file_source_checksum`), and recovery if the download is interrupted partway. Use it on disk-constrained machines with very large files. Ignored for local-path sources.",
 				Optional:            true,
 			},
 			"manifest_file_source": schema.StringAttribute{
@@ -212,9 +212,11 @@ func (r *PackageResource) Schema(ctx context.Context, req resource.SchemaRequest
 				},
 			},
 
-			// Hash attrs: Optional+Computed in both JCDS and FSDP modes.
+			// Hash attrs: Optional+Computed — Jamf Pro calculates them after a
+			// cloud distribution point upload, or the user supplies them when
+			// managing a record without an uploaded file.
 			"sha3_512": schema.StringAttribute{
-				MarkdownDescription: "SHA-3-512 hex digest of the package binary. JCDS uploads populate this in Jamf Pro after verification; FSDP-mode users may supply it. Mutually exclusive with `package_file_source`.",
+				MarkdownDescription: "SHA-3-512 hex digest of the package file. Calculated by Jamf Pro after a cloud distribution point upload, or set directly when managing the record without an uploaded file. Cannot be combined with `package_file_source`.",
 				Optional:            true,
 				Computed:            true,
 				Validators: []validator.String{
@@ -225,7 +227,7 @@ func (r *PackageResource) Schema(ctx context.Context, req resource.SchemaRequest
 				},
 			},
 			"sha256": schema.StringAttribute{
-				MarkdownDescription: "SHA-256 hex digest of the package binary. JCDS uploads populate this in Jamf Pro; FSDP-mode users may supply it. Mutually exclusive with `package_file_source`.",
+				MarkdownDescription: "SHA-256 hex digest of the package file. Calculated by Jamf Pro after a cloud distribution point upload, or set directly when managing the record without an uploaded file. Cannot be combined with `package_file_source`.",
 				Optional:            true,
 				Computed:            true,
 				Validators: []validator.String{
@@ -236,7 +238,7 @@ func (r *PackageResource) Schema(ctx context.Context, req resource.SchemaRequest
 				},
 			},
 			"md5": schema.StringAttribute{
-				MarkdownDescription: "MD5 hex digest of the package binary. JCDS uploads populate this in Jamf Pro; FSDP-mode users may supply it. Mutually exclusive with `package_file_source`.",
+				MarkdownDescription: "MD5 hex digest of the package file. Calculated by Jamf Pro after a cloud distribution point upload, or set directly when managing the record without an uploaded file. Cannot be combined with `package_file_source`.",
 				Optional:            true,
 				Computed:            true,
 				Validators: []validator.String{
@@ -247,7 +249,7 @@ func (r *PackageResource) Schema(ctx context.Context, req resource.SchemaRequest
 				},
 			},
 			"hash_type": schema.StringAttribute{
-				MarkdownDescription: "Hash algorithm advertised for the package. Allowed user-set values: `\"MD5\"`, `\"SHA_256\"`, `\"SHA3_512\"`. Jamf Pro may also return the legacy default `\"SHA_512\"` on records that have never been uploaded — this value is accepted on read but not on write. Mutually exclusive with `package_file_source` (JCDS mode populates `\"SHA3_512\"` post-verification).",
+				MarkdownDescription: "Hash algorithm for the package. Values you can set: `\"MD5\"`, `\"SHA_256\"`, `\"SHA3_512\"`. Jamf Pro may also return the legacy default `\"SHA_512\"` on records that have never had a file uploaded — that value is accepted on read but cannot be set. Cannot be combined with `package_file_source` (a cloud distribution point upload sets this to `\"SHA3_512\"`).",
 				Optional:            true,
 				Computed:            true,
 				Validators: []validator.String{
@@ -259,7 +261,7 @@ func (r *PackageResource) Schema(ctx context.Context, req resource.SchemaRequest
 				},
 			},
 			"hash_value": schema.StringAttribute{
-				MarkdownDescription: "Primary hash value used by Jamf Pro to match the package on a distribution point. JCDS mode populates this with the SHA-3-512 of the verified upload; FSDP mode users may supply a digest matching `hash_type`. Mutually exclusive with `package_file_source`. Requires `hash_type` to be set when user-supplied.",
+				MarkdownDescription: "Primary hash Jamf Pro uses to match the package on a distribution point. Set to the SHA-3-512 of the file after a cloud distribution point upload, or supply a digest matching `hash_type` when managing the record directly. Cannot be combined with `package_file_source`, and requires `hash_type` when set.",
 				Optional:            true,
 				Computed:            true,
 				Validators: []validator.String{
@@ -271,24 +273,20 @@ func (r *PackageResource) Schema(ctx context.Context, req resource.SchemaRequest
 				},
 			},
 
-			// Server-only / Computed-only fields.
+			// Read-only — Jamf Pro derives size from the uploaded binary and
+			// silently drops any value supplied on create or update (wire-probed
+			// platform-nmartin 2026-06-25). Every metadata update blanks the
+			// server-managed value, which the resource re-derives from a cloud
+			// distribution point refresh afterwards; modelled as plain Computed
+			// (no state-forwarding plan modifier) per STYLE_GUIDE §Server-derived
+			// computed fields so it can recompute when the binary changes without
+			// tripping "inconsistent result after apply".
 			"size": schema.StringAttribute{
-				MarkdownDescription: "Package binary size in bytes. Returned by Jamf Pro; not user-settable. Populated automatically by JCDS uploads — Jamf Pro silently drops user-supplied size values on update.",
+				MarkdownDescription: "Package binary size in bytes. Read-only — Jamf Pro calculates this from the uploaded package file, so any value set in configuration is ignored. Packages managed as metadata only (no uploaded file) leave this empty. Shown as `(known after apply)` on any update that changes the package, because Jamf Pro recalculates the size after the change is saved.",
 				Computed:            true,
-				PlanModifiers: []planmodifier.String{
-					// Watch both upload sources — DeletePackageManifestV1
-					// has a server-side side effect of clearing the
-					// package's size field, so a manifest_file_source
-					// transition set→null must also invalidate the planned
-					// size value.
-					resetIfSourceChangedString(
-						path.MatchRoot("package_file_source"),
-						path.MatchRoot("manifest_file_source"),
-					),
-				},
 			},
 			"install_language": schema.StringAttribute{
-				MarkdownDescription: "Locale tag, default `\"en_US\"`. Returned by Jamf Pro; not user-settable. Not exposed in the Jamf Pro admin UI; surfaced Computed-only to avoid drift on refresh.",
+				MarkdownDescription: "Locale tag, default `\"en_US\"`. Returned by Jamf Pro; not user-settable. Not exposed in the Jamf Pro admin UI; surfaced as read-only to avoid drift on refresh.",
 				Computed:            true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.UseStateForUnknown(),
@@ -316,7 +314,7 @@ func (r *PackageResource) Schema(ctx context.Context, req resource.SchemaRequest
 				},
 			},
 			"cloud_transfer_status": schema.StringAttribute{
-				MarkdownDescription: "JCDS transfer status — populated as the cloud distribution point processes an upload. The verification poll converges on `\"READY\"` for JCDS uploads; FSDP records leave this empty.",
+				MarkdownDescription: "Cloud distribution point transfer status — updated as Jamf Pro processes an uploaded file, reaching `\"READY\"` once the upload is complete. Empty for records with no uploaded file.",
 				Computed:            true,
 				PlanModifiers: []planmodifier.String{
 					resetIfSourceChangedString(path.MatchRoot("package_file_source")),

--- a/internal/resources/pro/package/resource_acceptance_test.go
+++ b/internal/resources/pro/package/resource_acceptance_test.go
@@ -216,6 +216,9 @@ func TestAccResource_ProPackage_LocalUploadCreateAndUpdate(t *testing.T) {
 					resource.TestCheckResourceAttr(packageResourceAddr, "info", "initial create"),
 					resource.TestCheckResourceAttr(packageResourceAddr, "hash_type", "SHA3_512"),
 					resource.TestCheckResourceAttr(packageResourceAddr, "cloud_transfer_status", "READY"),
+					// Jamf Pro derives size from the uploaded binary; it must be
+					// populated after a JCDS upload.
+					resource.TestCheckResourceAttrSet(packageResourceAddr, "size"),
 					testCheckPackageHashConverged(t, packageResourceAddr, staticDigest(sha161)),
 				),
 			},
@@ -234,6 +237,11 @@ func TestAccResource_ProPackage_LocalUploadCreateAndUpdate(t *testing.T) {
 				Config: hclLocalUpload(name, fileName, src150, "metadata-only-edit"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(packageResourceAddr, "info", "metadata-only-edit"),
+					// Regression guard: a metadata-only update blanks Jamf Pro's
+					// server-managed size; the resource re-derives it from a
+					// cloud distribution point refresh, so it must remain
+					// populated (not collapse to empty) after the update.
+					resource.TestCheckResourceAttrSet(packageResourceAddr, "size"),
 					testCheckPackageHashEquals(t, packageResourceAddr, staticDigest(sha150)),
 				),
 			},
@@ -287,6 +295,9 @@ func TestAccResource_ProPackage_URLUploadCreateAndUpdate(t *testing.T) {
 				Config: hclURLUpload(name, fileName, urlFixture160, "url-meta-only", false),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(packageResourceAddr, "info", "url-meta-only"),
+					// Regression guard: metadata-only update must not blank the
+					// server-derived size (see local-upload Step 3).
+					resource.TestCheckResourceAttrSet(packageResourceAddr, "size"),
 					testCheckPackageHashEquals(t, packageResourceAddr, staticDigest(sha160)),
 				),
 			},
@@ -524,6 +535,7 @@ resource "jamfplatform_pro_package" "test" {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet(packageResourceAddr, "manifest"),
 					resource.TestCheckResourceAttrSet(packageResourceAddr, "manifest_file_name"),
+					resource.TestCheckResourceAttrSet(packageResourceAddr, "size"),
 					testCheckPackageHashConverged(t, packageResourceAddr, staticDigest(sha161)),
 				),
 			},
@@ -536,6 +548,12 @@ resource "jamfplatform_pro_package" "test" {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckNoResourceAttr(packageResourceAddr, "manifest"),
 					resource.TestCheckNoResourceAttr(packageResourceAddr, "manifest_file_name"),
+					// Removing the manifest clears the server-managed size AND
+					// the metadata update blanks it; the resource must re-derive
+					// it from a cloud distribution point refresh so it stays
+					// populated rather than collapsing to empty.
+					resource.TestCheckResourceAttrSet(packageResourceAddr, "size"),
+					testCheckPackageHashConverged(t, packageResourceAddr, staticDigest(sha161)),
 				),
 			},
 		},


### PR DESCRIPTION
## Problem

For a Jamf Pro package backed by a cloud distribution point, Jamf Pro derives the hashes **and** the size from the uploaded binary. The `Update` path was echoing `size` into the metadata write (and force-setting the hashes it had just computed locally), so **every metadata-only change to an uploaded package blanked its `size` to `""`** — the same defect [jamf-cli PR #258](https://github.com/Jamf-Concepts/jamf-cli/pull/258) fixed for the CLI.

## Wire findings (probed against a live tenant)

| Scenario | `size` | hashes |
|---|---|---|
| metadata-only create/update (no uploaded file) | dropped by server (read-only) | user-supplied values **stick** |
| cloud-distribution-point package, any metadata write | **blanked to `""`** — whether size is echoed back *or* omitted | survive the write |
| cloud-distribution-point refresh-inventory (no write) | **re-derived** from the binary | — |

So `size` is recomputed *only* by a cloud-distribution-point inventory refresh, and any write invalidates it. Hashes are normal settable fields and survive a write.

## Changes

- **Never send `size`** on create/update — it is read-only and server-derived.
- **Drop the redundant hash-force on re-upload** — the upload + convergence poll already leaves Jamf Pro's own computed hashes on the record; re-sending them is pointless and against the gold-standard flow.
- **`finalReadRestoringSize`** — after a metadata write, for records with a binary on the cloud distribution point, nudge a refresh and poll until `size` repopulates before the final read. Used by `Create` and both `Update` paths (disk-staging + streaming-URL). No-op for metadata-only records.
- **`size` → plain `Computed`, no plan modifier** per STYLE_GUIDE §Server-derived computed fields: it is derived from a mutable sibling (the binary), so a state-forwarding modifier would trip `Provider produced inconsistent result after apply` when the binary changes. It now correctly shows `(known after apply)` on updates.
- **Regression guards** — `size` assertions added to the cloud-distribution-point create / replace / metadata-only / manifest-removed acceptance steps (the original bug had no `size` coverage).
- **Docs/example de-jargoned** per STYLE_GUIDE §User-facing descriptions (stripped `JCDS`/`FSDP`/`PUT`/`ConflictsWith`/`Computed-only`/etc. from registry-facing text).

## Validation

End-to-end against a live tenant (manual project, gitignored under `local-testing/`): one package swapped between two distinct binaries **5 times on the same record**. Every swap kept the right `size` and every hash (server-recomputed), `cloud_transfer_status = READY`, same package id throughout (in-place update, never replaced) — **35/35 assertions passed**.

Unit tests, `go vet`, and `golangci-lint` all pass; docs regenerated via `make generate`. Acceptance tests not run in CI here (require a tenant); the new `size` assertions are ready for the next acc run.

> Note: very large uploads (≈≥256 MB) hard-`502` at the platform gateway for **both** this provider and `jamf-cli` — an infrastructure ceiling, unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
