### PR TITLE
fix(pro): stop UIE LDAP access-group acc test racing server creation

### DIFF
--- a/internal/resources/pro/user_initiated_enrollment_settings/resource_acceptance_test.go
+++ b/internal/resources/pro/user_initiated_enrollment_settings/resource_acceptance_test.go
@@ -32,11 +32,12 @@ import (
 // vice versa.
 //
 // Env-gated tests:
-//   - TestAccResource_..._AccessGroupLdap stands up the shared Okta LDAP server
-//     fixture (testhelpers.LdapServerFixture, labelled acc_ldap), references its id
-//     for ldap_server_id, and resolves JAMFPLATFORM_ACC_LDAP_GROUP_NAME against it.
-//     Gated on the Okta LDAP env vars (RequireOktaLdapEnv + RequireLdapGroupName);
-//     unset → t.Skipf.
+//   - TestAccResource_..._AccessGroupLdap pre-creates the shared Okta LDAP server
+//     fixture via the live API (testhelpers.EnsureLdapServerFixture), waits for its
+//     bind to come up (testhelpers.WaitForLdapGroupResolvable), then references its
+//     id for ldap_server_id and resolves JAMFPLATFORM_ACC_LDAP_GROUP_NAME against
+//     it at apply time. Gated on the Okta LDAP env vars (RequireOktaLdapEnv +
+//     RequireLdapGroupName); unset → t.Skipf.
 
 const uieResourceAddr = "jamfplatform_pro_user_initiated_enrollment_settings.test"
 
@@ -406,9 +407,13 @@ func TestAccResource_ProUserInitiatedEnrollmentSettings_AccessGroupLdap(t *testi
 	ldapEnv := testhelpers.RequireOktaLdapEnv(t)
 	groupName := testhelpers.RequireLdapGroupName(t)
 	suffix := testhelpers.RunSuffix()
-	// Apply-time resolution against a specific ldap_server_id, so the in-config TF
-	// fixture (created first via the implicit acc_ldap.id reference) is sufficient.
-	fixture := testhelpers.LdapServerFixture("tf-acc-uie-ldap-"+suffix, ldapEnv)
+	// Pre-create the LDAP server via the live API (not embedded HCL) and wait for
+	// its bind to come up before Terraform ever applies. Resolving the env group
+	// against a server created in the SAME apply races the backend's search
+	// fan-out picking up the brand-new server — see WaitForLdapGroupResolvable's
+	// other callers for the same pattern.
+	ldapServerID := testhelpers.EnsureLdapServerFixture(t, "tf-acc-uie-ldap-"+suffix, ldapEnv)
+	testhelpers.WaitForLdapGroupResolvable(t, groupName)
 
 	const builtinElem = `{
 			ldap_server_id                         = "-1"
@@ -419,20 +424,20 @@ func TestAccResource_ProUserInitiatedEnrollmentSettings_AccessGroupLdap(t *testi
 		}`
 
 	envElem := fmt.Sprintf(`{
-			ldap_server_id                         = jamfplatform_pro_ldap_server.acc_ldap.id
+			ldap_server_id                         = %q
 			name                                   = %q
 			enterprise_enrollment_enabled          = true
 			personal_enrollment_enabled            = false
 			account_driven_user_enrollment_enabled = false
-		}`, groupName)
+		}`, ldapServerID, groupName)
 
-	withEnvGroup := fixture + fmt.Sprintf(`
+	withEnvGroup := fmt.Sprintf(`
 		resource "jamfplatform_pro_user_initiated_enrollment_settings" "test" {
 			access_group = [%s, %s]
 		}
 	`, builtinElem, envElem)
 
-	builtinOnly := fixture + fmt.Sprintf(`
+	builtinOnly := fmt.Sprintf(`
 		resource "jamfplatform_pro_user_initiated_enrollment_settings" "test" {
 			access_group = [%s]
 		}


### PR DESCRIPTION
## Summary
- `TestAccResource_ProUserInitiatedEnrollmentSettings_AccessGroupLdap` embedded the Okta LDAP server fixture as Terraform-managed HCL and resolved the env group's name against its freshly-created `ldap_server_id` in the same apply, racing the backend's directory-group search picking up a server created moments earlier.
- Failing consistently in CI since 2026-06-28 (fast ~2.6s failures — empty search result, not a timeout — see [run 28490689228](https://github.com/Jamf-Concepts/terraform-provider-jamfplatform/actions/runs/28490689228/job/84446499518)), passing locally.
- Fix: switch to `testhelpers.EnsureLdapServerFixture` (pre-creates the LDAP server via the live API before Terraform runs) + `testhelpers.WaitForLdapGroupResolvable` (polls until the group actually resolves) — the pattern every other name-resolution acceptance test already uses.

## Test plan
- [x] `go build`/`go vet`/`gofmt` clean under the `acceptance` tag
- [x] `make testacc-run RUN=TestAccResource_ProUserInitiatedEnrollmentSettings_AccessGroupLdap PKG=./internal/resources/pro/user_initiated_enrollment_settings/...` — green locally
- [x] Confirm green on next scheduled/PR CI acceptance run

🤖 Generated with [Claude Code](https://claude.com/claude-code)