### PR TITLE
fix(pro): printer PPD collapse + user_group criteria hydration (audit D)

### DIFF
--- a/internal/resources/pro/printer/datasource_acceptance_test.go
+++ b/internal/resources/pro/printer/datasource_acceptance_test.go
@@ -37,7 +37,9 @@ func TestAccDataSource_ProPrinter_ByID(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrPair("data.jamfplatform_pro_printer.lookup", "name", "jamfplatform_pro_printer.src", "name"),
 					resource.TestCheckResourceAttrPair("data.jamfplatform_pro_printer.lookup", "uri", "jamfplatform_pro_printer.src", "uri"),
-					resource.TestCheckResourceAttrSet("data.jamfplatform_pro_printer.lookup", "ppd_path"),
+					// use_generic defaults true, so the PPD trio collapses to
+					// null in state (server echo notwithstanding).
+					resource.TestCheckNoResourceAttr("data.jamfplatform_pro_printer.lookup", "ppd_path"),
 				),
 			},
 		},

--- a/internal/resources/pro/printer/resource_acceptance_test.go
+++ b/internal/resources/pro/printer/resource_acceptance_test.go
@@ -49,8 +49,10 @@ func testAccCheckPrinterDestroy(t *testing.T) resource.TestCheckFunc {
 }
 
 // TestAccResource_ProPrinter_Generic covers the simplest configuration —
