### PR TITLE
fix(pro): hydrate opt-out lists on import for licensed_software

### DIFF
--- a/internal/resources/pro/licensed_software/crud.go
+++ b/internal/resources/pro/licensed_software/crud.go
@@ -87,7 +87,7 @@ func (r *LicensedSoftwareResource) Create(ctx context.Context, req resource.Crea
 		resp.Diagnostics.AddError("Error reading created Jamf Pro licensed software", err.Error())
 		return
 	}
-	resp.Diagnostics.Append(assignLicensedSoftwareResourceModel(createCtx, &plan, got)...)
+	resp.Diagnostics.Append(assignLicensedSoftwareResourceModel(createCtx, &plan, got, false)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -163,7 +163,15 @@ func (r *LicensedSoftwareResource) Read(ctx context.Context, req resource.ReadRe
 		return
 	}
 
-	resp.Diagnostics.Append(assignLicensedSoftwareResourceModel(readCtx, &state, got)...)
+	// firstHydration detects an unpopulated incoming model (see mac_app_store_app
+	// / policy for the full rationale): name is schema-Required (no nested
+	// general block on this resource) and always populated in genuinely
+	// managed state, so state.Name.IsNull() can only mean this Read call is
+	// doing first-time import hydration. Hydrate the wire-present optional
+	// software_definitions/licenses lists in that case; subsequent Reads
+	// revert to only refreshing lists the current state already tracks.
+	firstHydration := state.Name.IsNull()
+	resp.Diagnostics.Append(assignLicensedSoftwareResourceModel(readCtx, &state, got, firstHydration)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -209,7 +217,7 @@ func (r *LicensedSoftwareResource) Update(ctx context.Context, req resource.Upda
 		resp.Diagnostics.AddError("Error reading updated Jamf Pro licensed software", err.Error())
 		return
 	}
-	resp.Diagnostics.Append(assignLicensedSoftwareResourceModel(updateCtx, &plan, got)...)
+	resp.Diagnostics.Append(assignLicensedSoftwareResourceModel(updateCtx, &plan, got, false)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}

--- a/internal/resources/pro/licensed_software/state_builders.go
+++ b/internal/resources/pro/licensed_software/state_builders.go
@@ -23,16 +23,16 @@ import (
 // when the incoming model already manages it (non-nil — plan on create/update,
 // prior state on read). When the user did not author the list (nil), it is left
 // null and the server's echo is ignored, so an unmanaged collection does not
-// surface as drift. This mirrors the scope-omission pattern; the trade-off is
-// that `terraform import` leaves both lists unmanaged (the importer has no prior
-// model), so they must be re-declared to take ownership.
+// surface as drift. This mirrors the scope-omission pattern.
 //
-// Within a managed list, user-authored strings adopt the configured value when
-// set, else the wire value with "" collapsed to null. The purchasing block is
-// only surfaced when the corresponding prior element already managed it — the
-// server echoes a default <purchasing> on every licence, so populating an
-// unmanaged one would violate the framework's "inconsistent result" check.
-func assignLicensedSoftwareResourceModel(ctx context.Context, state *LicensedSoftwareResourceModel, ls *proclassic.LicensedSoftware) diag.Diagnostics {
+// firstHydration is true only on a fresh import (see the Read caller): the
+// incoming model has no prior list to correlate against, but flattenDefinitions
+// / flattenLicenses already treat a positional index beyond the prior list's
+// length as "nothing to prefer, take the wire value" (see their `i < len(prior)`
+// bound checks) — so seeding an EMPTY (not nil) placeholder list is sufficient
+// to flip the managed gate on and let every element hydrate from the wire, with
+// no need to know the list's length up front.
+func assignLicensedSoftwareResourceModel(ctx context.Context, state *LicensedSoftwareResourceModel, ls *proclassic.LicensedSoftware, firstHydration bool) diag.Diagnostics {
 	var diags diag.Diagnostics
 	if ls == nil {
 		return diags
@@ -42,6 +42,14 @@ func assignLicensedSoftwareResourceModel(ctx context.Context, state *LicensedSof
 	// both the managed/unmanaged signal and the positional correlation source.
 	priorDefs := state.SoftwareDefinitions
 	priorLicenses := state.Licenses
+	if firstHydration {
+		if priorDefs == nil && ls.SoftwareDefinitions != nil {
+			priorDefs = []LicensedSoftwareDefinitionModel{}
+		}
+		if priorLicenses == nil && ls.Licenses != nil {
+			priorLicenses = []LicensedSoftwareLicenseModel{}
+		}
+	}
 
 	if id := extractLicensedSoftwareID(ls); id != "" {
 		state.ID = types.StringValue(id)

--- a/internal/resources/pro/licensed_software/state_builders_test.go
+++ b/internal/resources/pro/licensed_software/state_builders_test.go
@@ -127,7 +127,7 @@ func TestAssign_CreatePath_RoundTrip(t *testing.T) {
 		},
 	}
 
-	if diags := assignLicensedSoftwareResourceModel(context.Background(), plan, wireRecord()); diags.HasError() {
+	if diags := assignLicensedSoftwareResourceModel(context.Background(), plan, wireRecord(), false); diags.HasError() {
 		t.Fatalf("unexpected diags: %v", diags)
 	}
 
@@ -201,27 +201,56 @@ func TestAssign_CreatePath_RoundTrip(t *testing.T) {
 	}
 }
 
-// TestAssign_ImportPath_LeavesListsUnmanaged exercises import (no prior model):
-// the opt-out gating leaves software_definitions and licenses unmanaged (null)
-// even though the server echoes them, so they must be re-declared to be managed.
-// The Computed computers echo is still surfaced.
-func TestAssign_ImportPath_LeavesListsUnmanaged(t *testing.T) {
+// TestAssign_ImportPath_HydratesLists exercises first-time import hydration (no
+// prior model, firstHydration=true — see the import-hydration fix): with no
+// prior list to correlate against, software_definitions and licenses must
+// still populate from the wire (an empty, non-nil placeholder list is enough to
+// flip the managed gate on; flattenDefinitions/flattenLicenses's `i < len(prior)`
+// bound check naturally falls through to the wire value for every element).
+// Before the fix, these stayed permanently null after any import regardless of
+// config, matching issue #278's root cause for the other 12 resources.
+func TestAssign_ImportPath_HydratesLists(t *testing.T) {
 	state := &LicensedSoftwareResourceModel{} // no prior nested lists (import)
 
-	if diags := assignLicensedSoftwareResourceModel(context.Background(), state, wireRecord()); diags.HasError() {
+	if diags := assignLicensedSoftwareResourceModel(context.Background(), state, wireRecord(), true); diags.HasError() {
 		t.Fatalf("unexpected diags: %v", diags)
 	}
 
-	if state.SoftwareDefinitions != nil {
-		t.Errorf("software_definitions = %+v on import, want nil (unmanaged)", state.SoftwareDefinitions)
-	}
-	if state.Licenses != nil {
-		t.Errorf("licenses = %+v on import, want nil (unmanaged)", state.Licenses)
-	}
-	// Header still flattens, and the Computed computers echo is surfaced.
 	if state.Name.ValueString() != "ZZ-Probe-LicSW" {
 		t.Errorf("name = %v, want ZZ-Probe-LicSW", state.Name)
 	}
+
+	if len(state.SoftwareDefinitions) != 1 {
+		t.Fatalf("software_definitions len = %d, want 1", len(state.SoftwareDefinitions))
+	}
+	if got := state.SoftwareDefinitions[0].Name.ValueString(); got != "SoftA" {
+		t.Errorf("software_definitions[0].name = %q, want SoftA", got)
+	}
+
+	if len(state.Licenses) != 2 {
+		t.Fatalf("licenses len = %d, want 2", len(state.Licenses))
+	}
+	a, b := state.Licenses[0], state.Licenses[1]
+	if got := a.SerialNumber1.ValueString(); got != "SER-A1" {
+		t.Errorf("license[0].serial_number_1 = %q, want SER-A1", got)
+	}
+	// No prior at all (import): the echoed <purchasing> on EVERY licence is
+	// surfaced faithfully, including the bare licence's default-shaped block —
+	// there is nothing declared yet to compare against, so there is no
+	// "unmanaged echo" to suppress.
+	if a.Purchasing == nil {
+		t.Fatal("license[0].purchasing = nil, want populated on import")
+	}
+	if a.Purchasing.LicenseTerm.ValueString() != "perpetual" {
+		t.Errorf("license[0].license_term = %v, want perpetual", a.Purchasing.LicenseTerm)
+	}
+	if b.Purchasing == nil {
+		t.Fatal("license[1].purchasing = nil, want populated on import (default-shaped echo, faithfully surfaced)")
+	}
+	if b.Purchasing.LicenseTerm.ValueString() != "perpetual" {
+		t.Errorf("license[1].license_term = %v, want perpetual", b.Purchasing.LicenseTerm)
+	}
+
 	if state.Computers.IsNull() || len(state.Computers.Elements()) != 1 {
 		t.Errorf("computers = %v, want one known entry", state.Computers)
 	}


### PR DESCRIPTION
## Summary

Follow-up to #279 (issue #278). `licensed_software`'s `software_definitions` and `licenses` lists share the exact same root cause as the 12 resources fixed in #279 — `terraform import` left them permanently unmanaged (`null`) even when config declared them matching the server — but needed a different fix shape, so it was deliberately left out of that PR rather than rushed in.

**Why it's different**: the other 12 resources gate a *pointer* (`state.General == nil`) — trivial to flip with an empty allocation. `licensed_software`'s lists are id-less and reconciled **positionally** against a *prior* list (no server-assigned element ID to correlate by). The existing code's gate captured the incoming list as both the "is this managed" signal and the correlation source, and a fresh import has no prior list at all.

**The fix turned out simpler than expected once traced through**: `flattenDefinitions`/`flattenLicenses` already treat a positional index beyond the prior list's length as "nothing to prefer, take the wire value" (their `i < len(prior)` bound check) — that fallback already existed and is already correct. So on first hydration, seeding an **empty, non-nil** placeholder list is sufficient to flip the managed gate on; every wire element then falls through the existing per-element logic to the wire value, with no need to know the list's length up front and no same-length allocation required.

Gated on `state.Name.IsNull()` (no `general` block on this resource — mirrors the scalar-gate pattern from `app_installer`/`vpp_invitation`/`vpp_assignment`/`account_group` in #279): `Name` is schema-`Required`, always populated in genuinely managed state, so it can only be unset on first-time import hydration.

An existing unit test (`TestAssign_ImportPath_LeavesListsUnmanaged`) explicitly pinned the *old* buggy behavior as correct — rewrote it as `TestAssign_ImportPath_HydratesLists` asserting the fixed behavior, including that the bare license's default-shaped `purchasing` echo is now faithfully surfaced on import (nothing declared yet to suppress it against).

**Independent of #279** — branched from `main`, touches only `licensed_software`, no dependency on that PR merging first.

## Test plan

- [x] `go build ./...`, `go fix ./...`, `make fmt`, `make lint`, `make test` — all clean
- [x] Unit test rewritten and passing (`TestAssign_ImportPath_HydratesLists`)
- [x] Live-verified against a real tenant (dev-override provider build, classic `terraform import <addr> <id>`): created a record with `software_definitions` + `licenses` (including a full `purchasing` block) declared → state rm → import → plan is clean immediately (no even the one-time settle diff #279's resources needed, since nothing here was left undeclared) → normal edit (rename `organization_name`) → apply → plan-clean lifecycle re-verified unaffected → tenant cleaned up (record destroyed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)