### PR TITLE
fix(pro): fully hydrate list resources for generate-config-out

### DIFF
--- a/internal/common/helpers/helpers.go
+++ b/internal/common/helpers/helpers.go
@@ -263,6 +263,20 @@ func ReconcileOptionalBoolPointer(apiValue *bool, current types.Bool) types.Bool
 	return ReconcileOptionalBool(*apiValue, current)
 }
 
+// ReconcileOrAdoptBoolPointer applies the Optional+Computed reconcile rule for
+// CRUD reads (adopt is false) and adopts the wire value verbatim for the list
+// resource's config-generation path (adopt is true). The reconcile rule keeps
+// an Optional+Computed bool null when the caller never authored it so a refresh
+// does not snap it to the server default; config generation has no plan to
+// reconcile against, so the server value is authoritative and a value-carrying
+// flag (e.g. all_computers) must survive into the exported config.
+func ReconcileOrAdoptBoolPointer(apiValue *bool, current types.Bool, adopt bool) types.Bool {
+	if adopt {
+		return BoolPointerValueOrNull(apiValue)
+	}
+	return ReconcileOptionalBoolPointer(apiValue, current)
+}
+
 // ReconcileOptionalStringPointer behaves like ReconcileOptionalString but accepts a *string API value.
 func ReconcileOptionalStringPointer(apiValue *string, current types.String) types.String {
 	return ReconcileOptionalString(DerefString(apiValue), current)

--- a/internal/resources/pro/app_installer/crud.go
+++ b/internal/resources/pro/app_installer/crud.go
@@ -76,7 +76,7 @@ func (r *AppInstallerResource) Create(ctx context.Context, req resource.CreateRe
 		resp.Diagnostics.AddError("Error reading created App Installer deployment", err.Error())
 		return
 	}
-	assignAppInstallerResourceModel(&plan, got)
+	assignAppInstallerResourceModel(&plan, got, false)
 
 	resp.Diagnostics.Append(helpers.SetIdentity(ctx, resp.Identity, appInstallerIdentityModel{ID: plan.ID})...)
 	if resp.Diagnostics.HasError() {
@@ -149,7 +149,7 @@ func (r *AppInstallerResource) Read(ctx context.Context, req resource.ReadReques
 		return
 	}
 
-	assignAppInstallerResourceModel(&state, got)
+	assignAppInstallerResourceModel(&state, got, false)
 
 	// Reverse-resolve app_title_id → app_title_name. The deployment GET returns
 	// only the ID; on import there is no prior config to echo, so the name must
@@ -200,7 +200,7 @@ func (r *AppInstallerResource) Update(ctx context.Context, req resource.UpdateRe
 		resp.Diagnostics.AddError("Error reading updated App Installer deployment", err.Error())
 		return
 	}
-	assignAppInstallerResourceModel(&plan, got)
+	assignAppInstallerResourceModel(&plan, got, false)
 
 	resp.Diagnostics.Append(helpers.SetIdentity(ctx, resp.Identity, appInstallerIdentityModel{ID: plan.ID})...)
 	if resp.Diagnostics.HasError() {

--- a/internal/resources/pro/app_installer/list_resource.go
+++ b/internal/resources/pro/app_installer/list_resource.go
@@ -44,8 +44,10 @@ func NewAppInstallerListResource() list.ListResource {
 // the optional `filter` block is applied client-side as a case-insensitive name
 // substring. List items carry identity (id) + display name only, so when
 // IncludeResource is requested (config generation) each deployment is fetched
-// individually and hydrated through the shared Read state-builder — matching
-// the resource's import fidelity.
+// individually and hydrated through the shared Read state-builder with
+// includeUnmanaged=true, populating every wire-present block (scalars,
+// notification_settings, self_service_settings) so the generated config is
+// complete rather than scalar-only.
 type AppInstallerListResource struct {
 	client *pro.Client
 }
@@ -147,7 +149,7 @@ func (r *AppInstallerListResource) List(ctx context.Context, req list.ListReques
 				ID:       helpers.StringPointerValueOrNull(&e.ID),
 				Timeouts: helpers.NewResourceTimeoutsNullValue(appInstallerTimeoutAttributeTypes),
 			}
-			assignAppInstallerResourceModel(&state, got)
+			assignAppInstallerResourceModel(&state, got, true)
 			result.Diagnostics.Append(result.Resource.Set(ctx, &state)...)
 			if result.Diagnostics.HasError() {
 				stream.Results = list.ListResultsStreamDiagnostics(result.Diagnostics)

--- a/internal/resources/pro/app_installer/state_builders.go
+++ b/internal/resources/pro/app_installer/state_builders.go
@@ -16,7 +16,13 @@ import (
 // an unmanaged block would violate the framework's "produced inconsistent result
 // after apply" check (plan said null, we'd return a populated object). See
 // feedback_optional_computed_nested_object.
-func assignAppInstallerResourceModel(state *AppInstallerResourceModel, d *pro.AppInstallerDeployment) {
+//
+// includeUnmanaged inverts those block gates for the list resource's
+// config-generation path (terraform query -generate-config-out): there is no
+// plan to stay consistent with, so every wire-present block is refreshed,
+// yielding a complete exported config rather than a scalar-only one. CRUD
+// callers pass false.
+func assignAppInstallerResourceModel(state *AppInstallerResourceModel, d *pro.AppInstallerDeployment, includeUnmanaged bool) {
 	if d == nil {
 		return
 	}
@@ -37,10 +43,10 @@ func assignAppInstallerResourceModel(state *AppInstallerResourceModel, d *pro.Ap
 	state.InstallPredefinedConfigProfiles = types.BoolValue(d.InstallPredefinedConfigProfiles)
 	state.TriggerAdminNotifications = types.BoolValue(d.TriggerAdminNotifications)
 
-	if state.NotificationSettings != nil && d.NotificationSettings != nil {
+	if (includeUnmanaged || state.NotificationSettings != nil) && d.NotificationSettings != nil {
 		state.NotificationSettings = flattenNotificationSettings(d.NotificationSettings)
 	}
-	if state.SelfServiceSettings != nil && d.SelfServiceSettings != nil {
+	if (includeUnmanaged || state.SelfServiceSettings != nil) && d.SelfServiceSettings != nil {
 		state.SelfServiceSettings = flattenSelfServiceSettings(state.SelfServiceSettings, d.SelfServiceSettings)
 	}
 }

--- a/internal/resources/pro/app_installer/state_builders_test.go
+++ b/internal/resources/pro/app_installer/state_builders_test.go
@@ -32,7 +32,7 @@ func sampleDeployment() *pro.AppInstallerDeployment {
 
 func TestAssignAppInstallerResourceModel_FlatScalars(t *testing.T) {
 	state := AppInstallerResourceModel{}
-	assignAppInstallerResourceModel(&state, sampleDeployment())
+	assignAppInstallerResourceModel(&state, sampleDeployment(), false)
 
 	if state.ID.ValueString() != "177" {
 		t.Errorf("id: got %q", state.ID.ValueString())
@@ -59,7 +59,7 @@ func TestAssignAppInstallerResourceModel_NestedBlocksGated(t *testing.T) {
 	d.SelfServiceSettings = &pro.AppInstallerSelfServiceSettings{Description: new("desc")}
 
 	state := AppInstallerResourceModel{} // both blocks nil (unmanaged)
-	assignAppInstallerResourceModel(&state, d)
+	assignAppInstallerResourceModel(&state, d, false)
 	if state.NotificationSettings != nil {
 		t.Errorf("unmanaged notification_settings must stay nil")
 	}
@@ -93,7 +93,7 @@ func TestAssignAppInstallerResourceModel_NestedBlocksManaged(t *testing.T) {
 			},
 		},
 	}
-	assignAppInstallerResourceModel(&state, d)
+	assignAppInstallerResourceModel(&state, d, false)
 
 	if state.NotificationSettings == nil {
 		t.Fatalf("managed notification_settings must be refreshed")
@@ -128,7 +128,7 @@ func TestAssignAppInstallerResourceModel_CategoriesOmittedStaysNil(t *testing.T)
 	d := sampleDeployment()
 	d.SelfServiceSettings = &pro.AppInstallerSelfServiceSettings{Categories: nil}
 	state := AppInstallerResourceModel{SelfServiceSettings: &SelfServiceSettingsModel{}} // Categories nil
-	assignAppInstallerResourceModel(&state, d)
+	assignAppInstallerResourceModel(&state, d, false)
 	if state.SelfServiceSettings.Categories != nil {
 		t.Errorf("omitted categories must stay nil, got %v", state.SelfServiceSettings.Categories)
 	}
@@ -140,7 +140,7 @@ func TestAssignAppInstallerResourceModel_CategoriesEmptyConfigStaysEmpty(t *test
 	d := sampleDeployment()
 	d.SelfServiceSettings = &pro.AppInstallerSelfServiceSettings{Categories: nil}
 	state := AppInstallerResourceModel{SelfServiceSettings: &SelfServiceSettingsModel{Categories: []SelfServiceCategoryModel{}}}
-	assignAppInstallerResourceModel(&state, d)
+	assignAppInstallerResourceModel(&state, d, false)
 	if state.SelfServiceSettings.Categories == nil {
 		t.Errorf("config-supplied empty categories must stay non-nil empty")
 	}
@@ -149,9 +149,43 @@ func TestAssignAppInstallerResourceModel_CategoriesEmptyConfigStaysEmpty(t *test
 	}
 }
 
+// TestAssignAppInstallerResourceModel_IncludeUnmanagedHydratesFromScratch pins
+// the config-generation contract: with includeUnmanaged set and an empty
+// starting model, every wire-present block is allocated and hydrated from the
+// server even though no prior state manages them. (categories stays nil because
+// a nil prior cannot disambiguate omitted-vs-empty membership; the block's
+// scalar fields hydrate regardless.)
+func TestAssignAppInstallerResourceModel_IncludeUnmanagedHydratesFromScratch(t *testing.T) {
+	d := sampleDeployment()
+	d.NotificationSettings = &pro.AppInstallerNotificationSettings{
+		NotificationMessage: new("hi"),
+		Deadline:            new(48),
+	}
+	d.SelfServiceSettings = &pro.AppInstallerSelfServiceSettings{
+		Description:               new("desc"),
+		IncludeInFeaturedCategory: new(true),
+	}
+
+	state := AppInstallerResourceModel{} // both blocks nil (unmanaged)
+	assignAppInstallerResourceModel(&state, d, true)
+
+	if state.NotificationSettings == nil {
+		t.Fatal("expected notification_settings allocated when wire-present")
+	}
+	if state.NotificationSettings.NotificationMessage.ValueString() != "hi" || state.NotificationSettings.Deadline.ValueInt64() != 48 {
+		t.Errorf("notification_settings not hydrated: %+v", state.NotificationSettings)
+	}
+	if state.SelfServiceSettings == nil {
+		t.Fatal("expected self_service_settings allocated when wire-present")
+	}
+	if state.SelfServiceSettings.Description.ValueString() != "desc" || !state.SelfServiceSettings.IncludeInFeaturedCategory.ValueBool() {
+		t.Errorf("self_service_settings not hydrated: %+v", state.SelfServiceSettings)
+	}
+}
+
 func TestAssignAppInstallerResourceModel_NilSafe(t *testing.T) {
 	state := AppInstallerResourceModel{ID: types.StringValue("keep")}
-	assignAppInstallerResourceModel(&state, nil)
+	assignAppInstallerResourceModel(&state, nil, false)
 	if state.ID.ValueString() != "keep" {
 		t.Errorf("nil response must not clobber state")
 	}

--- a/internal/resources/pro/ebook/crud.go
+++ b/internal/resources/pro/ebook/crud.go
@@ -103,7 +103,7 @@ func (r *EbookResource) Create(ctx context.Context, req resource.CreateRequest, 
 		resp.Diagnostics.AddError("Error reading created Jamf Pro ebook", err.Error())
 		return
 	}
-	resp.Diagnostics.Append(assignEbookResourceModel(createCtx, &plan, got)...)
+	resp.Diagnostics.Append(assignEbookResourceModel(createCtx, &plan, got, false)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -179,7 +179,7 @@ func (r *EbookResource) Read(ctx context.Context, req resource.ReadRequest, resp
 		return
 	}
 
-	resp.Diagnostics.Append(assignEbookResourceModel(readCtx, &state, got)...)
+	resp.Diagnostics.Append(assignEbookResourceModel(readCtx, &state, got, false)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -226,7 +226,7 @@ func (r *EbookResource) Update(ctx context.Context, req resource.UpdateRequest, 
 		resp.Diagnostics.AddError("Error reading updated Jamf Pro ebook", err.Error())
 		return
 	}
-	resp.Diagnostics.Append(assignEbookResourceModel(updateCtx, &plan, got)...)
+	resp.Diagnostics.Append(assignEbookResourceModel(updateCtx, &plan, got, false)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}

--- a/internal/resources/pro/ebook/list_resource.go
+++ b/internal/resources/pro/ebook/list_resource.go
@@ -43,7 +43,9 @@ func NewEbookListResource() list.ListResource {
 // client-side via filters.ApplyClassicFilter. List items carry only id + name
 // on the wire, so when IncludeResource is requested (config generation) each
 // ebook is fetched individually and hydrated through the shared Read
-// state-builder — matching the resource's import fidelity.
+// state-builder with includeUnmanaged=true, populating every wire-present
+// section (general, scope, self_service) so the generated config is complete
+// rather than general-only.
 type EbookListResource struct {
 	client *proclassic.Client
 }
@@ -151,7 +153,7 @@ func (r *EbookListResource) List(ctx context.Context, req list.ListRequest, stre
 				ID:       id,
 				Timeouts: helpers.NewResourceTimeoutsNullValue(ebookTimeoutAttributeTypes),
 			}
-			result.Diagnostics.Append(assignEbookResourceModel(ctx, &state, got)...)
+			result.Diagnostics.Append(assignEbookResourceModel(ctx, &state, got, true)...)
 			result.Diagnostics.Append(result.Resource.Set(ctx, &state)...)
 			if result.Diagnostics.HasError() {
 				stream.Results = list.ListResultsStreamDiagnostics(result.Diagnostics)

--- a/internal/resources/pro/ebook/state_builders.go
+++ b/internal/resources/pro/ebook/state_builders.go
@@ -21,7 +21,15 @@ import (
 // with default values, so populating an unmanaged section would violate the
 // framework's "produced inconsistent result after apply" check (plan said null,
 // we'd return a populated object). See feedback_server_derived_echo_attrs.
-func assignEbookResourceModel(ctx context.Context, state *EbookResourceModel, e *proclassic.Ebook) diag.Diagnostics {
+//
+// includeUnmanaged inverts those section gates for the list resource's
+// config-generation path (terraform query -generate-config-out): there is no
+// plan to stay consistent with, so every wire-present optional section is
+// allocated and hydrated, yielding a complete exported config rather than a
+// general-only one. CRUD callers pass false. The ebook flatteners use the
+// PreferCurrent* helpers (which adopt the wire value when the current state is
+// null), so allocating an empty section is sufficient for it to fully hydrate.
+func assignEbookResourceModel(ctx context.Context, state *EbookResourceModel, e *proclassic.Ebook, includeUnmanaged bool) diag.Diagnostics {
 	var diags diag.Diagnostics
 	if e == nil {
 		return diags
@@ -36,8 +44,14 @@ func assignEbookResourceModel(ctx context.Context, state *EbookResourceModel, e 
 	}
 	flattenEbookGeneral(e.General, state.General)
 
+	if includeUnmanaged && state.Scope == nil && e.Scope != nil {
+		state.Scope = &EbookScopeModel{}
+	}
 	if state.Scope != nil && e.Scope != nil {
-		flattenEbookScope(ctx, e.Scope, state.Scope)
+		flattenEbookScope(ctx, e.Scope, state.Scope, includeUnmanaged)
+	}
+	if includeUnmanaged && state.SelfService == nil && e.SelfService != nil {
+		state.SelfService = &EbookSelfServiceModel{}
 	}
 	if state.SelfService != nil && e.SelfService != nil {
 		flattenEbookSelfService(e.SelfService, state.SelfService)
@@ -77,7 +91,23 @@ func flattenEbookGeneral(g *proclassic.EbookGeneral, state *EbookGeneralModel) {
 	}
 }
 
-func flattenEbookScope(ctx context.Context, s *proclassic.EbookScope, state *EbookScopeModel) {
+// flattenEbookScope refreshes the scope sub-blocks the caller already manages.
+// When includeUnmanaged is set (config generation) every wire-present sub-block
+// is first allocated so the from-scratch read hydrates the full scope rather
+// than leaving unmanaged targets/limitations/exclusions null.
+func flattenEbookScope(ctx context.Context, s *proclassic.EbookScope, state *EbookScopeModel, includeUnmanaged bool) {
+	if includeUnmanaged {
+		if state.Targets == nil {
+			state.Targets = &EbookScopeTargetsModel{}
+		}
+		if state.Limitations == nil && s.Limitations != nil {
+			state.Limitations = &EbookScopeLimitationsModel{}
+		}
+		if state.Exclusions == nil && s.Exclusions != nil {
+			state.Exclusions = &EbookScopeExclusionsModel{}
+		}
+	}
+
 	if state.Targets != nil {
 		t := state.Targets
 		t.AllComputers = helpers.PreferCurrentBoolPointer(s.AllComputers, t.AllComputers)

--- a/internal/resources/pro/ebook/state_builders_test.go
+++ b/internal/resources/pro/ebook/state_builders_test.go
@@ -81,7 +81,7 @@ func TestFlattenEbookScope_DualTargetRoundTrip(t *testing.T) {
 		Limitations: &EbookScopeLimitationsModel{},
 		Exclusions:  &EbookScopeExclusionsModel{},
 	}
-	flattenEbookScope(ctx, s, state)
+	flattenEbookScope(ctx, s, state, false)
 
 	if setLen(state.Targets.ComputerIDs) != 2 {
 		t.Errorf("computer_ids: want 2, got %d", setLen(state.Targets.ComputerIDs))
@@ -146,6 +146,52 @@ func TestFlattenEbookSelfService_CategoriesPreserveAuthoredValuesByID(t *testing
 	c := state.Categories[0]
 	if c.ID.ValueString() != "3" || !c.DisplayIn.ValueBool() || c.FeatureIn.ValueBool() {
 		t.Errorf("category authored values not preserved: %+v", c)
+	}
+}
+
+// TestAssignEbookResourceModel_IncludeUnmanagedHydratesFromScratch pins the
+// config-generation contract: with includeUnmanaged set and an empty starting
+// model, every wire-present section is allocated and hydrated from the server.
+func TestAssignEbookResourceModel_IncludeUnmanagedHydratesFromScratch(t *testing.T) {
+	state := &EbookResourceModel{}
+	src := &proclassic.Ebook{
+		ID:      new(9),
+		General: &proclassic.EbookGeneral{Name: new("tf-acc"), URL: new("https://example.org/g.pdf")},
+		Scope: &proclassic.EbookScope{
+			AllComputers: new(true),
+			ComputerGroups: &proclassic.EbookScopeComputerGroups{
+				ComputerGroup: &[]proclassic.IDName{{ID: new(11)}, {ID: new(22)}},
+			},
+			Exclusions: &proclassic.EbookScopeExclusions{
+				UserGroups: &proclassic.EbookScopeExclusionsUserGroups{UserGroup: &[]proclassic.IDName{{Name: new("Admins")}}},
+			},
+		},
+		SelfService: &proclassic.EbookSelfService{InstallButtonText: new("Install")},
+	}
+	diags := assignEbookResourceModel(context.Background(), state, src, true)
+	if diags.HasError() {
+		t.Fatalf("unexpected diagnostics: %v", diags)
+	}
+	if state.Scope == nil || state.Scope.Targets == nil {
+		t.Fatalf("expected scope.targets hydrated from scratch; got %+v", state.Scope)
+	}
+	if !state.Scope.Targets.AllComputers.ValueBool() {
+		t.Fatal("expected all_computers hydrated true")
+	}
+	if got := setLen(state.Scope.Targets.ComputerGroupIDs); got != 2 {
+		t.Fatalf("expected 2 computer_group_ids, got %d", got)
+	}
+	if state.Scope.Exclusions == nil {
+		t.Fatal("expected exclusions allocated when wire-present")
+	}
+	if setLen(state.Scope.Exclusions.DirectoryServiceUserGroupNames) != 1 {
+		t.Fatalf("expected 1 excluded user_group name, got %d", setLen(state.Scope.Exclusions.DirectoryServiceUserGroupNames))
+	}
+	if state.Scope.Limitations != nil {
+		t.Fatalf("expected limitations nil when wire-absent; got %+v", state.Scope.Limitations)
+	}
+	if state.SelfService == nil || state.SelfService.InstallButtonText.ValueString() != "Install" {
+		t.Fatalf("expected self_service hydrated; got %+v", state.SelfService)
 	}
 }
 

--- a/internal/resources/pro/mac_app_store_app/crud.go
+++ b/internal/resources/pro/mac_app_store_app/crud.go
@@ -82,7 +82,7 @@ func (r *MacAppResource) Create(ctx context.Context, req resource.CreateRequest,
 		resp.Diagnostics.AddError("Error reading created Jamf Pro Mac App Store app", err.Error())
 		return
 	}
-	resp.Diagnostics.Append(assignMacAppResourceModel(createCtx, &plan, got)...)
+	resp.Diagnostics.Append(assignMacAppResourceModel(createCtx, &plan, got, false)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -158,7 +158,7 @@ func (r *MacAppResource) Read(ctx context.Context, req resource.ReadRequest, res
 		return
 	}
 
-	resp.Diagnostics.Append(assignMacAppResourceModel(readCtx, &state, got)...)
+	resp.Diagnostics.Append(assignMacAppResourceModel(readCtx, &state, got, false)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -205,7 +205,7 @@ func (r *MacAppResource) Update(ctx context.Context, req resource.UpdateRequest,
 		resp.Diagnostics.AddError("Error reading updated Jamf Pro Mac App Store app", err.Error())
 		return
 	}
-	resp.Diagnostics.Append(assignMacAppResourceModel(updateCtx, &plan, got)...)
+	resp.Diagnostics.Append(assignMacAppResourceModel(updateCtx, &plan, got, false)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}

--- a/internal/resources/pro/mac_app_store_app/list_resource.go
+++ b/internal/resources/pro/mac_app_store_app/list_resource.go
@@ -43,7 +43,9 @@ func NewMacAppListResource() list.ListResource {
 // block is applied client-side via filters.ApplyClassicFilter. List items carry
 // only id + name on the wire, so when IncludeResource is requested (config
 // generation) each app is fetched individually and hydrated through the shared
-// Read state-builder — matching the resource's import fidelity.
+// Read state-builder with includeUnmanaged=true, populating every wire-present
+// section (general, scope, self_service, vpp) so the generated config is
+// complete rather than general-only.
 type MacAppListResource struct {
 	client *proclassic.Client
 }
@@ -151,7 +153,7 @@ func (r *MacAppListResource) List(ctx context.Context, req list.ListRequest, str
 				ID:       id,
 				Timeouts: helpers.NewResourceTimeoutsNullValue(macAppTimeoutAttributeTypes),
 			}
-			result.Diagnostics.Append(assignMacAppResourceModel(ctx, &state, got)...)
+			result.Diagnostics.Append(assignMacAppResourceModel(ctx, &state, got, true)...)
 			result.Diagnostics.Append(result.Resource.Set(ctx, &state)...)
 			if result.Diagnostics.HasError() {
 				stream.Results = list.ListResultsStreamDiagnostics(result.Diagnostics)

--- a/internal/resources/pro/mac_app_store_app/state_builders.go
+++ b/internal/resources/pro/mac_app_store_app/state_builders.go
@@ -22,7 +22,15 @@ import (
 // section would violate the framework's "produced inconsistent result after
 // apply" check (plan said null, we'd return a populated object). See
 // feedback_server_derived_echo_attrs at block granularity.
-func assignMacAppResourceModel(ctx context.Context, state *MacAppResourceModel, a *proclassic.MacApplication) diag.Diagnostics {
+//
+// includeUnmanaged inverts those section gates for the list resource's
+// config-generation path (terraform query -generate-config-out): there is no
+// plan to stay consistent with, so every wire-present optional section is
+// allocated and hydrated, yielding a complete exported config rather than a
+// general-only one. CRUD callers pass false. The mac-app flatteners use the
+// PreferCurrent* helpers (which adopt the wire value when the current state is
+// null), so allocating an empty section is sufficient for it to fully hydrate.
+func assignMacAppResourceModel(ctx context.Context, state *MacAppResourceModel, a *proclassic.MacApplication, includeUnmanaged bool) diag.Diagnostics {
 	var diags diag.Diagnostics
 	if a == nil {
 		return diags
@@ -37,11 +45,20 @@ func assignMacAppResourceModel(ctx context.Context, state *MacAppResourceModel, 
 	}
 	flattenMacAppGeneral(a.General, state.General)
 
+	if includeUnmanaged && state.Scope == nil && a.Scope != nil {
+		state.Scope = &scope.ComputerScopeModelNoIbeacons{}
+	}
 	if state.Scope != nil && a.Scope != nil {
-		flattenMacAppScope(ctx, a.Scope, state.Scope)
+		flattenMacAppScope(ctx, a.Scope, state.Scope, includeUnmanaged)
+	}
+	if includeUnmanaged && state.SelfService == nil && a.SelfService != nil {
+		state.SelfService = &MacAppSelfServiceModel{}
 	}
 	if state.SelfService != nil && a.SelfService != nil {
 		flattenMacAppSelfService(a.SelfService, state.SelfService)
+	}
+	if includeUnmanaged && state.Vpp == nil && a.Vpp != nil {
+		state.Vpp = &MacAppVppModel{}
 	}
 	if state.Vpp != nil && a.Vpp != nil {
 		flattenMacAppVpp(a.Vpp, state.Vpp)
@@ -79,7 +96,23 @@ func flattenMacAppGeneral(g *proclassic.MacApplicationGeneral, state *MacAppGene
 	}
 }
 
-func flattenMacAppScope(ctx context.Context, s *proclassic.MacApplicationScope, state *scope.ComputerScopeModelNoIbeacons) {
+// flattenMacAppScope refreshes the scope sub-blocks the caller already manages.
+// When includeUnmanaged is set (config generation) every wire-present sub-block
+// is first allocated so the from-scratch read hydrates the full scope rather
+// than leaving unmanaged targets/limitations/exclusions null.
+func flattenMacAppScope(ctx context.Context, s *proclassic.MacApplicationScope, state *scope.ComputerScopeModelNoIbeacons, includeUnmanaged bool) {
+	if includeUnmanaged {
+		if state.Targets == nil {
+			state.Targets = &scope.ComputerScopeTargetsModel{}
+		}
+		if state.Limitations == nil && s.Limitations != nil {
+			state.Limitations = &scope.ComputerScopeLimitationsModelNoIbeacons{}
+		}
+		if state.Exclusions == nil && s.Exclusions != nil {
+			state.Exclusions = &scope.ComputerScopeExclusionsModelNoIbeacons{}
+		}
+	}
+
 	// Targets are gated on caller management, mirroring the limitations /
 	// exclusions sub-blocks below: populating a targets block the user did not
 	// declare would violate the framework's "produced inconsistent result after

--- a/internal/resources/pro/mac_app_store_app/state_builders_test.go
+++ b/internal/resources/pro/mac_app_store_app/state_builders_test.go
@@ -63,7 +63,7 @@ func TestAssignMacApp_GuardedBlocks(t *testing.T) {
 		Vpp: &proclassic.MacApplicationVpp{VppAdminAccountID: new(-1)},
 	}
 
-	diags := assignMacAppResourceModel(context.Background(), state, server)
+	diags := assignMacAppResourceModel(context.Background(), state, server, false)
 	if diags.HasError() {
 		t.Fatalf("unexpected diags: %v", diags)
 	}
@@ -78,6 +78,55 @@ func TestAssignMacApp_GuardedBlocks(t *testing.T) {
 	}
 	if state.ID.ValueString() != "42" {
 		t.Errorf("id not set: %q", state.ID.ValueString())
+	}
+}
+
+// TestAssignMacAppResourceModel_IncludeUnmanagedHydratesFromScratch pins the
+// config-generation contract: with includeUnmanaged set and an empty starting
+// model, every wire-present section is allocated and hydrated from the server.
+func TestAssignMacAppResourceModel_IncludeUnmanagedHydratesFromScratch(t *testing.T) {
+	state := &MacAppResourceModel{}
+	server := &proclassic.MacApplication{
+		ID:      new(42),
+		General: &proclassic.MacApplicationGeneral{ID: new(42), Name: new("iMovie")},
+		Scope: &proclassic.MacApplicationScope{
+			AllComputers: new(true),
+			ComputerGroups: &proclassic.MacApplicationScopeComputerGroups{
+				ComputerGroup: &[]proclassic.IDName{{ID: new(5)}, {ID: new(6)}},
+			},
+			Exclusions: &proclassic.MacApplicationScopeExclusions{
+				Users: &proclassic.MacApplicationScopeExclusionsUsers{
+					User: &[]proclassic.MacApplicationScopeExclusionsUsersUserItem{{Name: new("alice")}},
+				},
+			},
+		},
+		SelfService: &proclassic.MacApplicationSelfService{InstallButtonText: new("Install")},
+		Vpp:         &proclassic.MacApplicationVpp{AssignVppDeviceBasedLicenses: new(true)},
+	}
+	diags := assignMacAppResourceModel(context.Background(), state, server, true)
+	if diags.HasError() {
+		t.Fatalf("unexpected diags: %v", diags)
+	}
+	if state.Scope == nil || state.Scope.Targets == nil {
+		t.Fatalf("expected scope.targets hydrated from scratch; got %+v", state.Scope)
+	}
+	if !state.Scope.Targets.AllComputers.ValueBool() {
+		t.Fatal("expected all_computers hydrated true")
+	}
+	if got := len(state.Scope.Targets.ComputerGroupIDs.Elements()); got != 2 {
+		t.Fatalf("expected 2 computer_group_ids, got %d", got)
+	}
+	if state.Scope.Exclusions == nil {
+		t.Fatal("expected exclusions allocated when wire-present")
+	}
+	if state.Scope.Limitations != nil {
+		t.Fatalf("expected limitations nil when wire-absent; got %+v", state.Scope.Limitations)
+	}
+	if state.SelfService == nil || state.SelfService.InstallButtonText.ValueString() != "Install" {
+		t.Fatalf("expected self_service hydrated; got %+v", state.SelfService)
+	}
+	if state.Vpp == nil || !state.Vpp.AssignVppDeviceBasedLicenses.ValueBool() {
+		t.Fatalf("expected vpp hydrated; got %+v", state.Vpp)
 	}
 }
 
@@ -107,7 +156,7 @@ func TestFlattenMacAppScope_RoundTrip(t *testing.T) {
 			},
 		},
 	}
-	flattenMacAppScope(ctx, s, state)
+	flattenMacAppScope(ctx, s, state, false)
 
 	var computerIDs []string
 	state.Targets.ComputerIDs.ElementsAs(ctx, &computerIDs, false)

--- a/internal/resources/pro/macos_configuration_profile/crud.go
+++ b/internal/resources/pro/macos_configuration_profile/crud.go
@@ -98,7 +98,7 @@ func (r *Resource) Create(ctx context.Context, req resource.CreateRequest, resp 
 	if got != nil && got.General != nil && got.General.Payloads != nil {
 		rawServerPayload = []byte(string(*got.General.Payloads))
 	}
-	resp.Diagnostics.Append(assignResourceModel(createCtx, &plan, got)...)
+	resp.Diagnostics.Append(assignResourceModel(createCtx, &plan, got, false)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -174,7 +174,7 @@ func (r *Resource) Read(ctx context.Context, req resource.ReadRequest, resp *res
 	if got != nil && got.General != nil && got.General.Payloads != nil {
 		rawServerPayload = []byte(string(*got.General.Payloads))
 	}
-	resp.Diagnostics.Append(assignResourceModel(readCtx, &state, got)...)
+	resp.Diagnostics.Append(assignResourceModel(readCtx, &state, got, false)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -260,7 +260,7 @@ func (r *Resource) Update(ctx context.Context, req resource.UpdateRequest, resp 
 	if got != nil && got.General != nil && got.General.Payloads != nil {
 		rawServerPayload = []byte(string(*got.General.Payloads))
 	}
-	resp.Diagnostics.Append(assignResourceModel(updateCtx, &plan, got)...)
+	resp.Diagnostics.Append(assignResourceModel(updateCtx, &plan, got, false)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}

--- a/internal/resources/pro/macos_configuration_profile/list_resource.go
+++ b/internal/resources/pro/macos_configuration_profile/list_resource.go
@@ -41,9 +41,9 @@ func NewListResource() list.ListResource {
 // runs client-side after the full list is fetched. List items carry only
 // id + name, so when IncludeResource is requested (config generation) each
 // profile is fetched individually and hydrated through the shared Read
-// state-builder, which populates the general section (including the payloads
-// plist) and leaves optional sections null — matching the resource's import
-// fidelity.
+// state-builder with includeUnmanaged=true, fully populating general, scope,
+// and self_service so the generated config is complete rather than
+// general-only.
 type ListResource struct {
 	client *proclassic.Client
 }
@@ -152,7 +152,7 @@ func (r *ListResource) List(ctx context.Context, req list.ListRequest, stream *l
 				ID:       id,
 				Timeouts: helpers.NewResourceTimeoutsNullValue(timeoutAttributeTypes),
 			}
-			result.Diagnostics.Append(assignResourceModel(ctx, &state, got)...)
+			result.Diagnostics.Append(assignResourceModel(ctx, &state, got, true)...)
 			result.Diagnostics.Append(result.Resource.Set(ctx, &state)...)
 			if result.Diagnostics.HasError() {
 				stream.Results = list.ListResultsStreamDiagnostics(result.Diagnostics)

--- a/internal/resources/pro/macos_configuration_profile/state_builders.go
+++ b/internal/resources/pro/macos_configuration_profile/state_builders.go
@@ -21,7 +21,13 @@ import (
 // Optional sub-blocks are only refreshed when the caller (plan or prior
 // state) already manages them — otherwise a server-populated block would
 // trip the framework's "produced inconsistent result after apply" check.
-func assignResourceModel(ctx context.Context, state *ResourceModel, p *proclassic.OsXConfigurationProfile) diag.Diagnostics {
+//
+// includeUnmanaged inverts that gate for the list resource's
+// config-generation path (terraform query -generate-config-out): there is no
+// plan to stay consistent with, so every wire-present optional section is
+// allocated and hydrated, yielding a complete exported config rather than a
+// general-only one. CRUD callers pass false.
+func assignResourceModel(ctx context.Context, state *ResourceModel, p *proclassic.OsXConfigurationProfile, includeUnmanaged bool) diag.Diagnostics {
 	var diags diag.Diagnostics
 	if p == nil {
 		return diags
@@ -38,8 +44,14 @@ func assignResourceModel(ctx context.Context, state *ResourceModel, p *proclassi
 	}
 	flattenGeneral(p.General, state.General)
 
+	if includeUnmanaged && state.Scope == nil && p.Scope != nil {
+		state.Scope = &scope.ComputerScopeModel{}
+	}
 	if state.Scope != nil && p.Scope != nil {
-		diags.Append(flattenScope(ctx, p.Scope, state.Scope)...)
+		diags.Append(flattenScope(ctx, p.Scope, state.Scope, includeUnmanaged)...)
+	}
+	if includeUnmanaged && state.SelfService == nil && p.SelfService != nil {
+		state.SelfService = &SelfServiceModel{}
 	}
 	if state.SelfService != nil && p.SelfService != nil {
 		flattenSelfService(p.SelfService, state.SelfService)
@@ -114,10 +126,26 @@ func flattenGeneral(g *proclassic.OsXConfigurationProfileGeneral, state *General
 	}
 }
 
-func flattenScope(ctx context.Context, s *proclassic.OsXConfigurationProfileScope, state *scope.ComputerScopeModel) diag.Diagnostics {
+// flattenScope refreshes the scope sub-blocks the caller already manages.
+// When includeUnmanaged is set (config generation) every wire-present
+// sub-block is first allocated so the from-scratch read hydrates the full
+// scope rather than leaving unmanaged targets/limitations/exclusions null.
+func flattenScope(ctx context.Context, s *proclassic.OsXConfigurationProfileScope, state *scope.ComputerScopeModel, includeUnmanaged bool) diag.Diagnostics {
 	var diags diag.Diagnostics
 	if s == nil {
 		return diags
+	}
+
+	if includeUnmanaged {
+		if state.Targets == nil {
+			state.Targets = &scope.ComputerScopeTargetsModel{}
+		}
+		if state.Limitations == nil && s.Limitations != nil {
+			state.Limitations = &scope.ComputerScopeLimitationsModel{}
+		}
+		if state.Exclusions == nil && s.Exclusions != nil {
+			state.Exclusions = &scope.ComputerScopeExclusionsModel{}
+		}
 	}
 
 	// Targets are gated on caller management, mirroring the limitations /
@@ -125,8 +153,8 @@ func flattenScope(ctx context.Context, s *proclassic.OsXConfigurationProfileScop
 	// declare would violate the framework's "produced inconsistent result after
 	// apply" check (plan said null, we would return a populated object).
 	if state.Targets != nil {
-		state.Targets.AllComputers = helpers.ReconcileOptionalBoolPointer(s.AllComputers, state.Targets.AllComputers)
-		state.Targets.AllJssUsers = helpers.ReconcileOptionalBoolPointer(s.AllJssUsers, state.Targets.AllJssUsers)
+		state.Targets.AllComputers = helpers.ReconcileOrAdoptBoolPointer(s.AllComputers, state.Targets.AllComputers, includeUnmanaged)
+		state.Targets.AllJssUsers = helpers.ReconcileOrAdoptBoolPointer(s.AllJssUsers, state.Targets.AllJssUsers, includeUnmanaged)
 
 		if s.Computers != nil {
 			v, d := scope.FlattenIDSlice(ctx, s.Computers.Computer, func(c proclassic.OsXConfigurationProfileScopeComputersComputerItem) *int {

--- a/internal/resources/pro/macos_configuration_profile/state_builders_test.go
+++ b/internal/resources/pro/macos_configuration_profile/state_builders_test.go
@@ -82,7 +82,7 @@ func TestFlattenScope_NilSubBlocksProduceEmptySets(t *testing.T) {
 	state := &scope.ComputerScopeModel{Targets: &scope.ComputerScopeTargetsModel{AllComputers: types.BoolValue(false)}}
 	diags := flattenScope(context.Background(), &proclassic.OsXConfigurationProfileScope{
 		AllComputers: new(true),
-	}, state)
+	}, state, false)
 	if diags.HasError() {
 		t.Fatalf("diags: %v", diags)
 	}
@@ -111,7 +111,7 @@ func TestFlattenScope_ReconcileLeavesNullWhenStateUnconfigured(t *testing.T) {
 	state := &scope.ComputerScopeModel{Targets: &scope.ComputerScopeTargetsModel{}}
 	flattenScope(context.Background(), &proclassic.OsXConfigurationProfileScope{
 		AllComputers: new(true),
-	}, state)
+	}, state, false)
 	if !state.Targets.AllComputers.IsNull() {
 		t.Fatalf("expected AllComputers to stay null for unconfigured state, got %v", state.Targets.AllComputers)
 	}
@@ -128,7 +128,7 @@ func TestFlattenScope_ComputerIDsPopulated(t *testing.T) {
 			},
 		},
 	}
-	diags := flattenScope(context.Background(), src, state)
+	diags := flattenScope(context.Background(), src, state, false)
 	if diags.HasError() {
 		t.Fatalf("diags: %v", diags)
 	}
@@ -303,7 +303,7 @@ func TestAssignResourceModel_TopLevelIDFromGeneral(t *testing.T) {
 	state := &ResourceModel{}
 	diags := assignResourceModel(context.Background(), state, &proclassic.OsXConfigurationProfile{
 		General: &proclassic.OsXConfigurationProfileGeneral{ID: new(99), Name: new("X")},
-	})
+	}, false)
 	if diags.HasError() {
 		t.Fatalf("diags: %v", diags)
 	}
@@ -324,7 +324,7 @@ func TestAssignResourceModel_OptionalSubBlocksSkippedWhenStateNil(t *testing.T) 
 		SelfService: &proclassic.OsXConfigurationProfileSelfService{
 			InstallButtonText: new("Install"),
 		},
-	})
+	}, false)
 	if diags.HasError() {
 		t.Fatalf("diags: %v", diags)
 	}
@@ -351,7 +351,7 @@ func TestAssignResourceModel_PopulatedSubBlocksRefreshed(t *testing.T) {
 		SelfService: &proclassic.OsXConfigurationProfileSelfService{
 			InstallButtonText: new("Install"),
 		},
-	})
+	}, false)
 	if diags.HasError() {
 		t.Fatalf("diags: %v", diags)
 	}
@@ -360,6 +360,46 @@ func TestAssignResourceModel_PopulatedSubBlocksRefreshed(t *testing.T) {
 	}
 	if state.SelfService.InstallButtonText.ValueString() != "Install" {
 		t.Fatalf("SelfService.InstallButtonText: got %q", state.SelfService.InstallButtonText.ValueString())
+	}
+}
+
+// TestAssignResourceModel_IncludeUnmanagedHydratesFromScratch pins the
+// config-generation contract: with includeUnmanaged set and an empty starting
+// model, every wire-present optional section is allocated and hydrated.
+func TestAssignResourceModel_IncludeUnmanagedHydratesFromScratch(t *testing.T) {
+	t.Parallel()
+	state := &ResourceModel{}
+	diags := assignResourceModel(context.Background(), state, &proclassic.OsXConfigurationProfile{
+		ID:      new(7),
+		General: &proclassic.OsXConfigurationProfileGeneral{Name: new("X")},
+		Scope: &proclassic.OsXConfigurationProfileScope{
+			AllComputers: new(true),
+			Computers: &proclassic.OsXConfigurationProfileScopeComputers{
+				Computer: &[]proclassic.OsXConfigurationProfileScopeComputersComputerItem{{ID: new(5)}},
+			},
+			Exclusions: &proclassic.OsXConfigurationProfileScopeExclusions{},
+		},
+		SelfService: &proclassic.OsXConfigurationProfileSelfService{
+			InstallButtonText: new("Install"),
+		},
+	}, true)
+	if diags.HasError() {
+		t.Fatalf("diags: %v", diags)
+	}
+	if state.Scope == nil || state.Scope.Targets == nil {
+		t.Fatalf("expected Scope.Targets hydrated from scratch; got %+v", state.Scope)
+	}
+	if !state.Scope.Targets.AllComputers.ValueBool() {
+		t.Fatal("expected all_computers hydrated true")
+	}
+	if state.Scope.Exclusions == nil {
+		t.Fatal("expected Exclusions allocated when wire-present")
+	}
+	if state.Scope.Limitations != nil {
+		t.Fatalf("expected Limitations to stay nil when wire-absent; got %+v", state.Scope.Limitations)
+	}
+	if state.SelfService == nil || state.SelfService.InstallButtonText.ValueString() != "Install" {
+		t.Fatalf("expected SelfService hydrated; got %+v", state.SelfService)
 	}
 }
 

--- a/internal/resources/pro/mobile_device_app/crud.go
+++ b/internal/resources/pro/mobile_device_app/crud.go
@@ -115,7 +115,7 @@ func (r *MobileAppResource) Create(ctx context.Context, req resource.CreateReque
 		resp.Diagnostics.AddError("Error reading created Jamf Pro mobile device app", err.Error())
 		return
 	}
-	resp.Diagnostics.Append(assignMobileAppResourceModel(createCtx, &plan, got)...)
+	resp.Diagnostics.Append(assignMobileAppResourceModel(createCtx, &plan, got, false)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -191,7 +191,7 @@ func (r *MobileAppResource) Read(ctx context.Context, req resource.ReadRequest, 
 		return
 	}
 
-	resp.Diagnostics.Append(assignMobileAppResourceModel(readCtx, &state, got)...)
+	resp.Diagnostics.Append(assignMobileAppResourceModel(readCtx, &state, got, false)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -239,7 +239,7 @@ func (r *MobileAppResource) Update(ctx context.Context, req resource.UpdateReque
 		resp.Diagnostics.AddError("Error reading updated Jamf Pro mobile device app", err.Error())
 		return
 	}
-	resp.Diagnostics.Append(assignMobileAppResourceModel(updateCtx, &plan, got)...)
+	resp.Diagnostics.Append(assignMobileAppResourceModel(updateCtx, &plan, got, false)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}

--- a/internal/resources/pro/mobile_device_app/list_resource.go
+++ b/internal/resources/pro/mobile_device_app/list_resource.go
@@ -43,8 +43,10 @@ func NewMobileAppListResource() list.ListResource {
 // optional `filter` block is applied client-side via filters.ApplyClassicFilter.
 // List items carry only id + name on the wire, so when IncludeResource is
 // requested (config generation) each app is fetched individually and hydrated
-// through the shared Read state-builder — matching the resource's import
-// fidelity.
+// through the shared Read state-builder with includeUnmanaged=true, populating
+// every wire-present section (general, scope, self_service, vpp,
+// app_configuration) so the generated config is complete rather than
+// general-only.
 type MobileAppListResource struct {
 	client *proclassic.Client
 }
@@ -152,7 +154,7 @@ func (r *MobileAppListResource) List(ctx context.Context, req list.ListRequest, 
 				ID:       id,
 				Timeouts: helpers.NewResourceTimeoutsNullValue(mobileAppTimeoutAttributeTypes),
 			}
-			result.Diagnostics.Append(assignMobileAppResourceModel(ctx, &state, got)...)
+			result.Diagnostics.Append(assignMobileAppResourceModel(ctx, &state, got, true)...)
 			result.Diagnostics.Append(result.Resource.Set(ctx, &state)...)
 			if result.Diagnostics.HasError() {
 				stream.Results = list.ListResultsStreamDiagnostics(result.Diagnostics)

--- a/internal/resources/pro/mobile_device_app/state_builders.go
+++ b/internal/resources/pro/mobile_device_app/state_builders.go
@@ -22,7 +22,15 @@ import (
 // an unmanaged section would violate the framework's "produced inconsistent
 // result after apply" check. See feedback_server_derived_echo_attrs at block
 // granularity.
-func assignMobileAppResourceModel(ctx context.Context, state *MobileAppResourceModel, a *proclassic.MobileDeviceApplication) diag.Diagnostics {
+//
+// includeUnmanaged inverts those section gates for the list resource's
+// config-generation path (terraform query -generate-config-out): there is no
+// plan to stay consistent with, so every wire-present optional section is
+// allocated and hydrated, yielding a complete exported config rather than a
+// general-only one. CRUD callers pass false. The mobile-app flatteners use the
+// PreferCurrent* helpers (which adopt the wire value when the current state is
+// null), so allocating an empty section is sufficient for it to fully hydrate.
+func assignMobileAppResourceModel(ctx context.Context, state *MobileAppResourceModel, a *proclassic.MobileDeviceApplication, includeUnmanaged bool) diag.Diagnostics {
 	var diags diag.Diagnostics
 	if a == nil {
 		return diags
@@ -37,14 +45,26 @@ func assignMobileAppResourceModel(ctx context.Context, state *MobileAppResourceM
 	}
 	flattenMobileAppGeneral(a.General, state.General)
 
+	if includeUnmanaged && state.Scope == nil && a.Scope != nil {
+		state.Scope = &scope.MobileScopeModelNoIbeacons{}
+	}
 	if state.Scope != nil && a.Scope != nil {
-		flattenMobileAppScope(ctx, a.Scope, state.Scope)
+		flattenMobileAppScope(ctx, a.Scope, state.Scope, includeUnmanaged)
+	}
+	if includeUnmanaged && state.SelfService == nil && a.SelfService != nil {
+		state.SelfService = &MobileAppSelfServiceModel{}
 	}
 	if state.SelfService != nil && a.SelfService != nil {
 		flattenMobileAppSelfService(a.SelfService, state.SelfService)
 	}
+	if includeUnmanaged && state.Vpp == nil && a.Vpp != nil {
+		state.Vpp = &MobileAppVppModel{}
+	}
 	if state.Vpp != nil && a.Vpp != nil {
 		flattenMobileAppVpp(a.Vpp, state.Vpp)
+	}
+	if includeUnmanaged && state.AppConfiguration == nil && a.AppConfiguration != nil {
+		state.AppConfiguration = &MobileAppAppConfigurationModel{}
 	}
 	if state.AppConfiguration != nil && a.AppConfiguration != nil {
 		// Preserve the configured value when the server differs only by newline
@@ -113,7 +133,23 @@ func flattenMobileAppGeneral(g *proclassic.MobileDeviceApplicationGeneral, state
 	}
 }
 
-func flattenMobileAppScope(ctx context.Context, s *proclassic.MobileDeviceApplicationScope, state *scope.MobileScopeModelNoIbeacons) {
+// flattenMobileAppScope refreshes the scope sub-blocks the caller already
+// manages. When includeUnmanaged is set (config generation) every wire-present
+// sub-block is first allocated so the from-scratch read hydrates the full scope
+// rather than leaving unmanaged targets/limitations/exclusions null.
+func flattenMobileAppScope(ctx context.Context, s *proclassic.MobileDeviceApplicationScope, state *scope.MobileScopeModelNoIbeacons, includeUnmanaged bool) {
+	if includeUnmanaged {
+		if state.Targets == nil {
+			state.Targets = &scope.MobileScopeTargetsModel{}
+		}
+		if state.Limitations == nil && s.Limitations != nil {
+			state.Limitations = &scope.MobileScopeLimitationsModelNoIbeacons{}
+		}
+		if state.Exclusions == nil && s.Exclusions != nil {
+			state.Exclusions = &scope.MobileScopeExclusionsModelNoIbeacons{}
+		}
+	}
+
 	if state.Targets != nil {
 		state.Targets.AllMobileDevices = helpers.PreferCurrentBoolPointer(s.AllMobileDevices, state.Targets.AllMobileDevices)
 		state.Targets.AllJssUsers = helpers.PreferCurrentBoolPointer(s.AllJssUsers, state.Targets.AllJssUsers)

--- a/internal/resources/pro/mobile_device_app/state_builders_test.go
+++ b/internal/resources/pro/mobile_device_app/state_builders_test.go
@@ -82,7 +82,7 @@ func TestAssignMobileApp_GuardedBlocks(t *testing.T) {
 		AppConfiguration: &proclassic.MobileDeviceApplicationAppConfiguration{Preferences: new("<dict/>")},
 	}
 
-	diags := assignMobileAppResourceModel(context.Background(), state, server)
+	diags := assignMobileAppResourceModel(context.Background(), state, server, false)
 	if diags.HasError() {
 		t.Fatalf("unexpected diags: %v", diags)
 	}
@@ -100,6 +100,59 @@ func TestAssignMobileApp_GuardedBlocks(t *testing.T) {
 	}
 	if state.ID.ValueString() != "42" {
 		t.Errorf("id not set: %q", state.ID.ValueString())
+	}
+}
+
+// TestAssignMobileAppResourceModel_IncludeUnmanagedHydratesFromScratch pins the
+// config-generation contract: with includeUnmanaged set and an empty starting
+// model, every wire-present section is allocated and hydrated from the server.
+func TestAssignMobileAppResourceModel_IncludeUnmanagedHydratesFromScratch(t *testing.T) {
+	state := &MobileAppResourceModel{}
+	server := &proclassic.MobileDeviceApplication{
+		ID:      new(42),
+		General: &proclassic.MobileDeviceApplicationGeneral{ID: new(42), Name: new("Maps"), OsType: new(osTypeIOS)},
+		Scope: &proclassic.MobileDeviceApplicationScope{
+			AllMobileDevices: new(true),
+			MobileDeviceGroups: &proclassic.MobileDeviceApplicationScopeMobileDeviceGroups{
+				MobileDeviceGroup: &[]proclassic.IDName{{ID: new(5)}, {ID: new(6)}},
+			},
+			Exclusions: &proclassic.MobileDeviceApplicationScopeExclusions{
+				Users: &proclassic.MobileDeviceApplicationScopeExclusionsUsers{
+					User: &[]proclassic.MobileDeviceApplicationScopeExclusionsUsersUserItem{{Name: new("alice")}},
+				},
+			},
+		},
+		SelfService:      &proclassic.MobileDeviceApplicationSelfService{SelfServiceInstallButtonText: new("Install")},
+		Vpp:              &proclassic.MobileDeviceApplicationVpp{AssignVppDeviceBasedLicenses: new(true)},
+		AppConfiguration: &proclassic.MobileDeviceApplicationAppConfiguration{Preferences: new("<dict/>")},
+	}
+	diags := assignMobileAppResourceModel(context.Background(), state, server, true)
+	if diags.HasError() {
+		t.Fatalf("unexpected diags: %v", diags)
+	}
+	if state.Scope == nil || state.Scope.Targets == nil {
+		t.Fatalf("expected scope.targets hydrated from scratch; got %+v", state.Scope)
+	}
+	if !state.Scope.Targets.AllMobileDevices.ValueBool() {
+		t.Fatal("expected all_mobile_devices hydrated true")
+	}
+	if got := len(state.Scope.Targets.MobileDeviceGroupIDs.Elements()); got != 2 {
+		t.Fatalf("expected 2 mobile_device_group_ids, got %d", got)
+	}
+	if state.Scope.Exclusions == nil {
+		t.Fatal("expected exclusions allocated when wire-present")
+	}
+	if state.Scope.Limitations != nil {
+		t.Fatalf("expected limitations nil when wire-absent; got %+v", state.Scope.Limitations)
+	}
+	if state.SelfService == nil || state.SelfService.InstallButtonText.ValueString() != "Install" {
+		t.Fatalf("expected self_service hydrated; got %+v", state.SelfService)
+	}
+	if state.Vpp == nil || !state.Vpp.AssignVppDeviceBasedLicenses.ValueBool() {
+		t.Fatalf("expected vpp hydrated; got %+v", state.Vpp)
+	}
+	if state.AppConfiguration == nil || state.AppConfiguration.Preferences.ValueString() != "<dict/>" {
+		t.Fatalf("expected app_configuration hydrated; got %+v", state.AppConfiguration)
 	}
 }
 
@@ -129,7 +182,7 @@ func TestFlattenMobileAppScope_RoundTrip(t *testing.T) {
 			},
 		},
 	}
-	flattenMobileAppScope(ctx, s, state)
+	flattenMobileAppScope(ctx, s, state, false)
 
 	var mdIDs []string
 	state.Targets.MobileDeviceIDs.ElementsAs(ctx, &mdIDs, false)

--- a/internal/resources/pro/mobile_device_configuration_profile/crud.go
+++ b/internal/resources/pro/mobile_device_configuration_profile/crud.go
@@ -89,7 +89,7 @@ func (r *Resource) Create(ctx context.Context, req resource.CreateRequest, resp 
 	if got != nil && got.General != nil && got.General.Payloads != nil {
 		rawServerPayload = []byte(string(*got.General.Payloads))
 	}
-	resp.Diagnostics.Append(assignResourceModel(createCtx, &plan, got)...)
+	resp.Diagnostics.Append(assignResourceModel(createCtx, &plan, got, false)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -165,7 +165,7 @@ func (r *Resource) Read(ctx context.Context, req resource.ReadRequest, resp *res
 	if got != nil && got.General != nil && got.General.Payloads != nil {
 		rawServerPayload = []byte(string(*got.General.Payloads))
 	}
-	resp.Diagnostics.Append(assignResourceModel(readCtx, &state, got)...)
+	resp.Diagnostics.Append(assignResourceModel(readCtx, &state, got, false)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -242,7 +242,7 @@ func (r *Resource) Update(ctx context.Context, req resource.UpdateRequest, resp 
 	if got != nil && got.General != nil && got.General.Payloads != nil {
 		rawServerPayload = []byte(string(*got.General.Payloads))
 	}
-	resp.Diagnostics.Append(assignResourceModel(updateCtx, &plan, got)...)
+	resp.Diagnostics.Append(assignResourceModel(updateCtx, &plan, got, false)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}

--- a/internal/resources/pro/mobile_device_configuration_profile/list_resource.go
+++ b/internal/resources/pro/mobile_device_configuration_profile/list_resource.go
@@ -39,9 +39,9 @@ func NewListResource() list.ListResource {
 // ListResource queries mobile device configuration profiles. List items carry
 // only id + name, so when IncludeResource is requested (config generation) each
 // profile is fetched individually and hydrated through the shared Read
-// state-builder, which populates the general section (including the payloads
-// plist) and leaves optional sections null — matching the resource's import
-// fidelity.
+// state-builder with includeUnmanaged=true, fully populating general, scope,
+// and self_service so the generated config is complete rather than
+// general-only.
 type ListResource struct {
 	client *proclassic.Client
 }
@@ -150,7 +150,7 @@ func (r *ListResource) List(ctx context.Context, req list.ListRequest, stream *l
 				ID:       id,
 				Timeouts: helpers.NewResourceTimeoutsNullValue(timeoutAttributeTypes),
 			}
-			result.Diagnostics.Append(assignResourceModel(ctx, &state, got)...)
+			result.Diagnostics.Append(assignResourceModel(ctx, &state, got, true)...)
 			result.Diagnostics.Append(result.Resource.Set(ctx, &state)...)
 			if result.Diagnostics.HasError() {
 				stream.Results = list.ListResultsStreamDiagnostics(result.Diagnostics)

--- a/internal/resources/pro/mobile_device_configuration_profile/state_builders.go
+++ b/internal/resources/pro/mobile_device_configuration_profile/state_builders.go
@@ -17,7 +17,17 @@ import (
 	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/common/scope"
 )
 
-func assignResourceModel(ctx context.Context, state *ResourceModel, p *proclassic.MobileDeviceConfigurationProfile) diag.Diagnostics {
+// assignResourceModel populates a ResourceModel from the SDK response.
+// Optional sub-blocks are only refreshed when the caller (plan or prior
+// state) already manages them — otherwise a server-populated block would
+// trip the framework's "produced inconsistent result after apply" check.
+//
+// includeUnmanaged inverts that gate for the list resource's
+// config-generation path (terraform query -generate-config-out): there is no
+// plan to stay consistent with, so every wire-present optional section is
+// allocated and hydrated, yielding a complete exported config rather than a
+// general-only one. CRUD callers pass false.
+func assignResourceModel(ctx context.Context, state *ResourceModel, p *proclassic.MobileDeviceConfigurationProfile, includeUnmanaged bool) diag.Diagnostics {
 	var diags diag.Diagnostics
 	if p == nil {
 		return diags
@@ -34,8 +44,14 @@ func assignResourceModel(ctx context.Context, state *ResourceModel, p *proclassi
 	}
 	flattenGeneral(p.General, state.General)
 
+	if includeUnmanaged && state.Scope == nil && p.Scope != nil {
+		state.Scope = &scope.MobileScopeModel{}
+	}
 	if state.Scope != nil && p.Scope != nil {
-		diags.Append(flattenScope(ctx, p.Scope, state.Scope)...)
+		diags.Append(flattenScope(ctx, p.Scope, state.Scope, includeUnmanaged)...)
+	}
+	if includeUnmanaged && state.SelfService == nil && p.SelfService != nil {
+		state.SelfService = &SelfServiceModel{}
 	}
 	if state.SelfService != nil && p.SelfService != nil {
 		flattenSelfService(p.SelfService, state.SelfService)
@@ -97,10 +113,26 @@ func flattenGeneral(g *proclassic.MobileDeviceConfigurationProfileGeneral, state
 	}
 }
 
-func flattenScope(ctx context.Context, s *proclassic.MobileDeviceConfigurationProfileScope, state *scope.MobileScopeModel) diag.Diagnostics {
+// flattenScope refreshes the scope sub-blocks the caller already manages.
+// When includeUnmanaged is set (config generation) every wire-present
+// sub-block is first allocated so the from-scratch read hydrates the full
+// scope rather than leaving unmanaged targets/limitations/exclusions null.
+func flattenScope(ctx context.Context, s *proclassic.MobileDeviceConfigurationProfileScope, state *scope.MobileScopeModel, includeUnmanaged bool) diag.Diagnostics {
 	var diags diag.Diagnostics
 	if s == nil {
 		return diags
+	}
+
+	if includeUnmanaged {
+		if state.Targets == nil {
+			state.Targets = &scope.MobileScopeTargetsModel{}
+		}
+		if state.Limitations == nil && s.Limitations != nil {
+			state.Limitations = &scope.MobileScopeLimitationsModel{}
+		}
+		if state.Exclusions == nil && s.Exclusions != nil {
+			state.Exclusions = &scope.MobileScopeExclusionsModel{}
+		}
 	}
 
 	// Targets are gated on caller management, mirroring the limitations /
@@ -108,8 +140,8 @@ func flattenScope(ctx context.Context, s *proclassic.MobileDeviceConfigurationPr
 	// declare would violate the framework's "produced inconsistent result after
 	// apply" check (plan said null, we would return a populated object).
 	if state.Targets != nil {
-		state.Targets.AllMobileDevices = helpers.ReconcileOptionalBoolPointer(s.AllMobileDevices, state.Targets.AllMobileDevices)
-		state.Targets.AllJssUsers = helpers.ReconcileOptionalBoolPointer(s.AllJssUsers, state.Targets.AllJssUsers)
+		state.Targets.AllMobileDevices = helpers.ReconcileOrAdoptBoolPointer(s.AllMobileDevices, state.Targets.AllMobileDevices, includeUnmanaged)
+		state.Targets.AllJssUsers = helpers.ReconcileOrAdoptBoolPointer(s.AllJssUsers, state.Targets.AllJssUsers, includeUnmanaged)
 
 		if s.MobileDevices != nil {
 			v, d := scope.FlattenIDSlice(ctx, s.MobileDevices.MobileDevice, func(c proclassic.MobileDeviceConfigurationProfileScopeMobileDevicesMobileDeviceItem) *int {

--- a/internal/resources/pro/mobile_device_configuration_profile/state_builders_test.go
+++ b/internal/resources/pro/mobile_device_configuration_profile/state_builders_test.go
@@ -99,7 +99,7 @@ func TestFlattenScope_NilSubBlocksProduceEmptySets(t *testing.T) {
 	state := &scope.MobileScopeModel{Targets: &scope.MobileScopeTargetsModel{AllMobileDevices: types.BoolValue(false)}}
 	diags := flattenScope(context.Background(), &proclassic.MobileDeviceConfigurationProfileScope{
 		AllMobileDevices: new(true),
-	}, state)
+	}, state, false)
 	if diags.HasError() {
 		t.Fatalf("diags: %v", diags)
 	}
@@ -125,7 +125,7 @@ func TestFlattenScope_ReconcileLeavesNullWhenStateUnconfigured(t *testing.T) {
 	state := &scope.MobileScopeModel{}
 	flattenScope(context.Background(), &proclassic.MobileDeviceConfigurationProfileScope{
 		AllMobileDevices: new(true),
-	}, state)
+	}, state, false)
 	if state.Targets != nil {
 		t.Fatalf("expected Targets to stay nil for unconfigured state, got %v", state.Targets)
 	}
@@ -141,7 +141,7 @@ func TestFlattenScope_MobileDeviceIDsPopulated(t *testing.T) {
 				{ID: new(31)},
 			},
 		},
-	}, state)
+	}, state, false)
 	if diags.HasError() {
 		t.Fatalf("diags: %v", diags)
 	}
@@ -266,7 +266,7 @@ func TestAssignResourceModel_TopLevelIDFromGeneral(t *testing.T) {
 	state := &ResourceModel{}
 	diags := assignResourceModel(context.Background(), state, &proclassic.MobileDeviceConfigurationProfile{
 		General: &proclassic.MobileDeviceConfigurationProfileGeneral{ID: new(99), Name: new("X")},
-	})
+	}, false)
 	if diags.HasError() {
 		t.Fatalf("diags: %v", diags)
 	}
@@ -287,7 +287,7 @@ func TestAssignResourceModel_OptionalSubBlocksSkippedWhenStateNil(t *testing.T) 
 		SelfService: &proclassic.MobileDeviceConfigurationProfileSelfService{
 			SelfServiceDescription: new("desc"),
 		},
-	})
+	}, false)
 	if diags.HasError() {
 		t.Fatalf("diags: %v", diags)
 	}
@@ -314,7 +314,7 @@ func TestAssignResourceModel_PopulatedSubBlocksRefreshed(t *testing.T) {
 				RemovalDisallowed: new(removalDisallowedNever),
 			},
 		},
-	})
+	}, false)
 	if diags.HasError() {
 		t.Fatalf("diags: %v", diags)
 	}
@@ -323,5 +323,42 @@ func TestAssignResourceModel_PopulatedSubBlocksRefreshed(t *testing.T) {
 	}
 	if state.SelfService.RemovalDisallowed.ValueString() != removalDisallowedNever {
 		t.Fatalf("SelfService.RemovalDisallowed: got %q", state.SelfService.RemovalDisallowed.ValueString())
+	}
+}
+
+// TestAssignResourceModel_IncludeUnmanagedHydratesFromScratch pins the
+// config-generation contract: with includeUnmanaged set and an empty starting
+// model, every wire-present optional section is allocated and hydrated.
+func TestAssignResourceModel_IncludeUnmanagedHydratesFromScratch(t *testing.T) {
+	t.Parallel()
+	state := &ResourceModel{}
+	diags := assignResourceModel(context.Background(), state, &proclassic.MobileDeviceConfigurationProfile{
+		ID:      new(7),
+		General: &proclassic.MobileDeviceConfigurationProfileGeneral{Name: new("X")},
+		Scope: &proclassic.MobileDeviceConfigurationProfileScope{
+			AllMobileDevices: new(true),
+			Exclusions:       &proclassic.MobileDeviceConfigurationProfileScopeExclusions{},
+		},
+		SelfService: &proclassic.MobileDeviceConfigurationProfileSelfService{
+			SelfServiceDescription: new("desc"),
+		},
+	}, true)
+	if diags.HasError() {
+		t.Fatalf("diags: %v", diags)
+	}
+	if state.Scope == nil || state.Scope.Targets == nil {
+		t.Fatalf("expected Scope.Targets hydrated from scratch; got %+v", state.Scope)
+	}
+	if !state.Scope.Targets.AllMobileDevices.ValueBool() {
+		t.Fatal("expected all_mobile_devices hydrated true")
+	}
+	if state.Scope.Exclusions == nil {
+		t.Fatal("expected Exclusions allocated when wire-present")
+	}
+	if state.Scope.Limitations != nil {
+		t.Fatalf("expected Limitations to stay nil when wire-absent; got %+v", state.Scope.Limitations)
+	}
+	if state.SelfService == nil {
+		t.Fatalf("expected SelfService hydrated; got nil")
 	}
 }

--- a/internal/resources/pro/patch_policy/crud.go
+++ b/internal/resources/pro/patch_policy/crud.go
@@ -107,7 +107,7 @@ func (r *PatchPolicyResource) Create(ctx context.Context, req resource.CreateReq
 		resp.Diagnostics.AddError("Error reading created Jamf Pro patch policy", err.Error())
 		return
 	}
-	resp.Diagnostics.Append(assignPatchPolicyResourceModel(createCtx, &plan, got)...)
+	resp.Diagnostics.Append(assignPatchPolicyResourceModel(createCtx, &plan, got, false)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -183,7 +183,7 @@ func (r *PatchPolicyResource) Read(ctx context.Context, req resource.ReadRequest
 		return
 	}
 
-	resp.Diagnostics.Append(assignPatchPolicyResourceModel(readCtx, &state, got)...)
+	resp.Diagnostics.Append(assignPatchPolicyResourceModel(readCtx, &state, got, false)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -228,7 +228,7 @@ func (r *PatchPolicyResource) Update(ctx context.Context, req resource.UpdateReq
 		resp.Diagnostics.AddError("Error reading updated Jamf Pro patch policy", err.Error())
 		return
 	}
-	resp.Diagnostics.Append(assignPatchPolicyResourceModel(updateCtx, &plan, got)...)
+	resp.Diagnostics.Append(assignPatchPolicyResourceModel(updateCtx, &plan, got, false)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}

--- a/internal/resources/pro/patch_policy/list_resource.go
+++ b/internal/resources/pro/patch_policy/list_resource.go
@@ -12,7 +12,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/list"
 	listschema "github.com/hashicorp/terraform-plugin-framework/list/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
-	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
 	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/common/filters"
@@ -24,6 +23,11 @@ import (
 // /patchpolicies endpoint. The list resource schema does not expose a
 // user-overridable timeout, so this is a fixed safety bound.
 const defaultListTimeout = 90 * time.Second
+
+// defaultItemReadTimeout bounds each per-item GET issued when IncludeResource is
+// requested (config generation). A single slow item is skipped from the
+// generated config rather than aborting the whole type.
+const defaultItemReadTimeout = 30 * time.Second
 
 var _ list.ListResource = &PatchPolicyListResource{}
 var _ list.ListResourceWithConfigure = &PatchPolicyListResource{}
@@ -71,11 +75,12 @@ func (r *PatchPolicyListResource) ListResourceConfigSchema(ctx context.Context, 
 
 // List executes the query and streams patch policy identities back to Terraform.
 //
-// The classic /patchpolicies list endpoint returns only id+name per item. When
-// include_resource is requested we therefore hydrate only id and name; the
-// remaining attributes are set null rather than issuing a per-item GET against
-// this concurrency-sensitive classic endpoint. Consumers needing full detail
-// should use the singular data source or the managed resource.
+// The classic /patchpolicies list endpoint returns only id+name per item, so
+// when IncludeResource is requested (config generation) each policy is fetched
+// individually and hydrated through the shared Read state-builder with
+// includeUnmanaged=true, populating every wire-present section (general, scope,
+// user_interaction) so the generated config is complete rather than
+// identity-only.
 func (r *PatchPolicyListResource) List(ctx context.Context, req list.ListRequest, stream *list.ListResultsStream) {
 	if r.client == nil {
 		stream.Results = list.ListResultsStreamDiagnostics(diag.Diagnostics{
@@ -143,25 +148,21 @@ func (r *PatchPolicyListResource) List(ctx context.Context, req list.ListRequest
 		}
 
 		if req.IncludeResource {
-			// The list endpoint exposes only id+name; the remaining attributes
-			// are left null (see method doc).
-			objType := types.ObjectType{AttrTypes: killAppAttrTypes}
-			state := PatchPolicyResourceModel{
-				ID:                           id,
-				SoftwareTitleConfigurationID: types.StringNull(),
-				Name:                         helpers.StringPointerValueOrNull(s.Name),
-				Enabled:                      types.BoolNull(),
-				TargetVersion:                types.StringNull(),
-				DistributionMethod:           types.StringNull(),
-				AllowDowngrade:               types.BoolNull(),
-				PatchUnknown:                 types.BoolNull(),
-				ReleaseDate:                  types.Int64Null(),
-				IncrementalUpdate:            types.BoolNull(),
-				Reboot:                       types.BoolNull(),
-				MinimumOS:                    types.StringNull(),
-				KillApps:                     types.ListNull(objType),
-				Timeouts:                     helpers.NewResourceTimeoutsNullValue(patchPolicyTimeoutAttributeTypes),
+			itemCtx, cancel := context.WithTimeout(ctx, defaultItemReadTimeout)
+			got, err := r.client.GetPatchPolicyByID(itemCtx, id.ValueString())
+			cancel()
+			if err != nil {
+				tflog.Warn(ctx, "Skipping Jamf Pro patch policy from generated config after per-item read failure", map[string]any{
+					"id":    id.ValueString(),
+					"error": err.Error(),
+				})
+				continue
 			}
+			state := PatchPolicyResourceModel{
+				ID:       id,
+				Timeouts: helpers.NewResourceTimeoutsNullValue(patchPolicyTimeoutAttributeTypes),
+			}
+			result.Diagnostics.Append(assignPatchPolicyResourceModel(ctx, &state, got, true)...)
 			result.Diagnostics.Append(result.Resource.Set(ctx, &state)...)
 			if result.Diagnostics.HasError() {
 				stream.Results = list.ListResultsStreamDiagnostics(result.Diagnostics)

--- a/internal/resources/pro/patch_policy/state_builders.go
+++ b/internal/resources/pro/patch_policy/state_builders.go
@@ -23,7 +23,15 @@ import (
 // block would violate the framework's "produced inconsistent result after apply"
 // check (plan said null, we'd return a populated object). See
 // feedback_server_derived_echo_attrs.
-func assignPatchPolicyResourceModel(ctx context.Context, state *PatchPolicyResourceModel, p *proclassic.PatchPolicy) diag.Diagnostics {
+//
+// includeUnmanaged inverts those section gates for the list resource's
+// config-generation path (terraform query -generate-config-out): there is no
+// plan to stay consistent with, so every wire-present optional section is
+// allocated and hydrated, yielding a complete exported config rather than a
+// general-only one. CRUD callers pass false. The patch-policy flatteners use the
+// PreferCurrent* helpers (which adopt the wire value when the current state is
+// null), so allocating an empty section is sufficient for it to fully hydrate.
+func assignPatchPolicyResourceModel(ctx context.Context, state *PatchPolicyResourceModel, p *proclassic.PatchPolicy, includeUnmanaged bool) diag.Diagnostics {
 	var diags diag.Diagnostics
 	if p == nil {
 		return diags
@@ -38,12 +46,18 @@ func assignPatchPolicyResourceModel(ctx context.Context, state *PatchPolicyResou
 
 	diags.Append(flattenGeneral(ctx, p.General, state)...)
 
+	if includeUnmanaged && state.Scope == nil && p.Scope != nil {
+		state.Scope = &PatchPolicyScopeModel{}
+	}
 	if state.Scope != nil && p.Scope != nil {
-		flattenScope(ctx, p.Scope, state.Scope)
+		flattenScope(ctx, p.Scope, state.Scope, includeUnmanaged)
 	}
 
+	if includeUnmanaged && state.UserInteraction == nil && p.UserInteraction != nil {
+		state.UserInteraction = &PatchPolicyUserInteractionModel{}
+	}
 	if state.UserInteraction != nil && p.UserInteraction != nil {
-		flattenUserInteraction(p.UserInteraction, state.UserInteraction)
+		flattenUserInteraction(p.UserInteraction, state.UserInteraction, includeUnmanaged)
 	}
 
 	return diags
@@ -101,7 +115,23 @@ func flattenKillApps(ctx context.Context, ka *proclassic.PatchPolicyGeneralKillA
 	return types.ListValue(objType, objects)
 }
 
-func flattenScope(ctx context.Context, s *proclassic.PatchPolicyScope, state *PatchPolicyScopeModel) {
+// flattenScope refreshes the scope sub-blocks the caller already manages. When
+// includeUnmanaged is set (config generation) every wire-present sub-block is
+// first allocated so the from-scratch read hydrates the full scope rather than
+// leaving unmanaged targets/limitations/exclusions null.
+func flattenScope(ctx context.Context, s *proclassic.PatchPolicyScope, state *PatchPolicyScopeModel, includeUnmanaged bool) {
+	if includeUnmanaged {
+		if state.Targets == nil {
+			state.Targets = &PatchPolicyScopeTargetsModel{}
+		}
+		if state.Limitations == nil && s.Limitations != nil {
+			state.Limitations = &PatchPolicyScopeLimitationsModel{}
+		}
+		if state.Exclusions == nil && s.Exclusions != nil {
+			state.Exclusions = &PatchPolicyScopeExclusionsModel{}
+		}
+	}
+
 	if state.Targets != nil {
 		state.Targets.AllComputers = helpers.PreferCurrentBoolPointer(s.AllComputers, state.Targets.AllComputers)
 		state.Targets.ComputerIDs = flattenComputerSet(ctx, computerSlice(s.Computers))
@@ -127,7 +157,27 @@ func flattenScope(ctx context.Context, s *proclassic.PatchPolicyScope, state *Pa
 	}
 }
 
-func flattenUserInteraction(ui *proclassic.PatchPolicyUserInteraction, state *PatchPolicyUserInteractionModel) {
+// flattenUserInteraction refreshes the user_interaction sub-blocks the caller
+// already manages. When includeUnmanaged is set (config generation) every
+// wire-present sub-block (and the reminders block nested under notifications) is
+// first allocated so the from-scratch read hydrates the full block rather than
+// leaving unmanaged notifications/deadlines/grace_period null.
+func flattenUserInteraction(ui *proclassic.PatchPolicyUserInteraction, state *PatchPolicyUserInteractionModel, includeUnmanaged bool) {
+	if includeUnmanaged {
+		if state.Notifications == nil && ui.Notifications != nil {
+			state.Notifications = &PatchPolicyUserInteractionNotificationsModel{}
+		}
+		if state.Notifications != nil && state.Notifications.Reminders == nil && ui.Notifications != nil && ui.Notifications.Reminders != nil {
+			state.Notifications.Reminders = &PatchPolicyUserInteractionNotificationsRemindersModel{}
+		}
+		if state.Deadlines == nil && ui.Deadlines != nil {
+			state.Deadlines = &PatchPolicyUserInteractionDeadlinesModel{}
+		}
+		if state.GracePeriod == nil && ui.GracePeriod != nil {
+			state.GracePeriod = &PatchPolicyUserInteractionGracePeriodModel{}
+		}
+	}
+
 	state.InstallButtonText = helpers.PreferCurrentStringPointer(ui.InstallButtonText, state.InstallButtonText)
 	state.SelfServiceDescription = helpers.PreferCurrentStringPointer(ui.SelfServiceDescription, state.SelfServiceDescription)
 	if ui.SelfServiceIcon != nil {

--- a/internal/resources/pro/patch_policy/state_builders_test.go
+++ b/internal/resources/pro/patch_policy/state_builders_test.go
@@ -35,7 +35,7 @@ func TestAssignResourceModel_GeneralSplit(t *testing.T) {
 	}
 
 	state := &PatchPolicyResourceModel{}
-	diags := assignPatchPolicyResourceModel(context.Background(), state, p)
+	diags := assignPatchPolicyResourceModel(context.Background(), state, p, false)
 	if diags.HasError() {
 		t.Fatalf("assign diags: %v", diags)
 	}
@@ -140,7 +140,7 @@ func TestFlattenScope_EntityByID(t *testing.T) {
 			Exclusions:  &PatchPolicyScopeExclusionsModel{},
 		},
 	}
-	diags := assignPatchPolicyResourceModel(context.Background(), state, p)
+	diags := assignPatchPolicyResourceModel(context.Background(), state, p, false)
 	if diags.HasError() {
 		t.Fatalf("assign diags: %v", diags)
 	}
@@ -172,7 +172,7 @@ func TestFlattenScope_UnmanagedNotRefreshed(t *testing.T) {
 		},
 	}
 	state := &PatchPolicyResourceModel{} // Scope nil → unmanaged.
-	if diags := assignPatchPolicyResourceModel(context.Background(), state, p); diags.HasError() {
+	if diags := assignPatchPolicyResourceModel(context.Background(), state, p, false); diags.HasError() {
 		t.Fatalf("assign diags: %v", diags)
 	}
 	if state.Scope != nil {
@@ -217,7 +217,7 @@ func TestFlattenUserInteraction_NestedRoundTrip(t *testing.T) {
 			GracePeriod: &PatchPolicyUserInteractionGracePeriodModel{},
 		},
 	}
-	if diags := assignPatchPolicyResourceModel(context.Background(), state, p); diags.HasError() {
+	if diags := assignPatchPolicyResourceModel(context.Background(), state, p, false); diags.HasError() {
 		t.Fatalf("assign diags: %v", diags)
 	}
 
@@ -239,6 +239,75 @@ func TestFlattenUserInteraction_NestedRoundTrip(t *testing.T) {
 	}
 	if ui.GracePeriod.Duration.ValueInt64() != 15 || ui.GracePeriod.NotificationCenterSubject.ValueString() != "Important" {
 		t.Errorf("grace_period not flattened")
+	}
+}
+
+// TestAssignPatchPolicyResourceModel_IncludeUnmanagedHydratesFromScratch pins
+// the config-generation contract: with includeUnmanaged set and an empty
+// starting model, every wire-present section (scope + its sub-blocks,
+// user_interaction + its sub-blocks) is allocated and hydrated from the server.
+func TestAssignPatchPolicyResourceModel_IncludeUnmanagedHydratesFromScratch(t *testing.T) {
+	p := &proclassic.PatchPolicy{
+		ID:      new(1),
+		General: &proclassic.PatchPolicyGeneral{Name: new("p"), TargetVersion: new("1.0")},
+		Scope: &proclassic.PatchPolicyScope{
+			AllComputers: new(true),
+			ComputerGroups: &proclassic.PatchPolicyScopeComputerGroups{
+				ComputerGroup: &[]proclassic.IDName{{ID: new(20)}, {ID: new(21)}},
+			},
+			Exclusions: &proclassic.PatchPolicyScopeExclusions{
+				Ibeacons: &proclassic.PatchPolicyScopeExclusionsIbeacons{
+					Ibeacon: &[]proclassic.IDName{{ID: new(75)}},
+				},
+			},
+		},
+		UserInteraction: &proclassic.PatchPolicyUserInteraction{
+			InstallButtonText: new("Update"),
+			Notifications: &proclassic.PatchPolicyUserInteractionNotifications{
+				NotificationEnabled: new(true),
+				Reminders: &proclassic.PatchPolicyUserInteractionNotificationsReminders{
+					NotificationReminderFrequency: new(24),
+				},
+			},
+			Deadlines: &proclassic.PatchPolicyUserInteractionDeadlines{DeadlinePeriod: new(7)},
+		},
+	}
+
+	state := &PatchPolicyResourceModel{}
+	diags := assignPatchPolicyResourceModel(context.Background(), state, p, true)
+	if diags.HasError() {
+		t.Fatalf("assign diags: %v", diags)
+	}
+
+	if state.Scope == nil || state.Scope.Targets == nil {
+		t.Fatalf("expected scope.targets hydrated from scratch; got %+v", state.Scope)
+	}
+	if !state.Scope.Targets.AllComputers.ValueBool() {
+		t.Fatal("expected all_computers hydrated true")
+	}
+	if got := setStrings(t, state.Scope.Targets.ComputerGroupIDs); len(got) != 2 {
+		t.Fatalf("expected 2 computer_group_ids, got %v", got)
+	}
+	if state.Scope.Exclusions == nil || len(setStrings(t, state.Scope.Exclusions.IbeaconIDs)) != 1 {
+		t.Fatalf("expected exclusions ibeacon hydrated; got %+v", state.Scope.Exclusions)
+	}
+	if state.Scope.Limitations != nil {
+		t.Fatalf("expected limitations nil when wire-absent; got %+v", state.Scope.Limitations)
+	}
+	if state.UserInteraction == nil || state.UserInteraction.InstallButtonText.ValueString() != "Update" {
+		t.Fatalf("expected user_interaction hydrated; got %+v", state.UserInteraction)
+	}
+	if state.UserInteraction.Notifications == nil || !state.UserInteraction.Notifications.Enabled.ValueBool() {
+		t.Fatalf("expected notifications hydrated; got %+v", state.UserInteraction.Notifications)
+	}
+	if state.UserInteraction.Notifications.Reminders == nil || state.UserInteraction.Notifications.Reminders.Frequency.ValueInt64() != 24 {
+		t.Fatalf("expected reminders hydrated; got %+v", state.UserInteraction.Notifications.Reminders)
+	}
+	if state.UserInteraction.Deadlines == nil || state.UserInteraction.Deadlines.Period.ValueInt64() != 7 {
+		t.Fatalf("expected deadlines hydrated; got %+v", state.UserInteraction.Deadlines)
+	}
+	if state.UserInteraction.GracePeriod != nil {
+		t.Fatalf("expected grace_period nil when wire-absent; got %+v", state.UserInteraction.GracePeriod)
 	}
 }
 

--- a/internal/resources/pro/policy/crud.go
+++ b/internal/resources/pro/policy/crud.go
@@ -83,7 +83,7 @@ func (r *PolicyResource) Create(ctx context.Context, req resource.CreateRequest,
 		resp.Diagnostics.AddError("Error reading created Jamf Pro policy", err.Error())
 		return
 	}
-	resp.Diagnostics.Append(assignPolicyResourceModel(createCtx, &plan, got)...)
+	resp.Diagnostics.Append(assignPolicyResourceModel(createCtx, &plan, got, false)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -159,7 +159,7 @@ func (r *PolicyResource) Read(ctx context.Context, req resource.ReadRequest, res
 		return
 	}
 
-	resp.Diagnostics.Append(assignPolicyResourceModel(readCtx, &state, got)...)
+	resp.Diagnostics.Append(assignPolicyResourceModel(readCtx, &state, got, false)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -216,7 +216,7 @@ func (r *PolicyResource) Update(ctx context.Context, req resource.UpdateRequest,
 		resp.Diagnostics.AddError("Error reading updated Jamf Pro policy", err.Error())
 		return
 	}
-	resp.Diagnostics.Append(assignPolicyResourceModel(updateCtx, &plan, got)...)
+	resp.Diagnostics.Append(assignPolicyResourceModel(updateCtx, &plan, got, false)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}

--- a/internal/resources/pro/policy/list_resource.go
+++ b/internal/resources/pro/policy/list_resource.go
@@ -43,8 +43,9 @@ func NewPolicyListResource() list.ListResource {
 // applied client-side via filters.ApplyClassicFilter. List items carry only
 // id + name on the wire, so when IncludeResource is requested (config
 // generation) each policy is fetched individually and hydrated through the
-// shared Read state-builder, which populates the general section and leaves
-// optional sections null — matching the resource's import fidelity.
+// shared Read state-builder with includeUnmanaged=true, populating every
+// wire-present section (general, scope, self_service, scripts, packages, …)
+// so the generated config is complete rather than general-only.
 type PolicyListResource struct {
 	client *proclassic.Client
 }
@@ -157,7 +158,7 @@ func (r *PolicyListResource) List(ctx context.Context, req list.ListRequest, str
 				ID:       id,
 				Timeouts: helpers.NewResourceTimeoutsNullValue(policyTimeoutAttributeTypes),
 			}
-			result.Diagnostics.Append(assignPolicyResourceModel(ctx, &state, got)...)
+			result.Diagnostics.Append(assignPolicyResourceModel(ctx, &state, got, true)...)
 			result.Diagnostics.Append(result.Resource.Set(ctx, &state)...)
 			if result.Diagnostics.HasError() {
 				stream.Results = list.ListResultsStreamDiagnostics(result.Diagnostics)

--- a/internal/resources/pro/policy/state_builders.go
+++ b/internal/resources/pro/policy/state_builders.go
@@ -17,7 +17,16 @@ import (
 // assignPolicyResourceModel populates a resource model from the SDK Policy
 // response. Server is authoritative for every Optional+Computed field — the
 // helper reconciles against the current state so unmanaged fields stay null.
-func assignPolicyResourceModel(ctx context.Context, state *PolicyResourceModel, p *proclassic.Policy) diag.Diagnostics {
+//
+// includeUnmanaged inverts the section gates for the list resource's
+// config-generation path (terraform query -generate-config-out): there is no
+// plan to stay consistent with, so every wire-present optional section is
+// allocated and hydrated from the server, yielding a complete exported config
+// rather than a general-only one. CRUD callers pass false. Because the policy
+// flatteners use the PreferCurrent* helpers (which adopt the wire value when
+// the current state is null), allocating an empty section is sufficient for it
+// to fully hydrate.
+func assignPolicyResourceModel(ctx context.Context, state *PolicyResourceModel, p *proclassic.Policy, includeUnmanaged bool) diag.Diagnostics {
 	var diags diag.Diagnostics
 	if p == nil {
 		return diags
@@ -32,27 +41,47 @@ func assignPolicyResourceModel(ctx context.Context, state *PolicyResourceModel, 
 	if state.General == nil {
 		state.General = &PolicyGeneralModel{}
 	}
-	flattenPolicyGeneral(ctx, p.General, state.General)
+	flattenPolicyGeneral(ctx, p.General, state.General, includeUnmanaged)
 
 	// Optional sections are only refreshed when the caller (plan or current
 	// state) already manages them. Server returns every section in GET with
 	// default values — populating an unmanaged section would violate the
 	// framework's "produced inconsistent result after apply" check, because
-	// plan said null and we'd return a populated object.
+	// plan said null and we'd return a populated object. includeUnmanaged
+	// allocates each wire-present section first so config generation hydrates
+	// the whole policy.
+	if includeUnmanaged && state.Scope == nil && p.Scope != nil {
+		state.Scope = &scope.ComputerScopeModel{}
+	}
 	if state.Scope != nil && p.Scope != nil {
-		diags.Append(flattenPolicyScope(ctx, p.Scope, state.Scope)...)
+		diags.Append(flattenPolicyScope(ctx, p.Scope, state.Scope, includeUnmanaged)...)
+	}
+	if includeUnmanaged && state.SelfService == nil && p.SelfService != nil {
+		state.SelfService = &PolicySelfServiceModel{}
 	}
 	if state.SelfService != nil && p.SelfService != nil {
-		flattenPolicySelfService(p.SelfService, state.SelfService)
+		flattenPolicySelfService(p.SelfService, state.SelfService, includeUnmanaged)
+	}
+	if includeUnmanaged && state.Packages == nil && p.PackageConfiguration != nil {
+		state.Packages = &PolicyPackagesModel{}
 	}
 	if state.Packages != nil && p.PackageConfiguration != nil {
 		flattenPolicyPackageConfiguration(p.PackageConfiguration, state.Packages)
 	}
+	if includeUnmanaged && state.Scripts == nil && p.Scripts != nil {
+		state.Scripts = &PolicyScriptsModel{}
+	}
 	if state.Scripts != nil && p.Scripts != nil {
 		flattenPolicyScripts(p.Scripts, state.Scripts)
 	}
+	if includeUnmanaged && state.Printers == nil && p.Printers != nil {
+		state.Printers = &PolicyPrintersModel{}
+	}
 	if state.Printers != nil && p.Printers != nil {
 		flattenPolicyPrinters(p.Printers, state.Printers)
+	}
+	if includeUnmanaged && state.DockItems == nil && p.DockItems != nil {
+		state.DockItems = &PolicyDockItemsModel{}
 	}
 	if state.DockItems != nil && p.DockItems != nil {
 		flattenPolicyDockItems(p.DockItems, state.DockItems)
@@ -62,19 +91,34 @@ func assignPolicyResourceModel(ctx context.Context, state *PolicyResourceModel, 
 	// caller already manages it (per-section gate), mirroring the optional
 	// section discipline above.
 	if p.AccountMaintenance != nil {
-		flattenPolicyAccountMaintenance(p.AccountMaintenance, state)
+		flattenPolicyAccountMaintenance(p.AccountMaintenance, state, includeUnmanaged)
+	}
+	if includeUnmanaged && state.RestartOptions == nil && p.Reboot != nil {
+		state.RestartOptions = &PolicyRestartOptionsModel{}
 	}
 	if state.RestartOptions != nil && p.Reboot != nil {
 		flattenPolicyReboot(p.Reboot, state.RestartOptions)
 	}
+	if includeUnmanaged && state.Maintenance == nil && p.Maintenance != nil {
+		state.Maintenance = &PolicyMaintenanceModel{}
+	}
 	if state.Maintenance != nil && p.Maintenance != nil {
 		flattenPolicyMaintenance(p.Maintenance, state.Maintenance)
+	}
+	if includeUnmanaged && state.FilesAndProcesses == nil && p.FilesProcesses != nil {
+		state.FilesAndProcesses = &PolicyFilesAndProcessesModel{}
 	}
 	if state.FilesAndProcesses != nil && p.FilesProcesses != nil {
 		flattenPolicyFilesProcesses(p.FilesProcesses, state.FilesAndProcesses)
 	}
+	if includeUnmanaged && state.UserInteraction == nil && p.UserInteraction != nil {
+		state.UserInteraction = &PolicyUserInteractionModel{}
+	}
 	if state.UserInteraction != nil && p.UserInteraction != nil {
 		flattenPolicyUserInteraction(p.UserInteraction, state.UserInteraction)
+	}
+	if includeUnmanaged && state.DiskEncryption == nil && p.DiskEncryption != nil {
+		state.DiskEncryption = &PolicyDiskEncryptionModel{}
 	}
 	if state.DiskEncryption != nil && p.DiskEncryption != nil {
 		flattenPolicyDiskEncryption(p.DiskEncryption, state.DiskEncryption)
@@ -83,9 +127,21 @@ func assignPolicyResourceModel(ctx context.Context, state *PolicyResourceModel, 
 	return diags
 }
 
-func flattenPolicyGeneral(ctx context.Context, g *proclassic.PolicyGeneral, state *PolicyGeneralModel) {
+func flattenPolicyGeneral(ctx context.Context, g *proclassic.PolicyGeneral, state *PolicyGeneralModel, includeUnmanaged bool) {
 	if g == nil {
 		return
+	}
+
+	if includeUnmanaged {
+		if state.DateTimeLimitations == nil && g.DateTimeLimitations != nil {
+			state.DateTimeLimitations = &PolicyGeneralDateTimeLimitationsModel{}
+		}
+		if state.NetworkLimitations == nil && g.NetworkLimitations != nil {
+			state.NetworkLimitations = &PolicyGeneralNetworkLimitationsModel{}
+		}
+		if state.OverrideDefaultSettings == nil && g.OverrideDefaultSettings != nil {
+			state.OverrideDefaultSettings = &PolicyGeneralOverrideDefaultsModel{}
+		}
 	}
 	state.ID = helpers.StringValueFromIntPtr(g.ID)
 	state.Name = helpers.StringPointerValueOrNull(g.Name)
@@ -169,8 +225,20 @@ func flattenPolicyNetworkLimitations(ctx context.Context, nl *proclassic.PolicyG
 	}
 }
 
-func flattenPolicyScope(ctx context.Context, s *proclassic.PolicyScope, state *scope.ComputerScopeModel) diag.Diagnostics {
+func flattenPolicyScope(ctx context.Context, s *proclassic.PolicyScope, state *scope.ComputerScopeModel, includeUnmanaged bool) diag.Diagnostics {
 	var diags diag.Diagnostics
+
+	if includeUnmanaged {
+		if state.Targets == nil {
+			state.Targets = &scope.ComputerScopeTargetsModel{}
+		}
+		if state.Limitations == nil && s.Limitations != nil {
+			state.Limitations = &scope.ComputerScopeLimitationsModel{}
+		}
+		if state.Exclusions == nil && s.Exclusions != nil {
+			state.Exclusions = &scope.ComputerScopeExclusionsModel{}
+		}
+	}
 
 	// Targets are gated on caller management, mirroring the limitations /
 	// exclusions sub-blocks below: populating a targets block the user did not
@@ -363,7 +431,15 @@ func flattenExclUsersNameSet(ctx context.Context, u *proclassic.PolicyScopeExclu
 
 // ---- self_service / packages / scripts / printers / dock_items / etc. ----------
 
-func flattenPolicySelfService(ss *proclassic.PolicySelfService, state *PolicySelfServiceModel) {
+func flattenPolicySelfService(ss *proclassic.PolicySelfService, state *PolicySelfServiceModel, includeUnmanaged bool) {
+	if includeUnmanaged {
+		if state.SelfServiceIcon == nil && ss.SelfServiceIcon != nil {
+			state.SelfServiceIcon = &PolicySelfServiceIconModel{}
+		}
+		if state.Categories == nil {
+			state.Categories = []PolicySelfServiceCategoryItemModel{}
+		}
+	}
 	state.UseForSelfService = helpers.PreferCurrentBoolPointer(ss.UseForSelfService, state.UseForSelfService)
 	state.SelfServiceDisplayName = helpers.PreferCurrentStringPointer(ss.SelfServiceDisplayName, state.SelfServiceDisplayName)
 	state.InstallButtonText = helpers.PreferCurrentStringPointer(ss.InstallButtonText, state.InstallButtonText)
@@ -515,7 +591,21 @@ func flattenPolicyDockItems(d *proclassic.PolicyDockItems, state *PolicyDockItem
 // DirectoryBindings non-nil, ManagementAccount / EfiPassword non-nil) —
 // populating an unmanaged section would violate the framework's "produced
 // inconsistent result after apply" check.
-func flattenPolicyAccountMaintenance(am *proclassic.PolicyAccountMaintenance, state *PolicyResourceModel) {
+func flattenPolicyAccountMaintenance(am *proclassic.PolicyAccountMaintenance, state *PolicyResourceModel, includeUnmanaged bool) {
+	if includeUnmanaged {
+		if state.LocalAccounts == nil && am.Accounts != nil && am.Accounts.Account != nil {
+			state.LocalAccounts = []PolicyAccountItemModel{}
+		}
+		if state.DirectoryBindings == nil && am.DirectoryBindings != nil && am.DirectoryBindings.Binding != nil {
+			state.DirectoryBindings = []PolicyDirectoryBindingItemModel{}
+		}
+		if state.ManagementAccount == nil && am.ManagementAccount != nil {
+			state.ManagementAccount = &PolicyManagementAccountModel{}
+		}
+		if state.EfiPassword == nil && am.OpenFirmwareEfiPassword != nil {
+			state.EfiPassword = &PolicyOpenFirmwareEfiPasswordModel{}
+		}
+	}
 	if state.LocalAccounts != nil && am.Accounts != nil && am.Accounts.Account != nil {
 		// Reorder wire accounts to match the plan's declared username
 		// order. The Jamf classic /policies endpoint does not preserve

--- a/internal/resources/pro/policy/state_builders_test.go
+++ b/internal/resources/pro/policy/state_builders_test.go
@@ -29,7 +29,7 @@ func TestAssignPolicyResourceModel_MinimalPolicy(t *testing.T) {
 			Enabled: new(true),
 		},
 	}
-	diags := assignPolicyResourceModel(context.Background(), state, src)
+	diags := assignPolicyResourceModel(context.Background(), state, src, false)
 	if diags.HasError() {
 		t.Fatalf("unexpected diagnostics: %v", diags)
 	}
@@ -65,7 +65,7 @@ func TestAssignPolicyResourceModel_FlattensScopeIDs(t *testing.T) {
 			},
 		},
 	}
-	diags := assignPolicyResourceModel(context.Background(), state, src)
+	diags := assignPolicyResourceModel(context.Background(), state, src, false)
 	if diags.HasError() {
 		t.Fatalf("unexpected diagnostics: %v", diags)
 	}
@@ -99,7 +99,7 @@ func TestAssignPolicyResourceModel_RoundTripNotification(t *testing.T) {
 			NotificationType: new("Self Service"),
 		},
 	}
-	diags := assignPolicyResourceModel(context.Background(), state, src)
+	diags := assignPolicyResourceModel(context.Background(), state, src, false)
 	if diags.HasError() {
 		t.Fatalf("unexpected diagnostics: %v", diags)
 	}
@@ -123,7 +123,7 @@ func TestAssignPolicyResourceModel_PackageConfigurationDistributionPoint(t *test
 			DistributionPoint: new("Dummy DP"),
 		},
 	}
-	diags := assignPolicyResourceModel(context.Background(), state, src)
+	diags := assignPolicyResourceModel(context.Background(), state, src, false)
 	if diags.HasError() {
 		t.Fatalf("unexpected diagnostics: %v", diags)
 	}
@@ -149,11 +149,67 @@ func TestAssignPolicyResourceModel_PackageConfigurationConfiguredWins(t *testing
 			DistributionPoint: new("Server DP"),
 		},
 	}
-	diags := assignPolicyResourceModel(context.Background(), state, src)
+	diags := assignPolicyResourceModel(context.Background(), state, src, false)
 	if diags.HasError() {
 		t.Fatalf("unexpected diagnostics: %v", diags)
 	}
 	if got := state.Packages.DistributionPoint.ValueString(); got != "Configured DP" {
 		t.Fatalf("preferCurrentStringPointer should keep configured value, got %q", got)
+	}
+}
+
+// TestAssignPolicyResourceModel_IncludeUnmanagedHydratesFromScratch pins the
+// config-generation contract: with includeUnmanaged set and an empty starting
+// model, every wire-present section is allocated and hydrated from the server.
+func TestAssignPolicyResourceModel_IncludeUnmanagedHydratesFromScratch(t *testing.T) {
+	t.Parallel()
+	state := &PolicyResourceModel{}
+	src := &proclassic.Policy{
+		ID:      new(9),
+		General: &proclassic.PolicyGeneral{Name: new("tf-acc"), Enabled: new(true)},
+		Scope: &proclassic.PolicyScope{
+			AllComputers: new(true),
+			ComputerGroups: &proclassic.PolicyScopeComputerGroups{
+				ComputerGroup: &[]proclassic.IDName{{ID: new(11)}, {ID: new(22)}},
+			},
+			Exclusions: &proclassic.PolicyScopeExclusions{},
+		},
+		Scripts: &proclassic.PolicyScripts{
+			Script: &[]proclassic.PolicyScriptsScriptItem{{ID: new(3), Priority: new("After")}},
+		},
+		PackageConfiguration: &proclassic.PolicyPackageConfiguration{
+			Packages: &proclassic.PolicyPackageConfigurationPackages{
+				Package: &[]proclassic.PolicyPackageConfigurationPackagesPackageItem{{ID: new(4)}},
+			},
+		},
+		SelfService: &proclassic.PolicySelfService{UseForSelfService: new(true)},
+	}
+	diags := assignPolicyResourceModel(context.Background(), state, src, true)
+	if diags.HasError() {
+		t.Fatalf("unexpected diagnostics: %v", diags)
+	}
+	if state.Scope == nil || state.Scope.Targets == nil {
+		t.Fatalf("expected scope.targets hydrated from scratch; got %+v", state.Scope)
+	}
+	if !state.Scope.Targets.AllComputers.ValueBool() {
+		t.Fatal("expected all_computers hydrated true")
+	}
+	if got := len(state.Scope.Targets.ComputerGroupIDs.Elements()); got != 2 {
+		t.Fatalf("expected 2 computer_group_ids, got %d", got)
+	}
+	if state.Scope.Exclusions == nil {
+		t.Fatal("expected exclusions allocated when wire-present")
+	}
+	if state.Scope.Limitations != nil {
+		t.Fatalf("expected limitations nil when wire-absent; got %+v", state.Scope.Limitations)
+	}
+	if state.Scripts == nil || len(state.Scripts.Scripts) != 1 {
+		t.Fatalf("expected scripts hydrated; got %+v", state.Scripts)
+	}
+	if state.Packages == nil || len(state.Packages.Packages) != 1 {
+		t.Fatalf("expected packages hydrated; got %+v", state.Packages)
+	}
+	if state.SelfService == nil || !state.SelfService.UseForSelfService.ValueBool() {
+		t.Fatalf("expected self_service hydrated; got %+v", state.SelfService)
 	}
 }

--- a/internal/resources/pro/restricted_software/crud.go
+++ b/internal/resources/pro/restricted_software/crud.go
@@ -83,7 +83,7 @@ func (r *RestrictedSoftwareResource) Create(ctx context.Context, req resource.Cr
 		resp.Diagnostics.AddError("Error reading created Jamf Pro restricted software", err.Error())
 		return
 	}
-	resp.Diagnostics.Append(assignRestrictedSoftwareResourceModel(createCtx, &plan, got)...)
+	resp.Diagnostics.Append(assignRestrictedSoftwareResourceModel(createCtx, &plan, got, false)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -159,7 +159,7 @@ func (r *RestrictedSoftwareResource) Read(ctx context.Context, req resource.Read
 		return
 	}
 
-	resp.Diagnostics.Append(assignRestrictedSoftwareResourceModel(readCtx, &state, got)...)
+	resp.Diagnostics.Append(assignRestrictedSoftwareResourceModel(readCtx, &state, got, false)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -205,7 +205,7 @@ func (r *RestrictedSoftwareResource) Update(ctx context.Context, req resource.Up
 		resp.Diagnostics.AddError("Error reading updated Jamf Pro restricted software", err.Error())
 		return
 	}
-	resp.Diagnostics.Append(assignRestrictedSoftwareResourceModel(updateCtx, &plan, got)...)
+	resp.Diagnostics.Append(assignRestrictedSoftwareResourceModel(updateCtx, &plan, got, false)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}

--- a/internal/resources/pro/restricted_software/list_resource.go
+++ b/internal/resources/pro/restricted_software/list_resource.go
@@ -44,8 +44,9 @@ func NewRestrictedSoftwareListResource() list.ListResource {
 // — the optional `filter` block is applied client-side via
 // filters.ApplyClassicFilter. List items carry only id + name on the wire, so
 // when IncludeResource is requested (config generation) each record is fetched
-// individually and hydrated through the shared Read state-builder — matching
-// the resource's import fidelity.
+// individually and hydrated through the shared Read state-builder with
+// includeUnmanaged=true, populating every wire-present section (general, scope)
+// so the generated config is complete rather than general-only.
 type RestrictedSoftwareListResource struct {
 	client *proclassic.Client
 }
@@ -153,7 +154,7 @@ func (r *RestrictedSoftwareListResource) List(ctx context.Context, req list.List
 				ID:       id,
 				Timeouts: helpers.NewResourceTimeoutsNullValue(restrictedSoftwareTimeoutAttributeTypes),
 			}
-			result.Diagnostics.Append(assignRestrictedSoftwareResourceModel(ctx, &state, got)...)
+			result.Diagnostics.Append(assignRestrictedSoftwareResourceModel(ctx, &state, got, true)...)
 			result.Diagnostics.Append(result.Resource.Set(ctx, &state)...)
 			if result.Diagnostics.HasError() {
 				stream.Results = list.ListResultsStreamDiagnostics(result.Diagnostics)

--- a/internal/resources/pro/restricted_software/state_builders.go
+++ b/internal/resources/pro/restricted_software/state_builders.go
@@ -21,7 +21,15 @@ import (
 // default values, so populating an unmanaged block would violate the
 // framework's "produced inconsistent result after apply" check (plan said null,
 // we'd return a populated object). See feedback_server_derived_echo_attrs.
-func assignRestrictedSoftwareResourceModel(ctx context.Context, state *RestrictedSoftwareResourceModel, rs *proclassic.RestrictedSoftware) diag.Diagnostics {
+//
+// includeUnmanaged inverts that gate for the list resource's config-generation
+// path (terraform query -generate-config-out): there is no plan to stay
+// consistent with, so a wire-present scope is allocated and hydrated, yielding a
+// complete exported config rather than a general-only one. CRUD callers pass
+// false. The flatteners use the PreferCurrent* helpers (which adopt the wire
+// value when the current state is null), so allocating an empty section is
+// sufficient for it to fully hydrate.
+func assignRestrictedSoftwareResourceModel(ctx context.Context, state *RestrictedSoftwareResourceModel, rs *proclassic.RestrictedSoftware, includeUnmanaged bool) diag.Diagnostics {
 	var diags diag.Diagnostics
 	if rs == nil {
 		return diags
@@ -36,8 +44,11 @@ func assignRestrictedSoftwareResourceModel(ctx context.Context, state *Restricte
 	}
 	flattenGeneral(rs.General, state.General)
 
+	if includeUnmanaged && state.Scope == nil && rs.Scope != nil {
+		state.Scope = &RestrictedSoftwareScopeModel{}
+	}
 	if state.Scope != nil && rs.Scope != nil {
-		flattenScope(ctx, rs.Scope, state.Scope)
+		flattenScope(ctx, rs.Scope, state.Scope, includeUnmanaged)
 	}
 
 	return diags
@@ -65,7 +76,21 @@ func flattenGeneral(g *proclassic.RestrictedSoftwareGeneral, state *RestrictedSo
 	}
 }
 
-func flattenScope(ctx context.Context, s *proclassic.RestrictedSoftwareScope, state *RestrictedSoftwareScopeModel) {
+// flattenScope refreshes the scope sub-blocks the caller already manages. When
+// includeUnmanaged is set (config generation) every wire-present sub-block is
+// first allocated so the from-scratch read hydrates the full scope rather than
+// leaving unmanaged targets/exclusions null. Restricted software has no
+// limitations tab.
+func flattenScope(ctx context.Context, s *proclassic.RestrictedSoftwareScope, state *RestrictedSoftwareScopeModel, includeUnmanaged bool) {
+	if includeUnmanaged {
+		if state.Targets == nil {
+			state.Targets = &RestrictedSoftwareScopeTargetsModel{}
+		}
+		if state.Exclusions == nil && s.Exclusions != nil {
+			state.Exclusions = &RestrictedSoftwareScopeExclusionsModel{}
+		}
+	}
+
 	if state.Targets != nil {
 		state.Targets.AllComputers = helpers.PreferCurrentBoolPointer(s.AllComputers, state.Targets.AllComputers)
 		state.Targets.ComputerIDs = scope.FlattenIDNameSet(ctx, computerSlice(s.Computers))

--- a/internal/resources/pro/restricted_software/state_builders_test.go
+++ b/internal/resources/pro/restricted_software/state_builders_test.go
@@ -70,6 +70,48 @@ func TestFlattenGeneral_PrefersConfigured(t *testing.T) {
 	}
 }
 
+// TestAssignRestrictedSoftwareResourceModel_IncludeUnmanagedHydratesFromScratch
+// pins the config-generation contract: with includeUnmanaged set and an empty
+// starting model, the wire-present scope is allocated and hydrated from the
+// server.
+func TestAssignRestrictedSoftwareResourceModel_IncludeUnmanagedHydratesFromScratch(t *testing.T) {
+	state := &RestrictedSoftwareResourceModel{}
+	src := &proclassic.RestrictedSoftware{
+		ID:      new(9),
+		General: &proclassic.RestrictedSoftwareGeneral{Name: new("blocked"), ProcessName: new("evil.app")},
+		Scope: &proclassic.RestrictedSoftwareScope{
+			AllComputers: new(true),
+			ComputerGroups: &proclassic.RestrictedSoftwareScopeComputerGroups{
+				ComputerGroup: &[]proclassic.IDName{{ID: new(11)}, {ID: new(22)}},
+			},
+			Exclusions: &proclassic.RestrictedSoftwareScopeExclusions{
+				Users: &proclassic.RestrictedSoftwareScopeExclusionsUsers{
+					User: &[]proclassic.IDName{{Name: new("alice")}},
+				},
+			},
+		},
+	}
+	diags := assignRestrictedSoftwareResourceModel(context.Background(), state, src, true)
+	if diags.HasError() {
+		t.Fatalf("unexpected diagnostics: %v", diags)
+	}
+	if state.Scope == nil || state.Scope.Targets == nil {
+		t.Fatalf("expected scope.targets hydrated from scratch; got %+v", state.Scope)
+	}
+	if !state.Scope.Targets.AllComputers.ValueBool() {
+		t.Fatal("expected all_computers hydrated true")
+	}
+	if got := len(state.Scope.Targets.ComputerGroupIDs.Elements()); got != 2 {
+		t.Fatalf("expected 2 computer_group_ids, got %d", got)
+	}
+	if state.Scope.Exclusions == nil {
+		t.Fatal("expected exclusions allocated when wire-present")
+	}
+	if got := len(state.Scope.Exclusions.DirectoryServiceOrLocalUserNames.Elements()); got != 1 {
+		t.Fatalf("expected 1 excluded user, got %d", got)
+	}
+}
+
 func TestFlattenScope_TargetsAndNameKeyedExclusions(t *testing.T) {
 	ctx := context.Background()
 	s := &proclassic.RestrictedSoftwareScope{
@@ -87,7 +129,7 @@ func TestFlattenScope_TargetsAndNameKeyedExclusions(t *testing.T) {
 		Targets:    &RestrictedSoftwareScopeTargetsModel{},
 		Exclusions: &RestrictedSoftwareScopeExclusionsModel{},
 	}
-	flattenScope(ctx, s, state)
+	flattenScope(ctx, s, state, false)
 
 	if state.Targets.AllComputers.ValueBool() {
 		t.Errorf("all_computers should be false")

--- a/internal/resources/pro/vpp_assignment/crud.go
+++ b/internal/resources/pro/vpp_assignment/crud.go
@@ -73,7 +73,7 @@ func (r *VPPAssignmentResource) Create(ctx context.Context, req resource.CreateR
 		resp.Diagnostics.AddError("Error reading created Jamf Pro VPP assignment", err.Error())
 		return
 	}
-	assignVPPAssignmentResourceModel(createCtx, &plan, got)
+	assignVPPAssignmentResourceModel(createCtx, &plan, got, false)
 
 	resp.Diagnostics.Append(helpers.SetIdentity(ctx, resp.Identity, vppAssignmentIdentityModel{ID: plan.ID})...)
 	if resp.Diagnostics.HasError() {
@@ -137,7 +137,7 @@ func (r *VPPAssignmentResource) Read(ctx context.Context, req resource.ReadReque
 		resp.Diagnostics.AddError("Error reading Jamf Pro VPP assignment", err.Error())
 		return
 	}
-	assignVPPAssignmentResourceModel(readCtx, &state, got)
+	assignVPPAssignmentResourceModel(readCtx, &state, got, false)
 
 	resp.Diagnostics.Append(helpers.SetIdentity(ctx, resp.Identity, vppAssignmentIdentityModel{ID: state.ID})...)
 	if resp.Diagnostics.HasError() {
@@ -180,7 +180,7 @@ func (r *VPPAssignmentResource) Update(ctx context.Context, req resource.UpdateR
 		resp.Diagnostics.AddError("Error reading updated Jamf Pro VPP assignment", err.Error())
 		return
 	}
-	assignVPPAssignmentResourceModel(updateCtx, &plan, got)
+	assignVPPAssignmentResourceModel(updateCtx, &plan, got, false)
 
 	resp.Diagnostics.Append(helpers.SetIdentity(ctx, resp.Identity, vppAssignmentIdentityModel{ID: plan.ID})...)
 	if resp.Diagnostics.HasError() {

--- a/internal/resources/pro/vpp_assignment/list_resource.go
+++ b/internal/resources/pro/vpp_assignment/list_resource.go
@@ -12,7 +12,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/list"
 	listschema "github.com/hashicorp/terraform-plugin-framework/list/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
-	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
 	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/common/filters"
@@ -21,6 +20,11 @@ import (
 )
 
 const defaultListTimeout = 90 * time.Second
+
+// defaultItemReadTimeout bounds each per-item GET issued when IncludeResource is
+// requested (config generation). A single slow item is skipped from the
+// generated config rather than aborting the whole type.
+const defaultItemReadTimeout = 30 * time.Second
 
 var (
 	_ list.ListResource              = &VPPAssignmentListResource{}
@@ -116,16 +120,21 @@ func (r *VPPAssignmentListResource) List(ctx context.Context, req list.ListReque
 		}
 
 		if req.IncludeResource {
-			state := VPPAssignmentResourceModel{
-				ID:                  id,
-				Name:                helpers.StringPointerValueOrNull(p.Name),
-				VPPAdminAccountID:   intStringOrNull(p.VppAdminAccountID),
-				VPPAdminAccountName: types.StringNull(),
-				IosAppAdamIDs:       types.SetNull(types.Int64Type),
-				MacAppAdamIDs:       types.SetNull(types.Int64Type),
-				EbookAdamIDs:        types.SetNull(types.Int64Type),
-				Timeouts:            helpers.NewResourceTimeoutsNullValue(vppAssignmentTimeoutAttributeTypes),
+			itemCtx, cancel := context.WithTimeout(ctx, defaultItemReadTimeout)
+			got, err := r.client.GetVPPAssignmentByID(itemCtx, id.ValueString())
+			cancel()
+			if err != nil {
+				tflog.Warn(ctx, "Skipping Jamf Pro VPP assignment from generated config after per-item read failure", map[string]any{
+					"id":    id.ValueString(),
+					"error": err.Error(),
+				})
+				continue
 			}
+			state := VPPAssignmentResourceModel{
+				ID:       id,
+				Timeouts: helpers.NewResourceTimeoutsNullValue(vppAssignmentTimeoutAttributeTypes),
+			}
+			assignVPPAssignmentResourceModel(ctx, &state, got, true)
 			result.Diagnostics.Append(result.Resource.Set(ctx, &state)...)
 			if result.Diagnostics.HasError() {
 				stream.Results = list.ListResultsStreamDiagnostics(result.Diagnostics)

--- a/internal/resources/pro/vpp_assignment/state_builders.go
+++ b/internal/resources/pro/vpp_assignment/state_builders.go
@@ -21,7 +21,15 @@ import (
 // optional scope block is refreshed only when state.Scope is non-nil (mirrors the
 // content opt-out + the vpp_invitation precedent). Item names are discarded
 // (only adam_id round-trips).
-func assignVPPAssignmentResourceModel(ctx context.Context, state *VPPAssignmentResourceModel, api *proclassic.VppAssignment) {
+//
+// includeUnmanaged inverts the content-set and scope gates for the list
+// resource's config-generation path (terraform query -generate-config-out):
+// there is no plan to stay consistent with, so every wire-present content set
+// and the scope block are hydrated from the server, yielding a complete exported
+// config rather than an identity-only one. CRUD callers pass false. The scope
+// flattener adopts the wire value verbatim, so allocating an empty section is
+// sufficient for it to fully hydrate.
+func assignVPPAssignmentResourceModel(ctx context.Context, state *VPPAssignmentResourceModel, api *proclassic.VppAssignment, includeUnmanaged bool) {
 	if api == nil || api.General == nil {
 		return
 	}
@@ -36,19 +44,23 @@ func assignVPPAssignmentResourceModel(ctx context.Context, state *VPPAssignmentR
 	// Content: refresh only managed (non-null) sets. The flatten returns a known
 	// (possibly empty) Set so a managed-but-now-empty collection reconciles to []
 	// rather than null (these are plain Optional attrs — a null after an empty
-	// config is a "provider produced inconsistent result" error).
-	if !state.IosAppAdamIDs.IsNull() {
+	// config is a "provider produced inconsistent result" error). Config
+	// generation hydrates all three regardless of prior management.
+	if includeUnmanaged || !state.IosAppAdamIDs.IsNull() {
 		state.IosAppAdamIDs = flattenAdamSet(ctx, iosAppAdamIDs(api.IosApps))
 	}
-	if !state.MacAppAdamIDs.IsNull() {
+	if includeUnmanaged || !state.MacAppAdamIDs.IsNull() {
 		state.MacAppAdamIDs = flattenAdamSet(ctx, macAppAdamIDs(api.MacApps))
 	}
-	if !state.EbookAdamIDs.IsNull() {
+	if includeUnmanaged || !state.EbookAdamIDs.IsNull() {
 		state.EbookAdamIDs = flattenAdamSet(ctx, ebookAdamIDs(api.Ebooks))
 	}
 
+	if includeUnmanaged && state.Scope == nil && api.Scope != nil {
+		state.Scope = &scope.UserScopeModel{}
+	}
 	if state.Scope != nil && api.Scope != nil {
-		flattenScope(ctx, api.Scope, state.Scope)
+		flattenScope(ctx, api.Scope, state.Scope, includeUnmanaged)
 	}
 }
 
@@ -76,11 +88,27 @@ func assignVPPAssignmentDataSourceModel(ctx context.Context, state *VPPAssignmen
 		Exclusions:  &scope.UserScopeExclusionsModel{},
 	}
 	if api.Scope != nil {
-		flattenScope(ctx, api.Scope, state.Scope)
+		flattenScope(ctx, api.Scope, state.Scope, false)
 	}
 }
 
-func flattenScope(ctx context.Context, s *proclassic.VppAssignmentScope, state *scope.UserScopeModel) {
+// flattenScope refreshes the scope sub-blocks the caller already manages. When
+// includeUnmanaged is set (config generation) every wire-present sub-block is
+// first allocated so the from-scratch read hydrates the full scope rather than
+// leaving unmanaged targets/limitations/exclusions null.
+func flattenScope(ctx context.Context, s *proclassic.VppAssignmentScope, state *scope.UserScopeModel, includeUnmanaged bool) {
+	if includeUnmanaged {
+		if state.Targets == nil {
+			state.Targets = &scope.UserScopeTargetsModel{}
+		}
+		if state.Limitations == nil && s.Limitations != nil {
+			state.Limitations = &scope.UserScopeLimitationsModel{}
+		}
+		if state.Exclusions == nil && s.Exclusions != nil {
+			state.Exclusions = &scope.UserScopeExclusionsModel{}
+		}
+	}
+
 	if state.Targets != nil {
 		state.Targets.AllJssUsers = helpers.BoolPointerValueOrNull(s.AllJssUsers)
 		state.Targets.JssUserIDs = scope.FlattenIDNameSet(ctx, jssUsersSlice(s.JssUsers))

--- a/internal/resources/pro/vpp_assignment/state_builders_test.go
+++ b/internal/resources/pro/vpp_assignment/state_builders_test.go
@@ -67,7 +67,7 @@ func TestAssignResourceModel_General(t *testing.T) {
 		MacAppAdamIDs: types.SetNull(types.Int64Type),
 		EbookAdamIDs:  types.SetNull(types.Int64Type),
 	}
-	assignVPPAssignmentResourceModel(context.Background(), state, sampleAPI())
+	assignVPPAssignmentResourceModel(context.Background(), state, sampleAPI(), false)
 
 	if state.ID.ValueString() != "2" {
 		t.Errorf("id = %q", state.ID.ValueString())
@@ -89,7 +89,7 @@ func TestAssignResourceModel_ContentOptOut(t *testing.T) {
 		MacAppAdamIDs: types.SetNull(types.Int64Type),
 		EbookAdamIDs:  types.SetNull(types.Int64Type),
 	}
-	assignVPPAssignmentResourceModel(context.Background(), unmanaged, sampleAPI())
+	assignVPPAssignmentResourceModel(context.Background(), unmanaged, sampleAPI(), false)
 	if !unmanaged.IosAppAdamIDs.IsNull() {
 		t.Error("unmanaged ios_app_adam_ids must stay null (don't fabricate management)")
 	}
@@ -100,7 +100,7 @@ func TestAssignResourceModel_ContentOptOut(t *testing.T) {
 		MacAppAdamIDs: types.SetNull(types.Int64Type),
 		EbookAdamIDs:  types.SetNull(types.Int64Type),
 	}
-	assignVPPAssignmentResourceModel(context.Background(), managed, sampleAPI())
+	assignVPPAssignmentResourceModel(context.Background(), managed, sampleAPI(), false)
 	if managed.IosAppAdamIDs.IsNull() || len(managed.IosAppAdamIDs.Elements()) != 1 {
 		t.Errorf("managed ios_app_adam_ids should be refreshed: %v", managed.IosAppAdamIDs)
 	}
@@ -137,7 +137,7 @@ func TestAssignResourceModel_ScopeOnlyWhenManaged(t *testing.T) {
 		MacAppAdamIDs: types.SetNull(types.Int64Type),
 		EbookAdamIDs:  types.SetNull(types.Int64Type),
 	}
-	assignVPPAssignmentResourceModel(context.Background(), state, sampleAPI())
+	assignVPPAssignmentResourceModel(context.Background(), state, sampleAPI(), false)
 	if state.Scope != nil {
 		t.Error("unmanaged scope block must stay nil")
 	}
@@ -152,7 +152,7 @@ func TestAssignResourceModel_ScopeOnlyWhenManaged(t *testing.T) {
 			Exclusions:  &scope.UserScopeExclusionsModel{},
 		},
 	}
-	assignVPPAssignmentResourceModel(context.Background(), managed, sampleAPI())
+	assignVPPAssignmentResourceModel(context.Background(), managed, sampleAPI(), false)
 	if managed.Scope.Targets.JssUserGroupIDs.IsNull() || len(managed.Scope.Targets.JssUserGroupIDs.Elements()) != 1 {
 		t.Errorf("jss_user_group_ids = %v", managed.Scope.Targets.JssUserGroupIDs)
 	}
@@ -179,6 +179,37 @@ func TestAssignDataSourceModel_PopulatesContentAndScope(t *testing.T) {
 	}
 	if state.Ebooks.IsNull() || len(state.Ebooks.Elements()) != 0 {
 		t.Errorf("DS ebooks must be a known empty list when absent, got %v", state.Ebooks)
+	}
+}
+
+// TestAssignVPPAssignmentResourceModel_IncludeUnmanagedHydratesFromScratch pins
+// the config-generation contract: with includeUnmanaged set and an empty
+// starting model, the content sets and the wire-present scope are hydrated from
+// the server.
+func TestAssignVPPAssignmentResourceModel_IncludeUnmanagedHydratesFromScratch(t *testing.T) {
+	state := &VPPAssignmentResourceModel{}
+	assignVPPAssignmentResourceModel(context.Background(), state, sampleAPI(), true)
+
+	if state.IosAppAdamIDs.IsNull() || len(state.IosAppAdamIDs.Elements()) != 1 {
+		t.Errorf("expected ios_app_adam_ids hydrated; got %v", state.IosAppAdamIDs)
+	}
+	if state.MacAppAdamIDs.IsNull() || len(state.MacAppAdamIDs.Elements()) != 1 {
+		t.Errorf("expected mac_app_adam_ids hydrated; got %v", state.MacAppAdamIDs)
+	}
+	if state.EbookAdamIDs.IsNull() {
+		t.Error("expected ebook_adam_ids hydrated to a known (empty) set")
+	}
+	if state.Scope == nil || state.Scope.Targets == nil {
+		t.Fatalf("expected scope.targets hydrated from scratch; got %+v", state.Scope)
+	}
+	if state.Scope.Targets.JssUserGroupIDs.IsNull() || len(state.Scope.Targets.JssUserGroupIDs.Elements()) != 1 {
+		t.Errorf("expected jss_user_group_ids hydrated; got %v", state.Scope.Targets.JssUserGroupIDs)
+	}
+	if state.Scope.Limitations == nil || state.Scope.Limitations.DirectoryServiceUserGroupNames.IsNull() {
+		t.Fatalf("expected limitations hydrated when wire-present; got %+v", state.Scope.Limitations)
+	}
+	if state.Scope.Exclusions == nil || state.Scope.Exclusions.DirectoryServiceUserGroupNames.IsNull() {
+		t.Fatalf("expected exclusions hydrated when wire-present; got %+v", state.Scope.Exclusions)
 	}
 }
 

--- a/internal/resources/pro/vpp_invitation/crud.go
+++ b/internal/resources/pro/vpp_invitation/crud.go
@@ -71,7 +71,7 @@ func (r *VPPInvitationResource) Create(ctx context.Context, req resource.CreateR
 		resp.Diagnostics.AddError("Error reading created Jamf Pro VPP invitation", err.Error())
 		return
 	}
-	assignVPPInvitationResourceModel(createCtx, &plan, got)
+	assignVPPInvitationResourceModel(createCtx, &plan, got, false)
 
 	resp.Diagnostics.Append(helpers.SetIdentity(ctx, resp.Identity, vppInvitationIdentityModel{ID: plan.ID})...)
 	if resp.Diagnostics.HasError() {
@@ -135,7 +135,7 @@ func (r *VPPInvitationResource) Read(ctx context.Context, req resource.ReadReque
 		resp.Diagnostics.AddError("Error reading Jamf Pro VPP invitation", err.Error())
 		return
 	}
-	assignVPPInvitationResourceModel(readCtx, &state, got)
+	assignVPPInvitationResourceModel(readCtx, &state, got, false)
 
 	resp.Diagnostics.Append(helpers.SetIdentity(ctx, resp.Identity, vppInvitationIdentityModel{ID: state.ID})...)
 	if resp.Diagnostics.HasError() {
@@ -178,7 +178,7 @@ func (r *VPPInvitationResource) Update(ctx context.Context, req resource.UpdateR
 		resp.Diagnostics.AddError("Error reading updated Jamf Pro VPP invitation", err.Error())
 		return
 	}
-	assignVPPInvitationResourceModel(updateCtx, &plan, got)
+	assignVPPInvitationResourceModel(updateCtx, &plan, got, false)
 
 	resp.Diagnostics.Append(helpers.SetIdentity(ctx, resp.Identity, vppInvitationIdentityModel{ID: plan.ID})...)
 	if resp.Diagnostics.HasError() {

--- a/internal/resources/pro/vpp_invitation/list_resource.go
+++ b/internal/resources/pro/vpp_invitation/list_resource.go
@@ -8,12 +8,10 @@ import (
 	"time"
 
 	"github.com/Jamf-Concepts/jamfplatform-go-sdk/jamfplatform/proclassic"
-	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/list"
 	listschema "github.com/hashicorp/terraform-plugin-framework/list/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
-	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
 	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/common/filters"
@@ -22,6 +20,11 @@ import (
 )
 
 const defaultListTimeout = 90 * time.Second
+
+// defaultItemReadTimeout bounds each per-item GET issued when IncludeResource is
+// requested (config generation). A single slow item is skipped from the
+// generated config rather than aborting the whole type.
+const defaultItemReadTimeout = 30 * time.Second
 
 var (
 	_ list.ListResource              = &VPPInvitationListResource{}
@@ -101,7 +104,6 @@ func (r *VPPInvitationListResource) List(ctx context.Context, req list.ListReque
 	}
 
 	results := make([]list.ListResult, 0, maxResults)
-	emptyUsages := types.ListValueMust(usageObjectType, []attr.Value{})
 
 	for _, p := range items {
 		if int64(len(results)) >= maxResults {
@@ -118,20 +120,21 @@ func (r *VPPInvitationListResource) List(ctx context.Context, req list.ListReque
 		}
 
 		if req.IncludeResource {
-			state := VPPInvitationResourceModel{
-				ID:                       id,
-				Name:                     helpers.StringPointerValueOrNull(p.Name),
-				VPPAccountID:             types.StringNull(),
-				DistributionMethod:       types.StringNull(),
-				AutoRegisterManagedUsers: types.BoolNull(),
-				SenderName:               types.StringNull(),
-				SenderEmailAddress:       types.StringNull(),
-				Subject:                  types.StringNull(),
-				Message:                  types.StringNull(),
-				RequireLogin:             types.BoolNull(),
-				InvitationUsages:         emptyUsages,
-				Timeouts:                 helpers.NewResourceTimeoutsNullValue(vppInvitationTimeoutAttributeTypes),
+			itemCtx, cancel := context.WithTimeout(ctx, defaultItemReadTimeout)
+			got, err := r.client.GetVPPInvitationByID(itemCtx, id.ValueString())
+			cancel()
+			if err != nil {
+				tflog.Warn(ctx, "Skipping Jamf Pro VPP invitation from generated config after per-item read failure", map[string]any{
+					"id":    id.ValueString(),
+					"error": err.Error(),
+				})
+				continue
 			}
+			state := VPPInvitationResourceModel{
+				ID:       id,
+				Timeouts: helpers.NewResourceTimeoutsNullValue(vppInvitationTimeoutAttributeTypes),
+			}
+			assignVPPInvitationResourceModel(ctx, &state, got, true)
 			result.Diagnostics.Append(result.Resource.Set(ctx, &state)...)
 			if result.Diagnostics.HasError() {
 				stream.Results = list.ListResultsStreamDiagnostics(result.Diagnostics)

--- a/internal/resources/pro/vpp_invitation/state_builders.go
+++ b/internal/resources/pro/vpp_invitation/state_builders.go
@@ -18,7 +18,15 @@ import (
 // the caller already manages it (state.Scope non-nil) so the server's
 // always-returned <scope> doesn't fabricate a block the user never declared.
 // invitation_usages (read-only) is always refreshed.
-func assignVPPInvitationResourceModel(ctx context.Context, state *VPPInvitationResourceModel, api *proclassic.VppInvitation) {
+//
+// includeUnmanaged inverts the scope gate for the list resource's
+// config-generation path (terraform query -generate-config-out): there is no
+// plan to stay consistent with, so the wire-present scope block is hydrated from
+// the server, yielding a complete exported config rather than an identity-only
+// one. CRUD callers pass false. The scope flattener adopts the wire value
+// verbatim, so allocating an empty section is sufficient for it to fully
+// hydrate.
+func assignVPPInvitationResourceModel(ctx context.Context, state *VPPInvitationResourceModel, api *proclassic.VppInvitation, includeUnmanaged bool) {
 	if api == nil || api.General == nil {
 		return
 	}
@@ -38,8 +46,11 @@ func assignVPPInvitationResourceModel(ctx context.Context, state *VPPInvitationR
 	state.Message = helpers.StringPointerValueOrNull(g.Message)
 	state.RequireLogin = helpers.BoolPointerValueOrNull(g.RequireLogin)
 
+	if includeUnmanaged && state.Scope == nil && api.Scope != nil {
+		state.Scope = &scope.UserScopeModel{}
+	}
 	if state.Scope != nil && api.Scope != nil {
-		flattenScope(ctx, api.Scope, state.Scope)
+		flattenScope(ctx, api.Scope, state.Scope, includeUnmanaged)
 	}
 	state.InvitationUsages = flattenUsages(api.InvitationUsages)
 }
@@ -72,12 +83,28 @@ func assignVPPInvitationDataSourceModel(ctx context.Context, state *VPPInvitatio
 		Exclusions:  &scope.UserScopeExclusionsModel{},
 	}
 	if api.Scope != nil {
-		flattenScope(ctx, api.Scope, state.Scope)
+		flattenScope(ctx, api.Scope, state.Scope, false)
 	}
 	state.InvitationUsages = flattenUsages(api.InvitationUsages)
 }
 
-func flattenScope(ctx context.Context, s *proclassic.VppInvitationScope, state *scope.UserScopeModel) {
+// flattenScope refreshes the scope sub-blocks the caller already manages. When
+// includeUnmanaged is set (config generation) every wire-present sub-block is
+// first allocated so the from-scratch read hydrates the full scope rather than
+// leaving unmanaged targets/limitations/exclusions null.
+func flattenScope(ctx context.Context, s *proclassic.VppInvitationScope, state *scope.UserScopeModel, includeUnmanaged bool) {
+	if includeUnmanaged {
+		if state.Targets == nil {
+			state.Targets = &scope.UserScopeTargetsModel{}
+		}
+		if state.Limitations == nil && s.Limitations != nil {
+			state.Limitations = &scope.UserScopeLimitationsModel{}
+		}
+		if state.Exclusions == nil && s.Exclusions != nil {
+			state.Exclusions = &scope.UserScopeExclusionsModel{}
+		}
+	}
+
 	if state.Targets != nil {
 		state.Targets.AllJssUsers = helpers.BoolPointerValueOrNull(s.AllJssUsers)
 		state.Targets.JssUserIDs = scope.FlattenIDNameSet(ctx, jssUsersSlice(s.JssUsers))

--- a/internal/resources/pro/vpp_invitation/state_builders_test.go
+++ b/internal/resources/pro/vpp_invitation/state_builders_test.go
@@ -55,7 +55,7 @@ func sampleAPI() *proclassic.VppInvitation {
 
 func TestAssignResourceModel_GeneralAndUsages(t *testing.T) {
 	state := &VPPInvitationResourceModel{}
-	assignVPPInvitationResourceModel(context.Background(), state, sampleAPI())
+	assignVPPInvitationResourceModel(context.Background(), state, sampleAPI(), false)
 
 	if state.ID.ValueString() != "2" {
 		t.Errorf("id = %q", state.ID.ValueString())
@@ -75,7 +75,7 @@ func TestAssignResourceModel_GeneralAndUsages(t *testing.T) {
 func TestAssignResourceModel_ScopeOnlyWhenManaged(t *testing.T) {
 	// nil Scope in state → scope not populated (server always echoes <scope>).
 	state := &VPPInvitationResourceModel{}
-	assignVPPInvitationResourceModel(context.Background(), state, sampleAPI())
+	assignVPPInvitationResourceModel(context.Background(), state, sampleAPI(), false)
 	if state.Scope != nil {
 		t.Error("unmanaged scope block must stay nil")
 	}
@@ -86,7 +86,7 @@ func TestAssignResourceModel_ScopeOnlyWhenManaged(t *testing.T) {
 		Limitations: &scope.UserScopeLimitationsModel{},
 		Exclusions:  &scope.UserScopeExclusionsModel{},
 	}}
-	assignVPPInvitationResourceModel(context.Background(), managed, sampleAPI())
+	assignVPPInvitationResourceModel(context.Background(), managed, sampleAPI(), false)
 	if managed.Scope.Targets.JssUserGroupIDs.IsNull() || len(managed.Scope.Targets.JssUserGroupIDs.Elements()) != 1 {
 		t.Errorf("jss_user_group_ids = %v", managed.Scope.Targets.JssUserGroupIDs)
 	}
@@ -95,6 +95,31 @@ func TestAssignResourceModel_ScopeOnlyWhenManaged(t *testing.T) {
 	}
 	if managed.Scope.Exclusions.DirectoryServiceUserGroupNames.IsNull() {
 		t.Error("exclusions DS names should be populated by name")
+	}
+}
+
+// TestAssignVPPInvitationResourceModel_IncludeUnmanagedHydratesFromScratch pins
+// the config-generation contract: with includeUnmanaged set and an empty
+// starting model, the wire-present scope is allocated and hydrated from the
+// server.
+func TestAssignVPPInvitationResourceModel_IncludeUnmanagedHydratesFromScratch(t *testing.T) {
+	state := &VPPInvitationResourceModel{}
+	assignVPPInvitationResourceModel(context.Background(), state, sampleAPI(), true)
+
+	if state.Scope == nil || state.Scope.Targets == nil {
+		t.Fatalf("expected scope.targets hydrated from scratch; got %+v", state.Scope)
+	}
+	if state.Scope.Targets.JssUserGroupIDs.IsNull() || len(state.Scope.Targets.JssUserGroupIDs.Elements()) != 1 {
+		t.Errorf("expected jss_user_group_ids hydrated; got %v", state.Scope.Targets.JssUserGroupIDs)
+	}
+	if state.Scope.Limitations == nil || state.Scope.Limitations.DirectoryServiceUserGroupNames.IsNull() {
+		t.Fatalf("expected limitations hydrated when wire-present; got %+v", state.Scope.Limitations)
+	}
+	if state.Scope.Exclusions == nil || state.Scope.Exclusions.DirectoryServiceUserGroupNames.IsNull() {
+		t.Fatalf("expected exclusions hydrated when wire-present; got %+v", state.Scope.Exclusions)
+	}
+	if state.InvitationUsages.IsNull() || len(state.InvitationUsages.Elements()) != 1 {
+		t.Errorf("expected invitation_usages hydrated; got %v", state.InvitationUsages)
 	}
 }
 


### PR DESCRIPTION
## Summary

Follow-on to #261 (which fixed the genconfig panic by hydrating `general`/identity). The eleven complex `jamfplatform_pro_*` list resources still emitted **only** `general` under `terraform query -generate-config-out`, leaving scope/self_service/scripts/packages/etc. null — so an exported policy carried no scope, no scripts, no self-service. This makes config generation produce **complete** resources.

### Mechanism

The list resources already reuse each resource's shared Read state-builder (`assignXResourceModel`), but that builder gates every optional section on `state.<section> != nil` — the CRUD refresh contract (the framework rejects a Read that populates a section the plan said was null, and the classic API echoes *every* section on GET). Both import and genconfig start from an empty model, so only `general` survived.

This threads an `includeUnmanaged bool` through the gated state-builders:
- The list resource's `IncludeResource` path (config generation — no plan to stay consistent with) passes **true**, allocating each wire-present section before flattening.
- CRUD and data-source callers pass **false** and are byte-for-byte unchanged.

Allocation is gated on the wire object being non-nil, so an un-flattened zero `types.Set` can never reach `Resource.Set`. The policy/most flatteners use `PreferCurrent*` (adopt the wire value when state is null), so allocation alone hydrates; the macOS/mobile profile scope all-flags use `Reconcile*` (preserve null for unmanaged state), so a new `helpers.ReconcileOrAdoptBoolPointer` adopts the wire value verbatim in the genconfig path.

### Resources

`policy`, `macos_configuration_profile`, `mobile_device_configuration_profile`, `ebook`, `mac_app_store_app`, `mobile_device_app`, `restricted_software`, `patch_policy`, `vpp_assignment`, `vpp_invitation`, `app_installer`.

`patch_policy`, `vpp_assignment`, and `vpp_invitation` list resources previously emitted id+name only and skipped per-item GETs; they now issue a per-item GET and hydrate through the state-builder, mirroring the policy pattern (own 30s item timeout, skip-on-error with a warning).

## Testing

- `go build ./...`, full `go test ./...`, and `golangci-lint run ./...` all green; each resource gained an `IncludeUnmanagedHydratesFromScratch` test, and the CRUD-contract tests (sections stay null when unmanaged) still pass with `false`.
- **Verified live against an EU tenant** (1390 resources, all 11 hydration types + scope-target types): 257/257 policies and 374 macOS profiles hydrate full scope/self_service/scripts/packages; 57 mobile apps hydrate app_configuration. `terraform validate` reports **0 errors on any of the eleven now-fully-hydrated types** (the remaining diagnostics are on `user_group`/`printer`, addressed by #264/#265).

🤖 Generated with [Claude Code](https://claude.com/claude-code)