### PR TITLE
fix(pro/package): retry JCDS upload when server reports size=0

### DIFF
--- a/internal/resources/pro/package/crud.go
+++ b/internal/resources/pro/package/crud.go
@@ -524,63 +524,117 @@ func openHashUploadVerify(ctx context.Context, client *pro.Client, plan *Package
 	return uploadAndPoll(ctx, client, plan.ID.ValueString(), fileName, file, sha, sz, previousHash)
 }
 
-// uploadAndPoll streams the supplied (already-rewound) file to
-// UploadPackageV1, then drives the verification poll. Splitting this from
-// the open/hash phase lets Update reuse the open handle from the hash
-// decision.
-func uploadAndPoll(ctx context.Context, client *pro.Client, id, fileName string, file io.Reader, localSha3 string, localSize int64, previousHash string) diag.Diagnostics {
-	tflog.Info(ctx, "package upload starting", map[string]any{
-		"id":            id,
-		"file_name":     fileName,
-		"local_sha3":    localSha3,
-		"local_size":    localSize,
-		"previous_hash": previousHash,
-	})
-	href, err := client.UploadPackageV1(ctx, id, fileName, file)
-	if err != nil {
-		tflog.Error(ctx, "package upload failed", map[string]any{"err": err.Error()})
-		return errorDiag("Error uploading Jamf Pro package binary", err.Error())
-	}
-	hrefStr := ""
-	if href != nil {
-		hrefStr = href.Href
-	}
-	tflog.Info(ctx, "package upload returned", map[string]any{"id": id, "href": hrefStr})
+// maxUploadAttempts bounds how many times uploadAndPoll re-uploads the same
+// binary after seeing errUploadFailed (server-reported size=0 immediately
+// after the hash changed). Matches jamf-cli/jamf-upload's default retry
+// ceiling for the same JCDS failure signal.
+const maxUploadAttempts = 5
 
-	convergedPkg, pollErr := PollPackageVerification(ctx, client, id, fileName, localSha3, localSize, previousHash)
-	if pollErr != nil {
-		tflog.Error(ctx, "package poll failed", map[string]any{"err": pollErr.Error()})
-		if errors.Is(pollErr, errCorruption) {
-			return errorDiag(
-				"Package binary verification failed (corruption)",
-				pollErr.Error(),
-			)
+// uploadAndPoll streams the supplied (already-rewound) file to
+// UploadPackageV1, then drives the verification poll, retrying the whole
+// upload up to maxUploadAttempts times when the poll reports errUploadFailed
+// (server size=0 — a failed upload, not a transient view). Splitting this
+// from the open/hash phase lets Update reuse the open handle from the hash
+// decision; file must be seekable so a retry can rewind and resend the same
+// bytes.
+func uploadAndPoll(ctx context.Context, client *pro.Client, id, fileName string, file io.ReadSeeker, localSha3 string, localSize int64, previousHash string) diag.Diagnostics {
+	for attempt := 1; ; attempt++ {
+		if attempt > 1 {
+			if _, seekErr := file.Seek(0, io.SeekStart); seekErr != nil {
+				return errorDiag("Error preparing package upload retry", seekErr.Error())
+			}
 		}
-		if errors.Is(pollErr, errVerificationTimeout) {
-			return errorDiag(
-				"Package binary verification timed out",
-				"JCDS did not converge on the expected hash before the timeout fired. Increase `timeouts.create` (or `timeouts.update`) to allow more time, or check the Jamf Pro admin console for CDP status.",
-			)
+
+		tflog.Info(ctx, "package upload starting", map[string]any{
+			"id":            id,
+			"file_name":     fileName,
+			"local_sha3":    localSha3,
+			"local_size":    localSize,
+			"previous_hash": previousHash,
+			"attempt":       attempt,
+		})
+		href, err := client.UploadPackageV1(ctx, id, fileName, file)
+		if err != nil {
+			tflog.Error(ctx, "package upload failed", map[string]any{"err": err.Error(), "attempt": attempt})
+			return errorDiag("Error uploading Jamf Pro package binary", err.Error())
 		}
-		return errorDiag("Error verifying Jamf Pro package upload", pollErr.Error())
+		hrefStr := ""
+		if href != nil {
+			hrefStr = href.Href
+		}
+		tflog.Info(ctx, "package upload returned", map[string]any{"id": id, "href": hrefStr, "attempt": attempt})
+
+		convergedPkg, pollErr := PollPackageVerification(ctx, client, id, fileName, localSha3, localSize, previousHash)
+		if pollErr == nil {
+			convergedHash := ""
+			convergedStatus := ""
+			if convergedPkg != nil {
+				if convergedPkg.HashValue != nil {
+					convergedHash = *convergedPkg.HashValue
+				}
+				if convergedPkg.CloudTransferStatus != nil {
+					convergedStatus = *convergedPkg.CloudTransferStatus
+				}
+			}
+			tflog.Info(ctx, "package poll converged", map[string]any{
+				"id":                  id,
+				"converged_hash":      convergedHash,
+				"converged_status":    convergedStatus,
+				"expected_local_sha3": localSha3,
+				"attempt":             attempt,
+			})
+			return nil
+		}
+
+		if retryableUploadFailure(pollErr, attempt, maxUploadAttempts) {
+			tflog.Warn(ctx, "package upload reported size=0 after hash changed; retrying upload", map[string]any{
+				"id":      id,
+				"attempt": attempt,
+				"max":     maxUploadAttempts,
+			})
+			// Baseline the next poll off whatever hash the server holds now
+			// (possibly this failed attempt's own transient value) so it is
+			// not mistaken for the pre-upload previousHash. A failed GET here
+			// is non-fatal — the retry proceeds with the stale baseline — but
+			// worth surfacing since it weakens the next attempt's ability to
+			// tell "still the old failed hash" apart from "genuinely new".
+			if cur, getErr := client.GetPackageV1(ctx, id); getErr == nil {
+				previousHash = strings.ToLower(helpers.DerefString(cur.HashValue))
+			} else {
+				tflog.Warn(ctx, "could not refresh previousHash baseline before upload retry", map[string]any{"id": id, "attempt": attempt, "err": getErr.Error()})
+			}
+			continue
+		}
+
+		tflog.Error(ctx, "package poll failed", map[string]any{"err": pollErr.Error(), "attempt": attempt})
+		return classifyUploadPollError(pollErr, attempt)
 	}
-	convergedHash := ""
-	convergedStatus := ""
-	if convergedPkg != nil {
-		if convergedPkg.HashValue != nil {
-			convergedHash = *convergedPkg.HashValue
-		}
-		if convergedPkg.CloudTransferStatus != nil {
-			convergedStatus = *convergedPkg.CloudTransferStatus
-		}
+}
+
+// classifyUploadPollError maps a terminal (non-retryable) PollPackageVerification
+// error to the diag.Diagnostics uploadAndPoll / streamURLUploadAndVerify return.
+// Shared so the two upload paths can't drift on error wording or the CDP-status
+// remediation hint. attempt is only used to report how many attempts ran.
+func classifyUploadPollError(pollErr error, attempt int) diag.Diagnostics {
+	if errors.Is(pollErr, errUploadFailed) {
+		return errorDiag(
+			"Package upload failed (server reported size=0)",
+			fmt.Sprintf("%v — gave up after %d attempt(s). Check the Jamf Pro admin console for Cloud Distribution Point status.", pollErr, attempt),
+		)
 	}
-	tflog.Info(ctx, "package poll converged", map[string]any{
-		"id":                  id,
-		"converged_hash":      convergedHash,
-		"converged_status":    convergedStatus,
-		"expected_local_sha3": localSha3,
-	})
-	return nil
+	if errors.Is(pollErr, errCorruption) {
+		return errorDiag(
+			"Package binary verification failed (corruption)",
+			pollErr.Error(),
+		)
+	}
+	if errors.Is(pollErr, errVerificationTimeout) {
+		return errorDiag(
+			"Package binary verification timed out",
+			"JCDS did not converge on the expected hash before the timeout fired. Increase `timeouts.create` (or `timeouts.update`) to allow more time, or check the Jamf Pro admin console for CDP status.",
+		)
+	}
+	return errorDiag("Error verifying Jamf Pro package upload", pollErr.Error())
 }
 
 // uploadPackageManifest streams the manifest source to the /manifest
@@ -621,10 +675,13 @@ func streamingURLEnabled(plan PackageResourceModel) bool {
 // streamURLUploadAndVerify wires up io.Pipe + io.MultiWriter so the URL
 // body flows simultaneously into the SHA-3 hasher and the multipart upload
 // pipe. The hash is known only AFTER the upload completes; the verification
-// poll then runs against the just-computed digest.
+// poll then runs against the just-computed digest. Retries the whole
+// upload — a fresh GET of the URL, since the exhausted io.Pipe from a prior
+// attempt cannot be replayed — up to maxUploadAttempts times when the poll
+// reports errUploadFailed (server size=0).
 //
 // Tradeoffs (versus the disk-staging path):
-//   - No 429 retry — the upload reader is not seekable.
+//   - No 429 retry mid-upload — the upload reader is not seekable.
 //   - No pre-upload checksum validation — bytes leave before the hash is known.
 //   - No Content-Length precompute — SDK transport falls back to chunked TE.
 //   - Mid-stream origin failure aborts the upload; a retry forces a fresh GET.
@@ -633,9 +690,46 @@ func streamingURLEnabled(plan PackageResourceModel) bool {
 // rationale. Caller has already enforced `package_file_source` is a URL
 // (streamingURLEnabled guards entry).
 func streamURLUploadAndVerify(ctx context.Context, client *pro.Client, plan *PackageResourceModel, previousHash string) diag.Diagnostics {
+	for attempt := 1; ; attempt++ {
+		diags, pollErr := streamURLUploadOnce(ctx, client, plan, previousHash, attempt)
+		if diags.HasError() {
+			return diags
+		}
+		if pollErr == nil {
+			return nil
+		}
+
+		if retryableUploadFailure(pollErr, attempt, maxUploadAttempts) {
+			tflog.Warn(ctx, "streamed package upload reported size=0 after hash changed; retrying upload", map[string]any{
+				"id":      plan.ID.ValueString(),
+				"attempt": attempt,
+				"max":     maxUploadAttempts,
+			})
+			// Baseline the next poll off whatever hash the server holds now
+			// so it is not mistaken for the pre-upload previousHash. See
+			// uploadAndPoll's matching rebaseline for why a failed GET here
+			// is logged rather than silently ignored.
+			if cur, getErr := client.GetPackageV1(ctx, plan.ID.ValueString()); getErr == nil {
+				previousHash = strings.ToLower(helpers.DerefString(cur.HashValue))
+			} else {
+				tflog.Warn(ctx, "could not refresh previousHash baseline before streamed upload retry", map[string]any{"id": plan.ID.ValueString(), "attempt": attempt, "err": getErr.Error()})
+			}
+			continue
+		}
+
+		return classifyUploadPollError(pollErr, attempt)
+	}
+}
+
+// streamURLUploadOnce performs a single upload+verify attempt of the
+// streaming-URL path documented on streamURLUploadAndVerify. Returns terminal
+// diagnostics for anything that fails before the poll (opening the URL,
+// streaming the upload itself); otherwise returns the poll's error (nil on
+// convergence) for the caller's retry decision.
+func streamURLUploadOnce(ctx context.Context, client *pro.Client, plan *PackageResourceModel, previousHash string, attempt int) (diag.Diagnostics, error) {
 	body, urlFilename, err := files.OpenURLStream(ctx, plan.PackageFileSource.ValueString(), files.DefaultMaxBytes)
 	if err != nil {
-		return errorDiag("Error opening package URL stream", err.Error())
+		return errorDiag("Error opening package URL stream", err.Error()), nil
 	}
 	defer func() { _ = body.Close() }()
 
@@ -660,28 +754,22 @@ func streamURLUploadAndVerify(ctx context.Context, client *pro.Client, plan *Pac
 	if fileName == "" {
 		fileName = urlFilename
 	}
+	tflog.Info(ctx, "streamed package upload starting", map[string]any{
+		"id":        plan.ID.ValueString(),
+		"file_name": fileName,
+		"attempt":   attempt,
+	})
 	if _, err := client.UploadPackageV1(ctx, plan.ID.ValueString(), fileName, pr); err != nil {
 		// Drain any remaining body so the goroutine exits cleanly.
 		_ = pr.CloseWithError(err)
-		return errorDiag("Error streaming Jamf Pro package upload", err.Error())
+		return errorDiag("Error streaming Jamf Pro package upload", err.Error()), nil
 	}
 
 	localSha3 := hex.EncodeToString(hasher.Sum(nil))
 	localSize := bytesStreamed
 
-	if _, err := PollPackageVerification(ctx, client, plan.ID.ValueString(), fileName, localSha3, localSize, previousHash); err != nil {
-		if errors.Is(err, errCorruption) {
-			return errorDiag("Package binary verification failed (corruption)", err.Error())
-		}
-		if errors.Is(err, errVerificationTimeout) {
-			return errorDiag(
-				"Package binary verification timed out",
-				"JCDS did not converge on the expected hash before the timeout fired. Increase `timeouts.create` (or `timeouts.update`) to allow more time, or check the Jamf Pro admin console for CDP status.",
-			)
-		}
-		return errorDiag("Error verifying Jamf Pro package upload", err.Error())
-	}
-	return nil
+	_, pollErr := PollPackageVerification(ctx, client, plan.ID.ValueString(), fileName, localSha3, localSize, previousHash)
+	return nil, pollErr
 }
 
 // reconcileManifestAndFinalise runs the manifest reconciliation and the

--- a/internal/resources/pro/package/helpers.go
+++ b/internal/resources/pro/package/helpers.go
@@ -46,6 +46,16 @@ var errLocalChecksumMismatch = errors.New("package_file_source_checksum did not 
 // what we hashed locally.
 var errCorruption = errors.New("server-computed package hash did not match locally computed SHA-3-512")
 
+// errUploadFailed is returned when the verification poll observes a
+// server-reported `size` of "0" in the same tick the hash first changes away
+// from `previousHash`. JCDS occasionally starts recomputing a package's
+// metadata for an upload that never actually landed the binary; size=0 is
+// its signal for that failure, distinct from the transient "" while size
+// catches up (continue) or a hash that matches neither expectation
+// (errCorruption). Mirrors the `size_is_zero` check in jamf-cli/jamf-upload's
+// JCDS poll loop. uploadAndPoll retries the upload when it sees this error.
+var errUploadFailed = errors.New("server reported size=0 immediately after the uploaded package's hash changed")
+
 // errVerificationTimeout is returned when the verification poll's context
 // deadline fires before convergence.
 var errVerificationTimeout = errors.New("verification poll timed out waiting for JCDS hash convergence")
@@ -85,6 +95,11 @@ func HashStreamSHA3(r io.Reader) (string, int64, error) {
 // briefly returning a transient `hashValue` matching the new bytes while
 // `size` was still the old binary's, then reverting — a hash-only
 // convergence check would falsely declare success on that transient view.
+//
+// Returns errUploadFailed as soon as a server-reported `size` of "0" shows
+// up alongside a hash change — a definitive failed-upload signal that would
+// otherwise stall out the full poll budget before timing out. uploadAndPoll
+// retries the whole upload when it sees this error.
 //
 // expectSha3 / expectSize describe the locally-computed digest + byte
 // count of the file we just uploaded. previousHash is the SHA-3 digest
@@ -152,6 +167,8 @@ func PollPackageVerification(ctx context.Context, client *pro.Client, id, fileNa
 		switch decision {
 		case pollDecisionConverged:
 			return pkg, nil
+		case pollDecisionUploadFailed:
+			return nil, fmt.Errorf("%w: package %s", errUploadFailed, id)
 		case pollDecisionCorruption:
 			return nil, fmt.Errorf("%w: expected %s, server reported %s", errCorruption, expectLower, cur)
 		}
@@ -270,6 +287,16 @@ func readSourceBytes(ctx context.Context, src string) ([]byte, error) {
 	return data, nil
 }
 
+// retryableUploadFailure reports whether uploadAndPoll / streamURLUploadOnce
+// should re-run the whole upload after a failed poll: errUploadFailed
+// (server size=0) with attempts remaining. Every other poll outcome —
+// corruption, timeout, or errUploadFailed with the budget exhausted — is
+// terminal. Pure-function extraction so the retry boundary is unit-tested
+// without spinning up a Pro client.
+func retryableUploadFailure(err error, attempt, maxAttempts int) bool {
+	return errors.Is(err, errUploadFailed) && attempt < maxAttempts
+}
+
 // pollDecision summarises the convergence-check outcome for a single
 // poll tick. Pure-function extraction lets the decision logic be
 // unit-tested without spinning up a Pro client.
@@ -278,18 +305,42 @@ type pollDecision int
 const (
 	pollDecisionContinue pollDecision = iota
 	pollDecisionConverged
+	pollDecisionUploadFailed
 	pollDecisionCorruption
 )
+
+// isZeroSize reports whether curSize is the server's literal "0" — the
+// signal for a package binary that never actually landed on the cloud
+// distribution point, as opposed to "" (size not yet computed; not a
+// failure). An empty or unparseable curSize is not zero.
+func isZeroSize(curSize string) bool {
+	if curSize == "" {
+		return false
+	}
+	n, err := strconv.ParseInt(curSize, 10, 64)
+	return err == nil && n == 0
+}
 
 // classifyPollTick decides what to do with the server's response on a
 // single verification poll tick. expectHash + expectSize describe the
 // locally-known bytes; previousHash is the digest stored before the
 // upload (used to swallow the "still recomputing" transient view).
 //
+//   - UploadFailed: the hash just changed away from previousHash AND size
+//     reads back "0" while the upload itself is NOT actually zero bytes.
+//     Checked before anything else — a zero-byte binary is a definitive
+//     failed-upload signal regardless of what the hash looks like, and
+//     waiting out the rest of the poll budget only delays the retry.
+//     Mirrors jamf-cli/jamf-upload's `size_is_zero` check. Gated on
+//     expectSize != 0 so a genuinely empty `package_file_source` (size "0"
+//     really is correct) still converges normally below instead of being
+//     misread as a failed upload.
 //   - Converged: hash matches expected, hashType is SHA3_512, status is
 //     READY, AND size matches expected. The size gate catches the
 //     transient JCDS window where hash flips to new while size still
-//     shows the old binary.
+//     shows the old binary — also covers the "package being updated"
+//     case, where a lingering size only matches the previous package's
+//     byte count, never the new upload's.
 //   - Corruption: server reported a SHA3_512 hash that is neither
 //     expected nor previousHash AND size matches expected (corrupt bytes
 //     would still report their own size). Skip the corruption branch
@@ -297,6 +348,11 @@ const (
 //     not a real mismatch.
 //   - Continue: everything else.
 func classifyPollTick(cur, expectHash, previousHash, hashType, status, curSize string, expectSize int64) pollDecision {
+	hashChanged := cur != "" && cur != previousHash
+	if hashChanged && expectSize != 0 && isZeroSize(curSize) {
+		return pollDecisionUploadFailed
+	}
+
 	sizeMatch := curSize != "" && curSize == strconv.FormatInt(expectSize, 10)
 	hashMatch := cur != "" && cur == expectHash && hashType == hashTypeSHA3512 && status == cloudStatusReady
 	if hashMatch && sizeMatch {

--- a/internal/resources/pro/package/helpers_test.go
+++ b/internal/resources/pro/package/helpers_test.go
@@ -104,6 +104,42 @@ func TestClassifyPollTick(t *testing.T) {
 			curSize:  expectSizeStr,
 			want:     pollDecisionContinue,
 		},
+		{
+			name:      "upload failed — size=0 with expected hash",
+			cur:       expectHash,
+			hashType:  "SHA3_512",
+			status:    "READY",
+			curSize:   "0",
+			want:      pollDecisionUploadFailed,
+			wantNotes: "definitive failed-upload signal, checked before the hash/size match branches",
+		},
+		{
+			name:      "upload failed — size=0 with a bogus hash",
+			cur:       corrupt,
+			hashType:  "SHA3_512",
+			status:    "IN_PROGRESS",
+			curSize:   "0",
+			want:      pollDecisionUploadFailed,
+			wantNotes: "size=0 wins over corruption — do not wait out the poll budget to report the wrong failure mode",
+		},
+		{
+			name:      "size=0 but hash has not changed yet — still warming up",
+			cur:       prevHash,
+			hashType:  "SHA3_512",
+			status:    "READY",
+			curSize:   "0",
+			want:      pollDecisionContinue,
+			wantNotes: "hash still equals previousHash — not yet a signal either way",
+		},
+		{
+			name:      "empty size is not zero size",
+			cur:       expectHash,
+			hashType:  "SHA3_512",
+			status:    "READY",
+			curSize:   "",
+			want:      pollDecisionContinue,
+			wantNotes: "\"\" means not-yet-computed, not a failed upload",
+		},
 	}
 
 	for _, tc := range cases {
@@ -114,6 +150,24 @@ func TestClassifyPollTick(t *testing.T) {
 				t.Fatalf("decision = %v, want %v (%s)", got, tc.want, tc.wantNotes)
 			}
 		})
+	}
+}
+
+// TestClassifyPollTick_ZeroByteUpload covers a genuinely empty
+// package_file_source (expectSize == 0), which the "upload failed" fast path
+// must NOT intercept — size "0" is the correct, converged value for a
+// zero-byte binary, not a failure signal.
+func TestClassifyPollTick_ZeroByteUpload(t *testing.T) {
+	t.Parallel()
+
+	const (
+		expectHash = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+		prevHash   = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+	)
+
+	got := classifyPollTick(expectHash, expectHash, prevHash, "SHA3_512", "READY", "0", 0)
+	if got != pollDecisionConverged {
+		t.Fatalf("decision = %v, want %v — a zero-byte upload must converge, not be flagged as a failed upload", got, pollDecisionConverged)
 	}
 }
 
@@ -216,5 +270,57 @@ func TestManifestBodiesEqual_EmptySrcVsNonEmptyStored(t *testing.T) {
 	}
 	if equal {
 		t.Errorf("empty src vs non-empty stored must not match")
+	}
+}
+
+func TestIsZeroSize(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name    string
+		curSize string
+		want    bool
+	}{
+		{name: "literal zero", curSize: "0", want: true},
+		{name: "empty string is not zero", curSize: "", want: false},
+		{name: "nonzero size", curSize: "11806221", want: false},
+		{name: "unparseable is not zero", curSize: "not-a-number", want: false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := isZeroSize(tc.curSize); got != tc.want {
+				t.Errorf("isZeroSize(%q) = %v, want %v", tc.curSize, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestRetryableUploadFailure(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name        string
+		err         error
+		attempt     int
+		maxAttempts int
+		want        bool
+	}{
+		{name: "upload failed with attempts remaining", err: errUploadFailed, attempt: 1, maxAttempts: 5, want: true},
+		{name: "upload failed on last attempt", err: errUploadFailed, attempt: 5, maxAttempts: 5, want: false},
+		{name: "upload failed past budget", err: errUploadFailed, attempt: 6, maxAttempts: 5, want: false},
+		{name: "corruption is never retried", err: errCorruption, attempt: 1, maxAttempts: 5, want: false},
+		{name: "timeout is never retried", err: errVerificationTimeout, attempt: 1, maxAttempts: 5, want: false},
+		{name: "nil error is never retried", err: nil, attempt: 1, maxAttempts: 5, want: false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := retryableUploadFailure(tc.err, tc.attempt, tc.maxAttempts); got != tc.want {
+				t.Errorf("retryableUploadFailure(%v, %d, %d) = %v, want %v", tc.err, tc.attempt, tc.maxAttempts, got, tc.want)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Summary
- JCDS occasionally starts recomputing a package's hash for an upload that never actually landed the binary, surfacing as a server-reported `size` of `"0"` right after the hash changes. `classifyPollTick` now detects that signal immediately (instead of burning the full poll timeout) and `uploadAndPoll`/`streamURLUploadOnce` retry the whole upload (up to 5 attempts) when it fires — mirroring jamf-cli/jamf-upload's own handling of this exact JCDS failure mode.
- Fixed a real edge case surfaced during review: the new fast-fail branch didn't consult `expectSize`, so a genuinely empty (`0`-byte) `package_file_source` would be misclassified as a failed upload every time. Now gated on `expectSize != 0`.
- Extracted the duplicated terminal-error classification between `uploadAndPoll` and `streamURLUploadAndVerify` into a shared `classifyUploadPollError`, and removed the now-dead post-loop fallback `return` in both retry loops (switched to the unbounded-`for` form so the compiler can prove it's unreachable).
- Added `tflog.Warn` visibility for the case where a retry's `previousHash` rebaseline GET fails (previously silent).

## Test plan
- [x] `make fix fmt lint test` — clean, 0 lint issues.
- [x] Unit tests: extended `classifyPollTick` coverage (size=0 fast-fail, zero-byte-file exemption) + new `retryableUploadFailure`/`isZeroSize` tests.
- [x] Live validation against `platform-nmartin` (~750 real package create/update operations across single-create, 100-package concurrent swap, 100-package serialized swap, and 10-package 100-120MB swap rounds): `size=0` never reproduced, zero regressions, zero false positives. Two unrelated pre-existing failure modes were observed and confirmed correctly handled by existing (unmodified) code: platform-gateway 503s under concurrent load, and an occasional JCDS backend-recompute stall that self-heals on retry.
- [x] Acceptance tests — not run in this session (no live-tenant CI creds); should be run via `make testacc` before merge per repo convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)