### PR TITLE
ci: deliver GITLEAKS_LICENSE to fork PRs + document fork-PR acceptance flow

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -86,3 +86,4 @@ Relates to #
 - [ ] Unit tests (and acceptance, where the `acceptance` gate is approved) pass in CI
 - [ ] Screenshots show expected behavior in Jamf Pro UI
 - [ ] No breaking changes (or properly documented)
+- [ ] For **fork PRs**, acceptance was validated via the maintainer re-push flow (see [CONTRIBUTING.md → Acceptance Tests on Fork PRs](../CONTRIBUTING.md#acceptance-tests-on-fork-prs-maintainers)) — the fork's own `Acceptance` check only self-skips

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -2,7 +2,13 @@ name: Gitleaks
 
 on:
   push:
-  pull_request:
+  # pull_request_target (not pull_request) so GITLEAKS_LICENSE is available on
+  # fork PRs — GitHub withholds ALL secrets from a pull_request run triggered by
+  # a fork, which is why the licensed gitleaks-action fails there. This is safe
+  # ONLY because gitleaks reads files and never executes repo code; the checkout
+  # below pins the PR head with persist-credentials:false so the privileged
+  # token is never written to disk for a later step to pick up.
+  pull_request_target:
   workflow_dispatch:
 
 permissions:
@@ -17,6 +23,12 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
+          # pull_request_target checks out the BASE ref by default; scan the PR
+          # head instead so the fork's actual content is inspected. Falls back to
+          # github.ref for push / workflow_dispatch. persist-credentials:false
+          # keeps the elevated pull_request_target token out of .git/config.
+          ref: ${{ github.event.pull_request.head.sha || github.ref }}
+          persist-credentials: false
       - uses: gitleaks/gitleaks-action@e0c47f4f8be36e29cdc102c57e68cb5cbf0e8d1e # v3.0.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -282,6 +282,57 @@ Use [conventional commit](https://www.conventionalcommits.org/) style messages:
 - Run `make generate` if schema descriptions changed (to update docs and copyright headers).
 - CI must pass before merge.
 
+## Acceptance Tests on Fork PRs (Maintainers)
+
+Fork PRs never receive repository secrets — GitHub withholds them from every
+workflow triggered by a `pull_request` from a fork (the run log shows `Secret
+source: None`). So the `Acceptance` job on a fork PR runs credential-less and
+every suite self-skips: a green check there means "skipped", **not** "passed".
+
+Do **not** wire the tenant credentials into a fork run (e.g. via
+`pull_request_target`). The PR's test code executes with those creds and could
+exfiltrate them or mutate/erase the shared tenant, and `pull_request_target`
+is not covered by the "require approval for external contributors" gate that
+protects ordinary fork `pull_request` runs. Instead, a maintainer re-runs the
+PR's code from a branch **inside this repo**, where secrets resolve normally:
+
+1. **Review the entire diff first — including `.github/` and `go.mod`.** The
+   steps below run the PR's code (and its workflow files) against the live
+   tenant, so this review is the security gate. If anything looks untrustworthy,
+   stop here.
+
+2. Fetch the PR head into a throwaway, clearly-named branch and push it to this
+   repo (replace `283` with the PR number):
+
+   ```bash
+   git fetch origin pull/283/head:acc/pr-283
+   git push origin acc/pr-283
+   ```
+
+3. Open an internal PR from that branch to `main`. It is a *same-repo* PR, so
+   the pipeline gets secrets and the `Acceptance` job runs the scoped subset for
+   real:
+
+   ```bash
+   gh pr create --base main --head acc/pr-283 \
+     --title "[acc] validate #283" --draft \
+     --body "CI-only validation of fork PR #283. Do not merge."
+   ```
+
+4. Watch the `Acceptance` checks on the internal PR, then copy the outcome back
+   to the original fork PR.
+
+5. Clean up — **close (do not merge)** the internal PR and delete the branch:
+
+   ```bash
+   gh pr close acc/pr-283 --delete-branch
+   ```
+
+> A manual `workflow_dispatch` of *Integration Tests* does **not** work for this:
+> the acceptance scope is computed by diffing against the PR base branch, which a
+> dispatch run doesn't have, so the `Acceptance` job is skipped. The internal PR
+> above is the trigger that runs it.
+
 ## Tracking Work
 
 **The GitHub project board is the source of truth for project status.** Local docs hold the detail behind each status.


### PR DESCRIPTION
## Problem

Fork PRs get **no secrets** on the `pull_request` event — GitHub withholds them from any workflow triggered by a fork (the run log shows `Secret source: None`). Two consequences on incoming fork PRs (e.g. #283):

- **Gitleaks fails hard.** The licensed `gitleaks-action` requires a key for org accounts, `GITLEAKS_LICENSE` is empty, so it errors: `[Jamf-Concepts] is an organization. License key is required. 🛑 missing gitleaks license`.
- **Acceptance can't authenticate.** `JAMFPLATFORM_*` are empty, so every suite self-skips — a green check means "skipped", not "passed".

## Changes

### Gitleaks — fix
Switch the trigger from `pull_request` to **`pull_request_target`** so `GITLEAKS_LICENSE` resolves on fork PRs. The checkout is pinned to the PR head with `persist-credentials: false`. This is safe because gitleaks only **reads** files — it never executes repo code, so the classic `pull_request_target` code-execution risk doesn't apply here.

### Acceptance — document, don't "fix"
Handing a fork the live tenant credentials would be a security hole: the PR's test code runs with those creds and could exfiltrate them or mutate/erase the shared tenant. `pull_request_target` is also **not** covered by the "require approval for external contributors" gate that protects normal fork `pull_request` runs. So acceptance intentionally stays credential-less on forks.

Instead, document the **maintainer re-push → internal-PR** flow (`CONTRIBUTING.md → Acceptance Tests on Fork PRs`): after reviewing the full diff, a maintainer pushes the PR head to a branch in this repo and opens an internal PR to `main` — a same-repo PR that gets secrets and runs the scoped acc suite for real. A pointer is added to the PR-template reviewer checklist.

No acceptance workflow code changes — the flow rides existing machinery.

## Notes for merge
- The Gitleaks fix only takes effect **after this merges to `main`** (`pull_request_target` always uses the base-branch workflow). To clear the check on #283, push a commit or close/reopen it after merge.
- Minor residual: a fork could add a permissive `.gitleaks.toml` to weaken the scan on its own PR (doesn't leak the license). Optional future hardening: pin `--config`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
