### PR TITLE
fix(pro): hydrate identity-only list resources for generate-config-out

### DIFF
--- a/internal/common/accountprivileges/accountprivileges_test.go
+++ b/internal/common/accountprivileges/accountprivileges_test.go
@@ -136,6 +136,24 @@ func TestIntersectIntoState_ImportMaterialisesFullGrid(t *testing.T) {
 	}
 }
 
+// TestIntersectIntoState_ImportDedupesServerDuplicates guards the genconfig /
+// import path: the classic /accounts endpoint can echo the same privilege
+// string more than once within a category, and types.SetValue rejects duplicate
+// elements with a hard "Duplicate Set Element" error. newStringSet must collapse
+// the duplicates so hydration succeeds.
+func TestIntersectIntoState_ImportDedupesServerDuplicates(t *testing.T) {
+	server := map[string][]string{
+		"jss_objects": {"Create/Read/Update Cloud Distribution Point", "Create/Read/Update Cloud Distribution Point", "Read Buildings"},
+	}
+	out, diags := IntersectIntoState(context.Background(), nil, server)
+	if diags.HasError() {
+		t.Fatalf("IntersectIntoState with duplicate server values: %v", diags)
+	}
+	if got, want := setStrings(t, out.JamfProServerObjects), []string{"Create/Read/Update Cloud Distribution Point", "Read Buildings"}; !reflect.DeepEqual(got, want) {
+		t.Errorf("duplicate server privileges should collapse, got %v want %v", got, want)
+	}
+}
+
 func TestModelToMap_OmitsNullCategories(t *testing.T) {
 	m := &Model{JamfProServerObjects: mustSet(t, "Read Computers")}
 	got, diags := m.ToMap(context.Background())

--- a/internal/common/accountprivileges/model.go
+++ b/internal/common/accountprivileges/model.go
@@ -105,14 +105,21 @@ func (m *Model) IsEmpty() bool {
 	return true
 }
 
-// newStringSet builds a types.Set of strings from a slice (sorted for stable
-// output). A nil slice yields an empty (non-null) set.
+// newStringSet builds a types.Set of strings from a slice (sorted and
+// de-duplicated for stable output). A nil slice yields an empty (non-null) set.
+// Deduping is required because the classic /accounts endpoint can echo the same
+// privilege string more than once within a category (wire-probed 2026-06-12);
+// types.SetValue rejects duplicate elements with a hard "Duplicate Set Element"
+// error, which previously aborted import / terraform query hydration.
 func newStringSet(vals []string) (types.Set, diag.Diagnostics) {
 	sorted := append([]string(nil), vals...)
 	sort.Strings(sorted)
-	elems := make([]attr.Value, len(sorted))
+	elems := make([]attr.Value, 0, len(sorted))
 	for i, v := range sorted {
-		elems[i] = types.StringValue(v)
+		if i > 0 && v == sorted[i-1] {
+			continue
+		}
+		elems = append(elems, types.StringValue(v))
 	}
 	return types.SetValue(types.StringType, elems)
 }

--- a/internal/resources/pro/app_installer/list_resource.go
+++ b/internal/resources/pro/app_installer/list_resource.go
@@ -23,6 +23,13 @@ import (
 // endpoint.
 const defaultListTimeout = 90 * time.Second
 
+// defaultItemReadTimeout bounds each per-item hydration GET issued when
+// IncludeResource is set (config generation), giving every item its own
+// deadline independent of the list-fetch budget so one slow item cannot
+// exhaust a shared deadline. An item whose read fails or times out is dropped
+// from the generated config rather than aborting the whole type.
+const defaultItemReadTimeout = 30 * time.Second
+
 var _ list.ListResource = &AppInstallerListResource{}
 var _ list.ListResourceWithConfigure = &AppInstallerListResource{}
 
@@ -126,11 +133,15 @@ func (r *AppInstallerListResource) List(ctx context.Context, req list.ListReques
 		}
 
 		if req.IncludeResource {
-			got, err := r.client.GetAppInstallerDeploymentV1(listCtx, e.ID)
+			itemCtx, cancel := context.WithTimeout(ctx, defaultItemReadTimeout)
+			got, err := r.client.GetAppInstallerDeploymentV1(itemCtx, e.ID)
+			cancel()
 			if err != nil {
-				result.Diagnostics.AddError("Unable to read app installer deployment", err.Error())
-				stream.Results = list.ListResultsStreamDiagnostics(result.Diagnostics)
-				return
+				tflog.Warn(ctx, "Skipping app installer deployment from generated config after per-item read failure", map[string]any{
+					"id":    e.ID,
+					"error": err.Error(),
+				})
+				continue
 			}
 			state := AppInstallerResourceModel{
 				ID:       helpers.StringPointerValueOrNull(&e.ID),

--- a/internal/resources/pro/app_installer/list_resource.go
+++ b/internal/resources/pro/app_installer/list_resource.go
@@ -35,8 +35,10 @@ func NewAppInstallerListResource() list.ListResource {
 // AppInstallerListResource implements Terraform query list support for App
 // Installer deployments. The deployments endpoint has no server-side filter, so
 // the optional `filter` block is applied client-side as a case-insensitive name
-// substring. List items carry identity (id) + display name only; full detail
-// requires a per-deployment read.
+// substring. List items carry identity (id) + display name only, so when
+// IncludeResource is requested (config generation) each deployment is fetched
+// individually and hydrated through the shared Read state-builder — matching
+// the resource's import fidelity.
 type AppInstallerListResource struct {
 	client *pro.Client
 }
@@ -121,6 +123,25 @@ func (r *AppInstallerListResource) List(ctx context.Context, req list.ListReques
 		if result.Diagnostics.HasError() {
 			stream.Results = list.ListResultsStreamDiagnostics(result.Diagnostics)
 			return
+		}
+
+		if req.IncludeResource {
+			got, err := r.client.GetAppInstallerDeploymentV1(listCtx, e.ID)
+			if err != nil {
+				result.Diagnostics.AddError("Unable to read app installer deployment", err.Error())
+				stream.Results = list.ListResultsStreamDiagnostics(result.Diagnostics)
+				return
+			}
+			state := AppInstallerResourceModel{
+				ID:       helpers.StringPointerValueOrNull(&e.ID),
+				Timeouts: helpers.NewResourceTimeoutsNullValue(appInstallerTimeoutAttributeTypes),
+			}
+			assignAppInstallerResourceModel(&state, got)
+			result.Diagnostics.Append(result.Resource.Set(ctx, &state)...)
+			if result.Diagnostics.HasError() {
+				stream.Results = list.ListResultsStreamDiagnostics(result.Diagnostics)
+				return
+			}
 		}
 
 		results = append(results, result)

--- a/internal/resources/pro/computer_prestage_enrollment/list_resource.go
+++ b/internal/resources/pro/computer_prestage_enrollment/list_resource.go
@@ -27,6 +27,10 @@ import (
 
 const defaultListTimeout = 60 * time.Second
 
+// defaultItemReadTimeout caps each per-item scope read performed during config
+// generation, independent of the list-fetch budget.
+const defaultItemReadTimeout = 30 * time.Second
+
 var (
 	_ list.ListResource              = &ComputerPrestageEnrollmentListResource{}
 	_ list.ListResourceWithConfigure = &ComputerPrestageEnrollmentListResource{}
@@ -38,8 +42,15 @@ var (
 // client-side after the full list is fetched. The list response carries the
 // full `GetComputerPrestageV3` shape per row, so when IncludeResource=true
 // the row is populated from the same response — no N+1 follow-up GET is
-// required. Scope assignments are NOT included on list results — request the
-// scope via the parent resource Read if needed.
+// required, except scope: the list response omits scope assignments, so when
+// IncludeResource is requested (config generation) each row's scope is fetched
+// with GetComputerPrestageScopeV2 and ScopeSerialNumbers is populated from it
+// (an empty set when no serials are assigned). This captures the real serials
+// for a faithful import and gives the set a defined element type — an
+// uninitialised types.Set has none and fails config generation with a value
+// conversion error. The per-item scope read uses its own timeout, decoupled
+// from the list-fetch budget; a row whose scope read fails is dropped from the
+// generated config rather than aborting the whole type.
 type ComputerPrestageEnrollmentListResource struct {
 	client *pro.Client
 }
@@ -141,6 +152,17 @@ func (r *ComputerPrestageEnrollmentListResource) List(ctx context.Context, req l
 				stream.Results = list.ListResultsStreamDiagnostics(result.Diagnostics)
 				return
 			}
+			scopeCtx, cancel := context.WithTimeout(ctx, defaultItemReadTimeout)
+			scope, err := r.client.GetComputerPrestageScopeV2(scopeCtx, item.ID)
+			cancel()
+			if err != nil {
+				tflog.Warn(ctx, "Skipping computer prestage enrollment from generated config after scope read failure", map[string]any{
+					"id":    item.ID,
+					"error": err.Error(),
+				})
+				continue
+			}
+			state.ScopeSerialNumbers = scopeSerialsToSet(scope)
 			result.Diagnostics.Append(result.Resource.Set(ctx, &state)...)
 			if result.Diagnostics.HasError() {
 				stream.Results = list.ListResultsStreamDiagnostics(result.Diagnostics)

--- a/internal/resources/pro/ebook/list_resource.go
+++ b/internal/resources/pro/ebook/list_resource.go
@@ -34,7 +34,9 @@ func NewEbookListResource() list.ListResource {
 // EbookListResource implements Terraform query list support for Jamf Pro
 // ebooks. Classic /ebooks has no RSQL — the optional `filter` block is applied
 // client-side via filters.ApplyClassicFilter. List items carry only id + name
-// on the wire (no ebook detail); identity-only is the canonical list output.
+// on the wire, so when IncludeResource is requested (config generation) each
+// ebook is fetched individually and hydrated through the shared Read
+// state-builder — matching the resource's import fidelity.
 type EbookListResource struct {
 	client *proclassic.Client
 }
@@ -125,6 +127,25 @@ func (r *EbookListResource) List(ctx context.Context, req list.ListRequest, stre
 		if result.Diagnostics.HasError() {
 			stream.Results = list.ListResultsStreamDiagnostics(result.Diagnostics)
 			return
+		}
+
+		if req.IncludeResource {
+			got, err := r.client.GetEbookByID(listCtx, id.ValueString())
+			if err != nil {
+				result.Diagnostics.AddError("Unable to read e-book", err.Error())
+				stream.Results = list.ListResultsStreamDiagnostics(result.Diagnostics)
+				return
+			}
+			state := EbookResourceModel{
+				ID:       id,
+				Timeouts: helpers.NewResourceTimeoutsNullValue(ebookTimeoutAttributeTypes),
+			}
+			result.Diagnostics.Append(assignEbookResourceModel(listCtx, &state, got)...)
+			result.Diagnostics.Append(result.Resource.Set(ctx, &state)...)
+			if result.Diagnostics.HasError() {
+				stream.Results = list.ListResultsStreamDiagnostics(result.Diagnostics)
+				return
+			}
 		}
 
 		results = append(results, result)

--- a/internal/resources/pro/ebook/list_resource.go
+++ b/internal/resources/pro/ebook/list_resource.go
@@ -23,6 +23,13 @@ import (
 // /ebooks endpoint.
 const defaultListTimeout = 90 * time.Second
 
+// defaultItemReadTimeout bounds each per-item hydration GET issued when
+// IncludeResource is set (config generation), giving every item its own
+// deadline independent of the list-fetch budget so one slow item cannot
+// exhaust a shared deadline. An item whose read fails or times out is dropped
+// from the generated config rather than aborting the whole type.
+const defaultItemReadTimeout = 30 * time.Second
+
 var _ list.ListResource = &EbookListResource{}
 var _ list.ListResourceWithConfigure = &EbookListResource{}
 
@@ -130,17 +137,21 @@ func (r *EbookListResource) List(ctx context.Context, req list.ListRequest, stre
 		}
 
 		if req.IncludeResource {
-			got, err := r.client.GetEbookByID(listCtx, id.ValueString())
+			itemCtx, cancel := context.WithTimeout(ctx, defaultItemReadTimeout)
+			got, err := r.client.GetEbookByID(itemCtx, id.ValueString())
+			cancel()
 			if err != nil {
-				result.Diagnostics.AddError("Unable to read e-book", err.Error())
-				stream.Results = list.ListResultsStreamDiagnostics(result.Diagnostics)
-				return
+				tflog.Warn(ctx, "Skipping e-book from generated config after per-item read failure", map[string]any{
+					"id":    id.ValueString(),
+					"error": err.Error(),
+				})
+				continue
 			}
 			state := EbookResourceModel{
 				ID:       id,
 				Timeouts: helpers.NewResourceTimeoutsNullValue(ebookTimeoutAttributeTypes),
 			}
-			result.Diagnostics.Append(assignEbookResourceModel(listCtx, &state, got)...)
+			result.Diagnostics.Append(assignEbookResourceModel(ctx, &state, got)...)
 			result.Diagnostics.Append(result.Resource.Set(ctx, &state)...)
 			if result.Diagnostics.HasError() {
 				stream.Results = list.ListResultsStreamDiagnostics(result.Diagnostics)

--- a/internal/resources/pro/mac_app_store_app/list_resource.go
+++ b/internal/resources/pro/mac_app_store_app/list_resource.go
@@ -34,8 +34,9 @@ func NewMacAppListResource() list.ListResource {
 // MacAppListResource implements Terraform query list support for Jamf Pro Mac
 // App Store apps. Classic /macapplications has no RSQL — the optional `filter`
 // block is applied client-side via filters.ApplyClassicFilter. List items carry
-// only id + name on the wire (no app detail); identity-only is the canonical
-// list output.
+// only id + name on the wire, so when IncludeResource is requested (config
+// generation) each app is fetched individually and hydrated through the shared
+// Read state-builder — matching the resource's import fidelity.
 type MacAppListResource struct {
 	client *proclassic.Client
 }
@@ -126,6 +127,25 @@ func (r *MacAppListResource) List(ctx context.Context, req list.ListRequest, str
 		if result.Diagnostics.HasError() {
 			stream.Results = list.ListResultsStreamDiagnostics(result.Diagnostics)
 			return
+		}
+
+		if req.IncludeResource {
+			got, err := r.client.GetMacApplicationByID(listCtx, id.ValueString())
+			if err != nil {
+				result.Diagnostics.AddError("Unable to read Mac App Store app", err.Error())
+				stream.Results = list.ListResultsStreamDiagnostics(result.Diagnostics)
+				return
+			}
+			state := MacAppResourceModel{
+				ID:       id,
+				Timeouts: helpers.NewResourceTimeoutsNullValue(macAppTimeoutAttributeTypes),
+			}
+			result.Diagnostics.Append(assignMacAppResourceModel(listCtx, &state, got)...)
+			result.Diagnostics.Append(result.Resource.Set(ctx, &state)...)
+			if result.Diagnostics.HasError() {
+				stream.Results = list.ListResultsStreamDiagnostics(result.Diagnostics)
+				return
+			}
 		}
 
 		results = append(results, result)

--- a/internal/resources/pro/mac_app_store_app/list_resource.go
+++ b/internal/resources/pro/mac_app_store_app/list_resource.go
@@ -23,6 +23,13 @@ import (
 // /macapplications endpoint.
 const defaultListTimeout = 90 * time.Second
 
+// defaultItemReadTimeout bounds each per-item hydration GET issued when
+// IncludeResource is set (config generation), giving every item its own
+// deadline independent of the list-fetch budget so one slow item cannot
+// exhaust a shared deadline. An item whose read fails or times out is dropped
+// from the generated config rather than aborting the whole type.
+const defaultItemReadTimeout = 30 * time.Second
+
 var _ list.ListResource = &MacAppListResource{}
 var _ list.ListResourceWithConfigure = &MacAppListResource{}
 
@@ -130,17 +137,21 @@ func (r *MacAppListResource) List(ctx context.Context, req list.ListRequest, str
 		}
 
 		if req.IncludeResource {
-			got, err := r.client.GetMacApplicationByID(listCtx, id.ValueString())
+			itemCtx, cancel := context.WithTimeout(ctx, defaultItemReadTimeout)
+			got, err := r.client.GetMacApplicationByID(itemCtx, id.ValueString())
+			cancel()
 			if err != nil {
-				result.Diagnostics.AddError("Unable to read Mac App Store app", err.Error())
-				stream.Results = list.ListResultsStreamDiagnostics(result.Diagnostics)
-				return
+				tflog.Warn(ctx, "Skipping Mac App Store app from generated config after per-item read failure", map[string]any{
+					"id":    id.ValueString(),
+					"error": err.Error(),
+				})
+				continue
 			}
 			state := MacAppResourceModel{
 				ID:       id,
 				Timeouts: helpers.NewResourceTimeoutsNullValue(macAppTimeoutAttributeTypes),
 			}
-			result.Diagnostics.Append(assignMacAppResourceModel(listCtx, &state, got)...)
+			result.Diagnostics.Append(assignMacAppResourceModel(ctx, &state, got)...)
 			result.Diagnostics.Append(result.Resource.Set(ctx, &state)...)
 			if result.Diagnostics.HasError() {
 				stream.Results = list.ListResultsStreamDiagnostics(result.Diagnostics)

--- a/internal/resources/pro/macos_configuration_profile/list_resource.go
+++ b/internal/resources/pro/macos_configuration_profile/list_resource.go
@@ -31,7 +31,12 @@ func NewListResource() list.ListResource {
 
 // ListResource queries macOS configuration profiles. Classic
 // /osxconfigurationprofiles has no RSQL — the optional name_substring filter
-// runs client-side after the full list is fetched.
+// runs client-side after the full list is fetched. List items carry only
+// id + name, so when IncludeResource is requested (config generation) each
+// profile is fetched individually and hydrated through the shared Read
+// state-builder, which populates the general section (including the payloads
+// plist) and leaves optional sections null — matching the resource's import
+// fidelity.
 type ListResource struct {
 	client *proclassic.Client
 }
@@ -124,6 +129,26 @@ func (r *ListResource) List(ctx context.Context, req list.ListRequest, stream *l
 			stream.Results = list.ListResultsStreamDiagnostics(result.Diagnostics)
 			return
 		}
+
+		if req.IncludeResource {
+			got, err := r.client.GetOSXConfigurationProfileByID(listCtx, id.ValueString())
+			if err != nil {
+				result.Diagnostics.AddError("Unable to read macOS configuration profile", err.Error())
+				stream.Results = list.ListResultsStreamDiagnostics(result.Diagnostics)
+				return
+			}
+			state := ResourceModel{
+				ID:       id,
+				Timeouts: helpers.NewResourceTimeoutsNullValue(timeoutAttributeTypes),
+			}
+			result.Diagnostics.Append(assignResourceModel(listCtx, &state, got)...)
+			result.Diagnostics.Append(result.Resource.Set(ctx, &state)...)
+			if result.Diagnostics.HasError() {
+				stream.Results = list.ListResultsStreamDiagnostics(result.Diagnostics)
+				return
+			}
+		}
+
 		results = append(results, result)
 	}
 

--- a/internal/resources/pro/macos_configuration_profile/list_resource.go
+++ b/internal/resources/pro/macos_configuration_profile/list_resource.go
@@ -21,6 +21,13 @@ import (
 
 const defaultListTimeout = 120 * time.Second
 
+// defaultItemReadTimeout bounds each per-item hydration GET issued when
+// IncludeResource is set (config generation), giving every item its own
+// deadline independent of the list-fetch budget so one slow item cannot
+// exhaust a shared deadline. An item whose read fails or times out is dropped
+// from the generated config rather than aborting the whole type.
+const defaultItemReadTimeout = 30 * time.Second
+
 var _ list.ListResource = &ListResource{}
 var _ list.ListResourceWithConfigure = &ListResource{}
 
@@ -131,17 +138,21 @@ func (r *ListResource) List(ctx context.Context, req list.ListRequest, stream *l
 		}
 
 		if req.IncludeResource {
-			got, err := r.client.GetOSXConfigurationProfileByID(listCtx, id.ValueString())
+			itemCtx, cancel := context.WithTimeout(ctx, defaultItemReadTimeout)
+			got, err := r.client.GetOSXConfigurationProfileByID(itemCtx, id.ValueString())
+			cancel()
 			if err != nil {
-				result.Diagnostics.AddError("Unable to read macOS configuration profile", err.Error())
-				stream.Results = list.ListResultsStreamDiagnostics(result.Diagnostics)
-				return
+				tflog.Warn(ctx, "Skipping macOS configuration profile from generated config after per-item read failure", map[string]any{
+					"id":    id.ValueString(),
+					"error": err.Error(),
+				})
+				continue
 			}
 			state := ResourceModel{
 				ID:       id,
 				Timeouts: helpers.NewResourceTimeoutsNullValue(timeoutAttributeTypes),
 			}
-			result.Diagnostics.Append(assignResourceModel(listCtx, &state, got)...)
+			result.Diagnostics.Append(assignResourceModel(ctx, &state, got)...)
 			result.Diagnostics.Append(result.Resource.Set(ctx, &state)...)
 			if result.Diagnostics.HasError() {
 				stream.Results = list.ListResultsStreamDiagnostics(result.Diagnostics)

--- a/internal/resources/pro/macos_configuration_profile/model_types.go
+++ b/internal/resources/pro/macos_configuration_profile/model_types.go
@@ -5,10 +5,21 @@ package macos_configuration_profile
 
 import (
 	resourceTimeouts "github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
 	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/common/scope"
 )
+
+// timeoutAttributeTypes defines the timeout attribute types for the macOS
+// configuration profile resource operations. Used to build a null timeouts
+// value when hydrating list results (terraform query -generate-config-out).
+var timeoutAttributeTypes = map[string]attr.Type{
+	"create": types.StringType,
+	"read":   types.StringType,
+	"update": types.StringType,
+	"delete": types.StringType,
+}
 
 // ResourceModel is the Terraform model for jamfplatform_pro_macos_configuration_profile.
 // Mirrors proclassic.OsXConfigurationProfile field-for-field with the

--- a/internal/resources/pro/mobile_device_app/list_resource.go
+++ b/internal/resources/pro/mobile_device_app/list_resource.go
@@ -23,6 +23,13 @@ import (
 // /mobiledeviceapplications endpoint.
 const defaultListTimeout = 90 * time.Second
 
+// defaultItemReadTimeout bounds each per-item hydration GET issued when
+// IncludeResource is set (config generation), giving every item its own
+// deadline independent of the list-fetch budget so one slow item cannot
+// exhaust a shared deadline. An item whose read fails or times out is dropped
+// from the generated config rather than aborting the whole type.
+const defaultItemReadTimeout = 30 * time.Second
+
 var _ list.ListResource = &MobileAppListResource{}
 var _ list.ListResourceWithConfigure = &MobileAppListResource{}
 
@@ -131,17 +138,21 @@ func (r *MobileAppListResource) List(ctx context.Context, req list.ListRequest, 
 		}
 
 		if req.IncludeResource {
-			got, err := r.client.GetMobileDeviceApplicationByID(listCtx, id.ValueString())
+			itemCtx, cancel := context.WithTimeout(ctx, defaultItemReadTimeout)
+			got, err := r.client.GetMobileDeviceApplicationByID(itemCtx, id.ValueString())
+			cancel()
 			if err != nil {
-				result.Diagnostics.AddError("Unable to read mobile device application", err.Error())
-				stream.Results = list.ListResultsStreamDiagnostics(result.Diagnostics)
-				return
+				tflog.Warn(ctx, "Skipping mobile device application from generated config after per-item read failure", map[string]any{
+					"id":    id.ValueString(),
+					"error": err.Error(),
+				})
+				continue
 			}
 			state := MobileAppResourceModel{
 				ID:       id,
 				Timeouts: helpers.NewResourceTimeoutsNullValue(mobileAppTimeoutAttributeTypes),
 			}
-			result.Diagnostics.Append(assignMobileAppResourceModel(listCtx, &state, got)...)
+			result.Diagnostics.Append(assignMobileAppResourceModel(ctx, &state, got)...)
 			result.Diagnostics.Append(result.Resource.Set(ctx, &state)...)
 			if result.Diagnostics.HasError() {
 				stream.Results = list.ListResultsStreamDiagnostics(result.Diagnostics)

--- a/internal/resources/pro/mobile_device_app/list_resource.go
+++ b/internal/resources/pro/mobile_device_app/list_resource.go
@@ -34,8 +34,10 @@ func NewMobileAppListResource() list.ListResource {
 // MobileAppListResource implements Terraform query list support for Jamf Pro
 // mobile device apps. Classic /mobiledeviceapplications has no RSQL — the
 // optional `filter` block is applied client-side via filters.ApplyClassicFilter.
-// List items carry only id + name on the wire (no app detail); identity-only is
-// the canonical list output.
+// List items carry only id + name on the wire, so when IncludeResource is
+// requested (config generation) each app is fetched individually and hydrated
+// through the shared Read state-builder — matching the resource's import
+// fidelity.
 type MobileAppListResource struct {
 	client *proclassic.Client
 }
@@ -126,6 +128,25 @@ func (r *MobileAppListResource) List(ctx context.Context, req list.ListRequest, 
 		if result.Diagnostics.HasError() {
 			stream.Results = list.ListResultsStreamDiagnostics(result.Diagnostics)
 			return
+		}
+
+		if req.IncludeResource {
+			got, err := r.client.GetMobileDeviceApplicationByID(listCtx, id.ValueString())
+			if err != nil {
+				result.Diagnostics.AddError("Unable to read mobile device application", err.Error())
+				stream.Results = list.ListResultsStreamDiagnostics(result.Diagnostics)
+				return
+			}
+			state := MobileAppResourceModel{
+				ID:       id,
+				Timeouts: helpers.NewResourceTimeoutsNullValue(mobileAppTimeoutAttributeTypes),
+			}
+			result.Diagnostics.Append(assignMobileAppResourceModel(listCtx, &state, got)...)
+			result.Diagnostics.Append(result.Resource.Set(ctx, &state)...)
+			if result.Diagnostics.HasError() {
+				stream.Results = list.ListResultsStreamDiagnostics(result.Diagnostics)
+				return
+			}
 		}
 
 		results = append(results, result)

--- a/internal/resources/pro/mobile_device_configuration_profile/list_resource.go
+++ b/internal/resources/pro/mobile_device_configuration_profile/list_resource.go
@@ -29,7 +29,12 @@ func NewListResource() list.ListResource {
 	return &ListResource{}
 }
 
-// ListResource queries mobile device configuration profiles.
+// ListResource queries mobile device configuration profiles. List items carry
+// only id + name, so when IncludeResource is requested (config generation) each
+// profile is fetched individually and hydrated through the shared Read
+// state-builder, which populates the general section (including the payloads
+// plist) and leaves optional sections null — matching the resource's import
+// fidelity.
 type ListResource struct {
 	client *proclassic.Client
 }
@@ -122,6 +127,26 @@ func (r *ListResource) List(ctx context.Context, req list.ListRequest, stream *l
 			stream.Results = list.ListResultsStreamDiagnostics(result.Diagnostics)
 			return
 		}
+
+		if req.IncludeResource {
+			got, err := r.client.GetMobileDeviceConfigurationProfileByID(listCtx, id.ValueString())
+			if err != nil {
+				result.Diagnostics.AddError("Unable to read mobile device configuration profile", err.Error())
+				stream.Results = list.ListResultsStreamDiagnostics(result.Diagnostics)
+				return
+			}
+			state := ResourceModel{
+				ID:       id,
+				Timeouts: helpers.NewResourceTimeoutsNullValue(timeoutAttributeTypes),
+			}
+			result.Diagnostics.Append(assignResourceModel(listCtx, &state, got)...)
+			result.Diagnostics.Append(result.Resource.Set(ctx, &state)...)
+			if result.Diagnostics.HasError() {
+				stream.Results = list.ListResultsStreamDiagnostics(result.Diagnostics)
+				return
+			}
+		}
+
 		results = append(results, result)
 	}
 

--- a/internal/resources/pro/mobile_device_configuration_profile/list_resource.go
+++ b/internal/resources/pro/mobile_device_configuration_profile/list_resource.go
@@ -21,6 +21,13 @@ import (
 
 const defaultListTimeout = 120 * time.Second
 
+// defaultItemReadTimeout bounds each per-item hydration GET issued when
+// IncludeResource is set (config generation), giving every item its own
+// deadline independent of the list-fetch budget so one slow item cannot
+// exhaust a shared deadline. An item whose read fails or times out is dropped
+// from the generated config rather than aborting the whole type.
+const defaultItemReadTimeout = 30 * time.Second
+
 var _ list.ListResource = &ListResource{}
 var _ list.ListResourceWithConfigure = &ListResource{}
 
@@ -129,17 +136,21 @@ func (r *ListResource) List(ctx context.Context, req list.ListRequest, stream *l
 		}
 
 		if req.IncludeResource {
-			got, err := r.client.GetMobileDeviceConfigurationProfileByID(listCtx, id.ValueString())
+			itemCtx, cancel := context.WithTimeout(ctx, defaultItemReadTimeout)
+			got, err := r.client.GetMobileDeviceConfigurationProfileByID(itemCtx, id.ValueString())
+			cancel()
 			if err != nil {
-				result.Diagnostics.AddError("Unable to read mobile device configuration profile", err.Error())
-				stream.Results = list.ListResultsStreamDiagnostics(result.Diagnostics)
-				return
+				tflog.Warn(ctx, "Skipping mobile device configuration profile from generated config after per-item read failure", map[string]any{
+					"id":    id.ValueString(),
+					"error": err.Error(),
+				})
+				continue
 			}
 			state := ResourceModel{
 				ID:       id,
 				Timeouts: helpers.NewResourceTimeoutsNullValue(timeoutAttributeTypes),
 			}
-			result.Diagnostics.Append(assignResourceModel(listCtx, &state, got)...)
+			result.Diagnostics.Append(assignResourceModel(ctx, &state, got)...)
 			result.Diagnostics.Append(result.Resource.Set(ctx, &state)...)
 			if result.Diagnostics.HasError() {
 				stream.Results = list.ListResultsStreamDiagnostics(result.Diagnostics)

--- a/internal/resources/pro/mobile_device_configuration_profile/model_types.go
+++ b/internal/resources/pro/mobile_device_configuration_profile/model_types.go
@@ -5,10 +5,22 @@ package mobile_device_configuration_profile
 
 import (
 	resourceTimeouts "github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
 	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/common/scope"
 )
+
+// timeoutAttributeTypes defines the timeout attribute types for the mobile
+// device configuration profile resource operations. Used to build a null
+// timeouts value when hydrating list results (terraform query
+// -generate-config-out).
+var timeoutAttributeTypes = map[string]attr.Type{
+	"create": types.StringType,
+	"read":   types.StringType,
+	"update": types.StringType,
+	"delete": types.StringType,
+}
 
 // ResourceModel is the Terraform model for jamfplatform_pro_mobile_device_configuration_profile.
 type ResourceModel struct {

--- a/internal/resources/pro/mobile_device_prestage_enrollment/list_resource.go
+++ b/internal/resources/pro/mobile_device_prestage_enrollment/list_resource.go
@@ -27,6 +27,10 @@ import (
 
 const defaultListTimeout = 60 * time.Second
 
+// defaultItemReadTimeout caps each per-item scope read performed during config
+// generation, independent of the list-fetch budget.
+const defaultItemReadTimeout = 30 * time.Second
+
 var (
 	_ list.ListResource              = &MobileDevicePrestageEnrollmentListResource{}
 	_ list.ListResourceWithConfigure = &MobileDevicePrestageEnrollmentListResource{}
@@ -38,8 +42,15 @@ var (
 // client-side after the full list is fetched. The list response carries the
 // full `GetMobileDevicePrestageV3` shape per row, so when IncludeResource=true
 // the row is populated from the same response — no N+1 follow-up GET is
-// required. Scope assignments are NOT included on list results — request the
-// scope via the parent resource Read if needed.
+// required, except scope: the list response omits scope assignments, so when
+// IncludeResource is requested (config generation) each row's scope is fetched
+// with GetMobileDevicePrestageScopeV2 and ScopeSerialNumbers is populated from
+// it (an empty set when no serials are assigned). This captures the real
+// serials for a faithful import and gives the set a defined element type — an
+// uninitialised types.Set has none and fails config generation with a value
+// conversion error. The per-item scope read uses its own timeout, decoupled
+// from the list-fetch budget; a row whose scope read fails is dropped from the
+// generated config rather than aborting the whole type.
 type MobileDevicePrestageEnrollmentListResource struct {
 	client *pro.Client
 }
@@ -141,6 +152,17 @@ func (r *MobileDevicePrestageEnrollmentListResource) List(ctx context.Context, r
 				stream.Results = list.ListResultsStreamDiagnostics(result.Diagnostics)
 				return
 			}
+			scopeCtx, cancel := context.WithTimeout(ctx, defaultItemReadTimeout)
+			scope, err := r.client.GetMobileDevicePrestageScopeV2(scopeCtx, item.ID)
+			cancel()
+			if err != nil {
+				tflog.Warn(ctx, "Skipping mobile device prestage enrollment from generated config after scope read failure", map[string]any{
+					"id":    item.ID,
+					"error": err.Error(),
+				})
+				continue
+			}
+			state.ScopeSerialNumbers = scopeSerialsToSet(scope)
 			result.Diagnostics.Append(result.Resource.Set(ctx, &state)...)
 			if result.Diagnostics.HasError() {
 				stream.Results = list.ListResultsStreamDiagnostics(result.Diagnostics)

--- a/internal/resources/pro/pki_json_web_token_configuration/list_resource.go
+++ b/internal/resources/pro/pki_json_web_token_configuration/list_resource.go
@@ -23,6 +23,13 @@ import (
 // JSON Web Token configurations endpoint.
 const defaultListTimeout = 90 * time.Second
 
+// defaultItemReadTimeout bounds each per-item hydration GET issued when
+// IncludeResource is set (config generation), giving every item its own
+// deadline independent of the list-fetch budget so one slow item cannot
+// exhaust a shared deadline. An item whose read fails or times out is dropped
+// from the generated config rather than aborting the whole type.
+const defaultItemReadTimeout = 30 * time.Second
+
 var (
 	_ list.ListResource              = &JSONWebTokenConfigurationListResource{}
 	_ list.ListResourceWithConfigure = &JSONWebTokenConfigurationListResource{}
@@ -134,11 +141,15 @@ func (r *JSONWebTokenConfigurationListResource) List(ctx context.Context, req li
 		}
 
 		if req.IncludeResource {
-			got, err := r.client.GetJsonWebTokenConfigurationByID(listCtx, id.ValueString())
+			itemCtx, cancel := context.WithTimeout(ctx, defaultItemReadTimeout)
+			got, err := r.client.GetJsonWebTokenConfigurationByID(itemCtx, id.ValueString())
+			cancel()
 			if err != nil {
-				result.Diagnostics.AddError("Unable to read JSON web token configuration", err.Error())
-				stream.Results = list.ListResultsStreamDiagnostics(result.Diagnostics)
-				return
+				tflog.Warn(ctx, "Skipping JSON web token configuration from generated config after per-item read failure", map[string]any{
+					"id":    id.ValueString(),
+					"error": err.Error(),
+				})
+				continue
 			}
 			state := JSONWebTokenConfigurationResourceModel{
 				ID:       id,

--- a/internal/resources/pro/pki_json_web_token_configuration/list_resource.go
+++ b/internal/resources/pro/pki_json_web_token_configuration/list_resource.go
@@ -37,7 +37,10 @@ func NewJSONWebTokenConfigurationListResource() list.ListResource {
 // JSONWebTokenConfigurationListResource implements Terraform query list support
 // for Jamf Pro JSON Web Token configurations. The classic endpoint has no
 // server-side filtering — the optional `filter` block is applied client-side
-// via filters.ApplyClassicFilter.
+// via filters.ApplyClassicFilter. List items carry only id + name on the wire,
+// so when IncludeResource is requested (config generation) each configuration
+// is fetched individually and hydrated through the shared Read state-builder —
+// matching the resource's import fidelity.
 type JSONWebTokenConfigurationListResource struct {
 	client *proclassic.Client
 }
@@ -128,6 +131,25 @@ func (r *JSONWebTokenConfigurationListResource) List(ctx context.Context, req li
 		if result.Diagnostics.HasError() {
 			stream.Results = list.ListResultsStreamDiagnostics(result.Diagnostics)
 			return
+		}
+
+		if req.IncludeResource {
+			got, err := r.client.GetJsonWebTokenConfigurationByID(listCtx, id.ValueString())
+			if err != nil {
+				result.Diagnostics.AddError("Unable to read JSON web token configuration", err.Error())
+				stream.Results = list.ListResultsStreamDiagnostics(result.Diagnostics)
+				return
+			}
+			state := JSONWebTokenConfigurationResourceModel{
+				ID:       id,
+				Timeouts: helpers.NewResourceTimeoutsNullValue(jsonWebTokenConfigurationTimeoutAttributeTypes),
+			}
+			assignJSONWebTokenConfigurationResourceModel(&state, got)
+			result.Diagnostics.Append(result.Resource.Set(ctx, &state)...)
+			if result.Diagnostics.HasError() {
+				stream.Results = list.ListResultsStreamDiagnostics(result.Diagnostics)
+				return
+			}
 		}
 
 		results = append(results, result)

--- a/internal/resources/pro/policy/list_resource.go
+++ b/internal/resources/pro/policy/list_resource.go
@@ -23,6 +23,13 @@ import (
 // /policies endpoint.
 const defaultListTimeout = 120 * time.Second
 
+// defaultItemReadTimeout bounds each per-item hydration GET issued when
+// IncludeResource is set (config generation), giving every item its own
+// deadline independent of the list-fetch budget so one slow item cannot
+// exhaust a shared deadline. An item whose read fails or times out is dropped
+// from the generated config rather than aborting the whole type.
+const defaultItemReadTimeout = 30 * time.Second
+
 var _ list.ListResource = &PolicyListResource{}
 var _ list.ListResourceWithConfigure = &PolicyListResource{}
 
@@ -136,17 +143,21 @@ func (r *PolicyListResource) List(ctx context.Context, req list.ListRequest, str
 		}
 
 		if req.IncludeResource {
-			got, err := r.client.GetPolicyByID(listCtx, id.ValueString())
+			itemCtx, cancel := context.WithTimeout(ctx, defaultItemReadTimeout)
+			got, err := r.client.GetPolicyByID(itemCtx, id.ValueString())
+			cancel()
 			if err != nil {
-				result.Diagnostics.AddError("Unable to read Jamf Pro policy", err.Error())
-				stream.Results = list.ListResultsStreamDiagnostics(result.Diagnostics)
-				return
+				tflog.Warn(ctx, "Skipping Jamf Pro policy from generated config after per-item read failure", map[string]any{
+					"id":    id.ValueString(),
+					"error": err.Error(),
+				})
+				continue
 			}
 			state := PolicyResourceModel{
 				ID:       id,
 				Timeouts: helpers.NewResourceTimeoutsNullValue(policyTimeoutAttributeTypes),
 			}
-			result.Diagnostics.Append(assignPolicyResourceModel(listCtx, &state, got)...)
+			result.Diagnostics.Append(assignPolicyResourceModel(ctx, &state, got)...)
 			result.Diagnostics.Append(result.Resource.Set(ctx, &state)...)
 			if result.Diagnostics.HasError() {
 				stream.Results = list.ListResultsStreamDiagnostics(result.Diagnostics)

--- a/internal/resources/pro/policy/list_resource.go
+++ b/internal/resources/pro/policy/list_resource.go
@@ -34,8 +34,10 @@ func NewPolicyListResource() list.ListResource {
 // PolicyListResource implements Terraform query list support for Jamf Pro
 // policies. Classic /policies has no RSQL — the optional `filter` block is
 // applied client-side via filters.ApplyClassicFilter. List items carry only
-// id + name on the wire (no policy detail); identity-only is the canonical
-// list output.
+// id + name on the wire, so when IncludeResource is requested (config
+// generation) each policy is fetched individually and hydrated through the
+// shared Read state-builder, which populates the general section and leaves
+// optional sections null — matching the resource's import fidelity.
 type PolicyListResource struct {
 	client *proclassic.Client
 }
@@ -131,6 +133,25 @@ func (r *PolicyListResource) List(ctx context.Context, req list.ListRequest, str
 		if result.Diagnostics.HasError() {
 			stream.Results = list.ListResultsStreamDiagnostics(result.Diagnostics)
 			return
+		}
+
+		if req.IncludeResource {
+			got, err := r.client.GetPolicyByID(listCtx, id.ValueString())
+			if err != nil {
+				result.Diagnostics.AddError("Unable to read Jamf Pro policy", err.Error())
+				stream.Results = list.ListResultsStreamDiagnostics(result.Diagnostics)
+				return
+			}
+			state := PolicyResourceModel{
+				ID:       id,
+				Timeouts: helpers.NewResourceTimeoutsNullValue(policyTimeoutAttributeTypes),
+			}
+			result.Diagnostics.Append(assignPolicyResourceModel(listCtx, &state, got)...)
+			result.Diagnostics.Append(result.Resource.Set(ctx, &state)...)
+			if result.Diagnostics.HasError() {
+				stream.Results = list.ListResultsStreamDiagnostics(result.Diagnostics)
+				return
+			}
 		}
 
 		results = append(results, result)

--- a/internal/resources/pro/restricted_software/list_resource.go
+++ b/internal/resources/pro/restricted_software/list_resource.go
@@ -23,6 +23,13 @@ import (
 // /restrictedsoftware endpoint.
 const defaultListTimeout = 90 * time.Second
 
+// defaultItemReadTimeout bounds each per-item hydration GET issued when
+// IncludeResource is set (config generation), giving every item its own
+// deadline independent of the list-fetch budget so one slow item cannot
+// exhaust a shared deadline. An item whose read fails or times out is dropped
+// from the generated config rather than aborting the whole type.
+const defaultItemReadTimeout = 30 * time.Second
+
 var _ list.ListResource = &RestrictedSoftwareListResource{}
 var _ list.ListResourceWithConfigure = &RestrictedSoftwareListResource{}
 
@@ -132,17 +139,21 @@ func (r *RestrictedSoftwareListResource) List(ctx context.Context, req list.List
 		}
 
 		if req.IncludeResource {
-			got, err := r.client.GetRestrictedSoftwareByID(listCtx, id.ValueString())
+			itemCtx, cancel := context.WithTimeout(ctx, defaultItemReadTimeout)
+			got, err := r.client.GetRestrictedSoftwareByID(itemCtx, id.ValueString())
+			cancel()
 			if err != nil {
-				result.Diagnostics.AddError("Unable to read restricted software", err.Error())
-				stream.Results = list.ListResultsStreamDiagnostics(result.Diagnostics)
-				return
+				tflog.Warn(ctx, "Skipping restricted software from generated config after per-item read failure", map[string]any{
+					"id":    id.ValueString(),
+					"error": err.Error(),
+				})
+				continue
 			}
 			state := RestrictedSoftwareResourceModel{
 				ID:       id,
 				Timeouts: helpers.NewResourceTimeoutsNullValue(restrictedSoftwareTimeoutAttributeTypes),
 			}
-			result.Diagnostics.Append(assignRestrictedSoftwareResourceModel(listCtx, &state, got)...)
+			result.Diagnostics.Append(assignRestrictedSoftwareResourceModel(ctx, &state, got)...)
 			result.Diagnostics.Append(result.Resource.Set(ctx, &state)...)
 			if result.Diagnostics.HasError() {
 				stream.Results = list.ListResultsStreamDiagnostics(result.Diagnostics)

--- a/internal/resources/pro/restricted_software/list_resource.go
+++ b/internal/resources/pro/restricted_software/list_resource.go
@@ -35,8 +35,10 @@ func NewRestrictedSoftwareListResource() list.ListResource {
 // RestrictedSoftwareListResource implements Terraform query list support for
 // Jamf Pro restricted software records. Classic /restrictedsoftware has no RSQL
 // — the optional `filter` block is applied client-side via
-// filters.ApplyClassicFilter. List items carry only id + name on the wire;
-// identity-only is the canonical list output.
+// filters.ApplyClassicFilter. List items carry only id + name on the wire, so
+// when IncludeResource is requested (config generation) each record is fetched
+// individually and hydrated through the shared Read state-builder — matching
+// the resource's import fidelity.
 type RestrictedSoftwareListResource struct {
 	client *proclassic.Client
 }
@@ -127,6 +129,25 @@ func (r *RestrictedSoftwareListResource) List(ctx context.Context, req list.List
 		if result.Diagnostics.HasError() {
 			stream.Results = list.ListResultsStreamDiagnostics(result.Diagnostics)
 			return
+		}
+
+		if req.IncludeResource {
+			got, err := r.client.GetRestrictedSoftwareByID(listCtx, id.ValueString())
+			if err != nil {
+				result.Diagnostics.AddError("Unable to read restricted software", err.Error())
+				stream.Results = list.ListResultsStreamDiagnostics(result.Diagnostics)
+				return
+			}
+			state := RestrictedSoftwareResourceModel{
+				ID:       id,
+				Timeouts: helpers.NewResourceTimeoutsNullValue(restrictedSoftwareTimeoutAttributeTypes),
+			}
+			result.Diagnostics.Append(assignRestrictedSoftwareResourceModel(listCtx, &state, got)...)
+			result.Diagnostics.Append(result.Resource.Set(ctx, &state)...)
+			if result.Diagnostics.HasError() {
+				stream.Results = list.ListResultsStreamDiagnostics(result.Diagnostics)
+				return
+			}
 		}
 
 		results = append(results, result)

--- a/internal/resources/pro/volume_purchasing_notification/list_resource.go
+++ b/internal/resources/pro/volume_purchasing_notification/list_resource.go
@@ -22,6 +22,13 @@ import (
 // defaultListTimeout caps how long the list operation waits on the endpoint.
 const defaultListTimeout = 90 * time.Second
 
+// defaultItemReadTimeout bounds each per-item hydration GET issued when
+// IncludeResource is set (config generation), giving every item its own
+// deadline independent of the list-fetch budget so one slow item cannot
+// exhaust a shared deadline. An item whose read fails or times out is dropped
+// from the generated config rather than aborting the whole type.
+const defaultItemReadTimeout = 30 * time.Second
+
 var (
 	_ list.ListResource              = &VolumePurchasingNotificationListResource{}
 	_ list.ListResourceWithConfigure = &VolumePurchasingNotificationListResource{}
@@ -125,17 +132,21 @@ func (r *VolumePurchasingNotificationListResource) List(ctx context.Context, req
 		}
 
 		if req.IncludeResource {
-			got, err := r.client.GetVolumePurchasingSubscriptionV1(listCtx, e.ID)
+			itemCtx, cancel := context.WithTimeout(ctx, defaultItemReadTimeout)
+			got, err := r.client.GetVolumePurchasingSubscriptionV1(itemCtx, e.ID)
+			cancel()
 			if err != nil {
-				result.Diagnostics.AddError("Unable to read volume purchasing notification", err.Error())
-				stream.Results = list.ListResultsStreamDiagnostics(result.Diagnostics)
-				return
+				tflog.Warn(ctx, "Skipping volume purchasing notification from generated config after per-item read failure", map[string]any{
+					"id":    e.ID,
+					"error": err.Error(),
+				})
+				continue
 			}
 			state := VolumePurchasingNotificationResourceModel{
 				ID:       helpers.StringPointerValueOrNull(&e.ID),
 				Timeouts: helpers.NewResourceTimeoutsNullValue(volumePurchasingNotificationTimeoutAttributeTypes),
 			}
-			result.Diagnostics.Append(assignVolumePurchasingNotificationResourceModel(listCtx, &state, got)...)
+			result.Diagnostics.Append(assignVolumePurchasingNotificationResourceModel(ctx, &state, got)...)
 			result.Diagnostics.Append(result.Resource.Set(ctx, &state)...)
 			if result.Diagnostics.HasError() {
 				stream.Results = list.ListResultsStreamDiagnostics(result.Diagnostics)

--- a/internal/resources/pro/volume_purchasing_notification/list_resource.go
+++ b/internal/resources/pro/volume_purchasing_notification/list_resource.go
@@ -35,7 +35,9 @@ func NewVolumePurchasingNotificationListResource() list.ListResource {
 // VolumePurchasingNotificationListResource implements Terraform query list support.
 // The endpoint has no server-side name filter, so the optional `filter` block is
 // applied client-side as a case-insensitive name substring. List items carry
-// identity (id) + display name only; full detail requires a per-notification read.
+// identity (id) + display name only, so when IncludeResource is requested (config
+// generation) each notification is fetched individually and hydrated through the
+// shared Read state-builder — matching the resource's import fidelity.
 type VolumePurchasingNotificationListResource struct {
 	client *pro.Client
 }
@@ -120,6 +122,25 @@ func (r *VolumePurchasingNotificationListResource) List(ctx context.Context, req
 		if result.Diagnostics.HasError() {
 			stream.Results = list.ListResultsStreamDiagnostics(result.Diagnostics)
 			return
+		}
+
+		if req.IncludeResource {
+			got, err := r.client.GetVolumePurchasingSubscriptionV1(listCtx, e.ID)
+			if err != nil {
+				result.Diagnostics.AddError("Unable to read volume purchasing notification", err.Error())
+				stream.Results = list.ListResultsStreamDiagnostics(result.Diagnostics)
+				return
+			}
+			state := VolumePurchasingNotificationResourceModel{
+				ID:       helpers.StringPointerValueOrNull(&e.ID),
+				Timeouts: helpers.NewResourceTimeoutsNullValue(volumePurchasingNotificationTimeoutAttributeTypes),
+			}
+			result.Diagnostics.Append(assignVolumePurchasingNotificationResourceModel(listCtx, &state, got)...)
+			result.Diagnostics.Append(result.Resource.Set(ctx, &state)...)
+			if result.Diagnostics.HasError() {
+				stream.Results = list.ListResultsStreamDiagnostics(result.Diagnostics)
+				return
+			}
 		}
 
 		results = append(results, result)

--- a/internal/resources/pro/webhook/list_resource.go
+++ b/internal/resources/pro/webhook/list_resource.go
@@ -23,6 +23,13 @@ import (
 // /webhooks endpoint.
 const defaultListTimeout = 90 * time.Second
 
+// defaultItemReadTimeout bounds each per-item hydration GET issued when
+// IncludeResource is set (config generation), giving every item its own
+// deadline independent of the list-fetch budget so one slow item cannot
+// exhaust a shared deadline. An item whose read fails or times out is dropped
+// from the generated config rather than aborting the whole type.
+const defaultItemReadTimeout = 30 * time.Second
+
 var (
 	_ list.ListResource              = &WebhookListResource{}
 	_ list.ListResourceWithConfigure = &WebhookListResource{}
@@ -132,17 +139,21 @@ func (r *WebhookListResource) List(ctx context.Context, req list.ListRequest, st
 		}
 
 		if req.IncludeResource {
-			got, err := r.client.GetWebhookByID(listCtx, id.ValueString())
+			itemCtx, cancel := context.WithTimeout(ctx, defaultItemReadTimeout)
+			got, err := r.client.GetWebhookByID(itemCtx, id.ValueString())
+			cancel()
 			if err != nil {
-				result.Diagnostics.AddError("Unable to read webhook", err.Error())
-				stream.Results = list.ListResultsStreamDiagnostics(result.Diagnostics)
-				return
+				tflog.Warn(ctx, "Skipping webhook from generated config after per-item read failure", map[string]any{
+					"id":    id.ValueString(),
+					"error": err.Error(),
+				})
+				continue
 			}
 			state := WebhookResourceModel{
 				ID:       id,
 				Timeouts: helpers.NewResourceTimeoutsNullValue(webhookTimeoutAttributeTypes),
 			}
-			result.Diagnostics.Append(assignWebhookResourceModel(listCtx, &state, got)...)
+			result.Diagnostics.Append(assignWebhookResourceModel(ctx, &state, got)...)
 			result.Diagnostics.Append(result.Resource.Set(ctx, &state)...)
 			if result.Diagnostics.HasError() {
 				stream.Results = list.ListResultsStreamDiagnostics(result.Diagnostics)

--- a/internal/resources/pro/webhook/list_resource.go
+++ b/internal/resources/pro/webhook/list_resource.go
@@ -36,7 +36,9 @@ func NewWebhookListResource() list.ListResource {
 // WebhookListResource implements Terraform query list support for Jamf Pro
 // webhooks. Classic /webhooks has no RSQL — the optional `filter` block is
 // applied client-side via filters.ApplyClassicFilter. List items carry only
-// id + name on the wire; identity-only is the canonical list output.
+// id + name on the wire, so when IncludeResource is requested (config
+// generation) each webhook is fetched individually and hydrated through the
+// shared Read state-builder — matching the resource's import fidelity.
 type WebhookListResource struct {
 	client *proclassic.Client
 }
@@ -127,6 +129,25 @@ func (r *WebhookListResource) List(ctx context.Context, req list.ListRequest, st
 		if result.Diagnostics.HasError() {
 			stream.Results = list.ListResultsStreamDiagnostics(result.Diagnostics)
 			return
+		}
+
+		if req.IncludeResource {
+			got, err := r.client.GetWebhookByID(listCtx, id.ValueString())
+			if err != nil {
+				result.Diagnostics.AddError("Unable to read webhook", err.Error())
+				stream.Results = list.ListResultsStreamDiagnostics(result.Diagnostics)
+				return
+			}
+			state := WebhookResourceModel{
+				ID:       id,
+				Timeouts: helpers.NewResourceTimeoutsNullValue(webhookTimeoutAttributeTypes),
+			}
+			result.Diagnostics.Append(assignWebhookResourceModel(listCtx, &state, got)...)
+			result.Diagnostics.Append(result.Resource.Set(ctx, &state)...)
+			if result.Diagnostics.HasError() {
+				stream.Results = list.ListResultsStreamDiagnostics(result.Diagnostics)
+				return
+			}
 		}
 
 		results = append(results, result)


### PR DESCRIPTION
## Summary

Under `terraform query -generate-config-out` (which always requests `IncludeResource`), 11 Jamf Pro list resources only set `result.Identity` and never called `result.Resource.Set`, leaving the resource object a typed-null. Terraform core's genconfig writer **panics** on a typed-null object for any schema with nested attributes (9 of the 11) and silently emits empty config for the 2 flat ones. This blocked full-coverage config generation for the headline types (policies, profiles, apps).

This branch fixes that and two follow-ups surfaced by a full live run:

1. **Hydrate the 11 identity-only list resources** (`24fe7ad`) — each now does a per-item GET → existing Read state-builder (`assign*`) → `result.Resource.Set` when `IncludeResource` is set, mirroring `account_group`/`building`. Fixes the panic and closes the coverage gap. Also dedupes the `account_group` privileges Set (the classic `/accounts` endpoint can echo a privilege more than once, which `types.SetValue` rejects with a hard `Duplicate Set Element` error).

2. **Decouple per-item hydration timeouts + drop failed items** (`00fa219`) — the per-item GETs shared the list's 120s context, so across hundreds of sequential GETs (e.g. ~376 macOS profiles, ~257 policies) a single slow one could trip the cumulative deadline and abort the whole type. Each per-item GET now gets its own 30s timeout (`defaultItemReadTimeout`) derived from the request context; a GET that fails/times out drops just that item (`tflog.Warn` + `continue`) rather than aborting the stream (these nested-attribute types can't emit identity-only output without re-triggering the genconfig panic).

3. **Read prestage scope in the list hydration path** (`00fa219`) — `computer_/mobile_device_prestage_enrollment` hydrate from the list response, which omits scope, leaving `ScopeSerialNumbers` a typeless zero-value `types.Set` that failed config generation with `types.SetType[!!! MISSING TYPE !!!]`. The list path now fetches scope per-item (`Get{Computer,MobileDevice}PrestageScopeV2` → `scopeSerialsToSet`), matching the resource Read: real serials are captured for a faithful import, and an unassigned scope yields an empty (typed) set.

## Affected list resources

`policy`, `macos_configuration_profile`, `mobile_device_configuration_profile`, `mobile_device_app`, `mac_app_store_app`, `ebook`, `app_installer`, `restricted_software`, `volume_purchasing_notification`, `webhook`, `pki_json_web_token_configuration`; plus `computer_prestage_enrollment` / `mobile_device_prestage_enrollment` (scope).

## Testing

- Live `terraform query -generate-config-out` against an EU tenant: no panic, **1840 resources hydrated**, `terraform validate` reaches resource-level diagnostics (no crash). Narrow prestage run emits `scope_serial_numbers` with a defined element type and no conversion error.
- `gofmt -s`, `go vet`, `golangci-lint`, and unit tests pass on all touched packages; full provider unit suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