-// use_generic is left unset (defaults to true) and the server auto-fills
-// ppd_path with the bundled Generic.ppd path. The update step exercises
+// use_generic is left unset (defaults to true). The server echoes the bundled
+// Generic.ppd path even in generic mode, but the cross-field validator forbids
+// the PPD trio there, so the state builder collapses ppd/ppd_path/ppd_contents
+// to null — the asserts below verify that round-trip. The update step exercises
 // PUT partial-merge: rename + populate optional fields without touching the
 // PPD trio.
 func TestAccResource_ProPrinter_Generic(t *testing.T) {
@@ -74,8 +76,10 @@ func TestAccResource_ProPrinter_Generic(t *testing.T) {
 					resource.TestCheckResourceAttrSet("jamfplatform_pro_printer.test", "id"),
 					resource.TestCheckResourceAttr("jamfplatform_pro_printer.test", "name", original),
 					resource.TestCheckResourceAttr("jamfplatform_pro_printer.test", "use_generic", "true"),
-					// Server auto-fills ppd_path under use_generic=true.
-					resource.TestCheckResourceAttrSet("jamfplatform_pro_printer.test", "ppd_path"),
+					// Server echoes the bundled Generic.ppd path under
+					// use_generic=true, but the validator forbids the PPD trio
+					// there — the state builder collapses it to null.
+					resource.TestCheckNoResourceAttr("jamfplatform_pro_printer.test", "ppd_path"),
 					// shared defaults to false (schema Default).
 					resource.TestCheckResourceAttr("jamfplatform_pro_printer.test", "shared", "false"),
 				),

--- a/internal/resources/pro/printer/state_builders.go
+++ b/internal/resources/pro/printer/state_builders.go
@@ -40,12 +40,24 @@ func assignPrinterResourceModel(state *PrinterResourceModel, p *proclassic.Print
 	state.Notes = helpers.StringPointerValueOrNull(p.Notes)
 	state.MakeDefault = helpers.BoolPointerValueOrNull(p.MakeDefault)
 	state.UseGeneric = helpers.BoolPointerValueOrNull(p.UseGeneric)
-	state.PPD = helpers.StringPointerValueOrNull(p.Ppd)
-	state.PPDPath = helpers.StringPointerValueOrNull(p.PpdPath)
-	state.PPDContents = trimmedStringValueFromPtr(p.PpdContents)
+	state.PPD, state.PPDPath, state.PPDContents = ppdTrioValues(p)
 	state.Shared = helpers.BoolPointerValueOrNull(p.Shared)
 	state.OSRequirements = helpers.StringPointerValueOrNull(p.OsRequirements)
 	return diags
+}
+
+// ppdTrioValues maps the server's PPD trio (ppd, ppd_path, ppd_contents) into
+// state, collapsing all three to null when the printer is in generic mode
+// (use_generic true or omitted). The Jamf Pro server echoes the bundled
+// Generic.ppd path even for a generic printer, but the cross-field validator
+// forbids the trio in that mode — so a faithful read must null it to round-trip.
+func ppdTrioValues(p *proclassic.Printer) (ppd, ppdPath types.String, ppdContents trimmedStringValue) {
+	if p.UseGeneric == nil || *p.UseGeneric {
+		return types.StringNull(), types.StringNull(), trimmedStringValueFromPtr(nil)
+	}
+	return helpers.StringPointerValueOrNull(p.Ppd),
+		helpers.StringPointerValueOrNull(p.PpdPath),
+		trimmedStringValueFromPtr(p.PpdContents)
 }
 
 // assignPrinterDataSourceModel populates a data source model from a Printer
@@ -70,9 +82,7 @@ func assignPrinterDataSourceModel(state *PrinterDataSourceModel, p *proclassic.P
 	state.Notes = helpers.StringPointerValueOrNull(p.Notes)
 	state.MakeDefault = helpers.BoolPointerValueOrNull(p.MakeDefault)
 	state.UseGeneric = helpers.BoolPointerValueOrNull(p.UseGeneric)
-	state.PPD = helpers.StringPointerValueOrNull(p.Ppd)
-	state.PPDPath = helpers.StringPointerValueOrNull(p.PpdPath)
-	state.PPDContents = trimmedStringValueFromPtr(p.PpdContents)
+	state.PPD, state.PPDPath, state.PPDContents = ppdTrioValues(p)
 	state.Shared = helpers.BoolPointerValueOrNull(p.Shared)
 	state.OSRequirements = helpers.StringPointerValueOrNull(p.OsRequirements)
 	return diags

--- a/internal/resources/pro/printer/state_builders_test.go
+++ b/internal/resources/pro/printer/state_builders_test.go
@@ -59,6 +59,53 @@ func TestAssignPrinterResourceModel_FullPayload(t *testing.T) {
 	}
 }
 
+// TestAssignPrinterResourceModel_GenericCollapsesPPDTrio asserts that when the
+// server reports use_generic=true it still echoes the bundled Generic.ppd path,
+// the state builder nulls the whole PPD trio. The cross-field validator forbids
+// ppd/ppd_path/ppd_contents in generic mode, so a faithful read must collapse the
+// echo to round-trip.
+func TestAssignPrinterResourceModel_GenericCollapsesPPDTrio(t *testing.T) {
+	state := PrinterResourceModel{}
+	api := &proclassic.Printer{
+		ID:          new(67),
+		Name:        new("Printer"),
+		UseGeneric:  new(true),
+		Ppd:         new("Generic.ppd"),
+		PpdPath:     new("/System/Library/Frameworks/ApplicationServices.framework/Versions/A/Frameworks/PrintCore.framework/Resources/Generic.ppd"),
+		PpdContents: new("*PPD-Adobe: \"4.3\""),
+	}
+	if diags := assignPrinterResourceModel(&state, api); diags.HasError() {
+		t.Fatalf("unexpected diagnostics: %v", diags)
+	}
+	if !state.PPD.IsNull() {
+		t.Errorf("ppd must be null in generic mode, got %q", state.PPD.ValueString())
+	}
+	if !state.PPDPath.IsNull() {
+		t.Errorf("ppd_path must be null in generic mode, got %q", state.PPDPath.ValueString())
+	}
+	if !state.PPDContents.IsNull() {
+		t.Errorf("ppd_contents must be null in generic mode, got %q", state.PPDContents.ValueString())
+	}
+}
+
+// TestAssignPrinterResourceModel_NonGenericKeepsPPDPath asserts the PPD trio is
+// preserved when use_generic=false.
+func TestAssignPrinterResourceModel_NonGenericKeepsPPDPath(t *testing.T) {
+	state := PrinterResourceModel{}
+	api := &proclassic.Printer{
+		ID:         new(70),
+		Name:       new("HP"),
+		UseGeneric: new(false),
+		PpdPath:    new("/Library/Printers/PPDs/Contents/Resources/HP.ppd"),
+	}
+	if diags := assignPrinterResourceModel(&state, api); diags.HasError() {
+		t.Fatalf("unexpected diagnostics: %v", diags)
+	}
+	if state.PPDPath.ValueString() != "/Library/Printers/PPDs/Contents/Resources/HP.ppd" {
+		t.Errorf("ppd_path must be preserved in non-generic mode, got %q", state.PPDPath.ValueString())
+	}
+}
+
 // TestAssignPrinterResourceModel_CategorySentinelDecodes verifies the wire
 // sentinel `categoryUnassignedSentinel` rounds-trips to null in TF state.
 func TestAssignPrinterResourceModel_CategorySentinelDecodes(t *testing.T) {

--- a/internal/resources/pro/user_group/list_resource.go
+++ b/internal/resources/pro/user_group/list_resource.go
@@ -24,6 +24,10 @@ import (
 // /usergroups endpoint.
 const defaultListTimeout = 90 * time.Second
 
+// defaultItemReadTimeout caps each per-item GET issued to hydrate a list result,
+// decoupled from the overall list budget so one slow record cannot stall the list.
+const defaultItemReadTimeout = 30 * time.Second
+
 var _ list.ListResource = &UserGroupListResource{}
 var _ list.ListResourceWithConfigure = &UserGroupListResource{}
 
@@ -35,9 +39,14 @@ func NewUserGroupListResource() list.ListResource {
 // UserGroupListResource implements Terraform query list support for Jamf Pro
 // user groups. Classic /usergroups has no RSQL — the optional `filter` block
 // is applied client-side via filters.ApplyClassicFilter after the full list
-// is fetched. List items carry only id, name, is_smart, is_notify_on_change
-// on the wire (surfaced as group_type and notify_on_membership_change);
-// every other resource attribute is set to null on list results.
+// is fetched. List items carry only id, name, is_smart, is_notify_on_change on
+// the wire, so on `include_resource` each item is re-fetched by id to hydrate
+// site, criteria and member_count — otherwise smart groups export with null
+// criteria and fail the "smart groups require a criterion" validator. Members
+// stay null (mirroring import; membership is managed only when configured), and
+// directory-service / group-ref criteria are not value-resolved here (the
+// managed resource does that on first Read). A per-item read failure drops just
+// that item (logged).
 type UserGroupListResource struct {
 	client *proclassic.Client
 }
@@ -136,19 +145,26 @@ func (r *UserGroupListResource) List(ctx context.Context, req list.ListRequest, 
 		}
 
 		if req.IncludeResource {
-			// List response carries id, name, is_smart, is_notify_on_change.
-			// Every other Optional/Computed attribute is null on list results.
+			itemCtx, cancelItem := context.WithTimeout(ctx, defaultItemReadTimeout)
+			got, getErr := r.client.GetUserGroupByID(itemCtx, id.ValueString())
+			cancelItem()
+			if getErr != nil {
+				tflog.Warn(ctx, "Skipping user group hydration after per-item read failed", map[string]any{
+					"id":    id.ValueString(),
+					"error": getErr.Error(),
+				})
+				continue
+			}
+
 			state := UserGroupResourceModel{
-				ID:                       id,
-				Name:                     helpers.StringPointerValueOrNull(u.Name),
-				GroupType:                groupTypeFromIsSmart(u.IsSmart),
-				NotifyOnMembershipChange: helpers.BoolPointerValueOrNull(u.IsNotifyOnChange),
-				SiteID:                   types.StringNull(),
-				SiteName:                 types.StringNull(),
-				Criteria:                 nil,
-				Members:                  types.SetNull(types.StringType),
-				MemberCount:              types.Int64Null(),
-				Timeouts:                 helpers.NewResourceTimeoutsNullValue(userGroupTimeoutAttributeTypes),
+				ID:       id,
+				Members:  types.SetNull(types.StringType),
+				Timeouts: helpers.NewResourceTimeoutsNullValue(userGroupTimeoutAttributeTypes),
+			}
+			result.Diagnostics.Append(assignUserGroupResourceModel(ctx, &state, got, false)...)
+			if result.Diagnostics.HasError() {
+				stream.Results = list.ListResultsStreamDiagnostics(result.Diagnostics)
+				return
 			}
 			result.Diagnostics.Append(result.Resource.Set(ctx, &state)...)
 			if result.Diagnostics.HasError() {

--- a/internal/resources/pro/user_group/state_builders.go
+++ b/internal/resources/pro/user_group/state_builders.go
@@ -154,10 +154,14 @@ func flattenCriteria(wrapper *proclassic.UserGroupCriteria) []UserGroupCriterion
 			searchType = types.StringNull()
 		}
 
-		// criterion.value is Required — server is authoritative. Direct copy
-		// (no Reconcile) so the import path lands the same value as the
-		// post-apply refresh path.
-		value := helpers.StringPointerValueOrNull(c.Value)
+		// criterion.value is Required and the server always returns the element,
+		// empty for criteria like an unset "before (yyyy-mm-dd)" date. Copy it
+		// verbatim (mapping a nil/empty echo to "" rather than null) so Required
+		// stays satisfied and import lands the same value as a post-apply refresh.
+		value := types.StringValue("")
+		if c.Value != nil {
+			value = types.StringValue(*c.Value)
+		}
 
 		var andOr types.String
 		if c.AndOr != nil && *c.AndOr != "" {

--- a/internal/resources/pro/user_group/state_builders_test.go
+++ b/internal/resources/pro/user_group/state_builders_test.go
@@ -90,6 +90,40 @@ func TestAssignUserGroupResourceModel_Smart_MembersAlwaysNull(t *testing.T) {
 	}
 }
 
+// TestAssignUserGroupResourceModel_EmptyCriterionValueIsEmptyNotNull asserts
+// that a criterion the server returns with an empty or absent value (e.g. an
+// unset "before (yyyy-mm-dd)" date, as seen on a real smart group) round-trips
+// to "" rather than null. The value attribute is Required, so null would fail
+// validation on a faithful export.
+func TestAssignUserGroupResourceModel_EmptyCriterionValueIsEmptyNotNull(t *testing.T) {
+	id := 87
+	ug := &proclassic.UserGroup{
+		ID:      &id,
+		Name:    new("Int and Date"),
+		IsSmart: new(true),
+		Criteria: &proclassic.UserGroupCriteria{Criterion: &[]proclassic.Criterion{
+			{Name: new("Date EA"), Priority: new(0), AndOr: new("and"), SearchType: new("before (yyyy-mm-dd)"), Value: new(""), OpeningParen: new(false), ClosingParen: new(false)},
+			{Name: new("Integer EA"), Priority: new(1), AndOr: new("and"), SearchType: new("is"), Value: nil, OpeningParen: new(false), ClosingParen: new(false)},
+		}},
+	}
+
+	state := &UserGroupResourceModel{}
+	if diags := assignUserGroupResourceModel(context.Background(), state, ug, false); diags.HasError() {
+		t.Fatalf("diagnostics: %v", diags)
+	}
+	if len(state.Criteria) != 2 {
+		t.Fatalf("Criteria expected 2, got %d", len(state.Criteria))
+	}
+	for i, c := range state.Criteria {
+		if c.Value.IsNull() {
+			t.Errorf("criterion[%d].value must be empty string, not null", i)
+		}
+		if c.Value.ValueString() != "" {
+			t.Errorf("criterion[%d].value expected \"\", got %q", i, c.Value.ValueString())
+		}
+	}
+}
+
 func TestAssignUserGroupDataSourceModel_PopulatesUsersBlock(t *testing.T) {
 	id := 2
 	ug := &proclassic.UserGroup{


### PR DESCRIPTION
## What

Two read-path fixes from the schema audit (category D):

| Resource.attr | Errors | Fix |
|---|---|---|
| `pro_printer.ppd_path` (forbidden when `use_generic=true`) | 2 | state builder nulls the PPD trio in generic mode |
| `pro_user_group` smart-group `criteria` | 3 | list resource hydrates criteria via per-item GET; empty criteria values round-trip as `""` |

## printer.ppd_path
Wire-confirmed (`jamf-cli`): printers 67 and 139 both return `use_generic=true` **and** `ppd_path=.../Generic.ppd` — the server echoes the bundled generic PPD even in generic mode, but the cross-field validator forbids the PPD trio there. New `ppdTrioValues()` collapses `ppd`/`ppd_path`/`ppd_contents` to null when generic.

## user_group criteria
The Classic list endpoint is `id+name` only and the list resource null-filled `criteria`, so smart groups exported `criteria = null` and failed *"smart groups require a criterion."* The singular GET returns criteria (wire-confirmed on group 87), so the list resource now hydrates each item via `GetUserGroupByID` + the existing assign builder (own `defaultItemReadTimeout`, drop-item-on-failure).
- **Static groups** return no criteria → stay null → satisfy *"criteria forbidden on static"* (verified: 3 static + 3 smart validate together).
- A criterion's **Required `value`** is copied verbatim — real smart groups carry empty-valued criteria (e.g. an unset `before (yyyy-mm-dd)` date) which was being collapsed to null and re-failing the Required check. Now empty → `""`.

## Dropped from this PR: blueprint device_groups min-1
The audit's third D item hypothesised that a blueprint can legitimately have 0 device groups. **Wire-probe disproved it**: `POST /blueprints` with `scope.deviceGroups: []` → `400 [NotEmpty] scope.deviceGroups: must not be empty`. So `setvalidator.SizeAtLeast(1)` correctly mirrors the server and **stays**. The lone 0-group blueprint on the tenant (`scope: null`, no name, `NOT_DEPLOYED`) is a non-creatable UI draft — jamformer should skip such drafts on export rather than the provider relaxing a correct validator. (Tracked as a jamformer-side follow-up.)

## Verification
`go build` / `gofmt -s` / `golangci-lint` / `go test ./...` (135 pkgs) green; acceptance-tag compiles. **Live (dev_override)** narrowed to printer/user_group: `terraform validate` 0 errors.

Independent of #262 / #263 / #264 — disjoint files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)