### PR TITLE
fix(blueprints): stop legacy-payload perpetual diff and updated-attr inconsistency (#282)

### DIFF
--- a/internal/resources/blueprints/blueprint/resource.go
+++ b/internal/resources/blueprints/blueprint/resource.go
@@ -34,6 +34,7 @@ type BlueprintResource struct {
 var _ resource.Resource = &BlueprintResource{}
 var _ resource.ResourceWithImportState = &BlueprintResource{}
 var _ resource.ResourceWithIdentity = &BlueprintResource{}
+var _ resource.ResourceWithModifyPlan = &BlueprintResource{}
 
 const (
 	defaultCreateTimeout = 60 * time.Second
@@ -239,6 +240,28 @@ func (r *BlueprintResource) Configure(ctx context.Context, req resource.Configur
 	}
 
 	r.client = blueprints.New(pd.Client)
+}
+
+// ModifyPlan marks the server-managed `updated` and `deployment_state`
+// attributes as unknown whenever a change is planned. The service re-stamps
+// `updated` on every write (and may transition `deployment_state` while a
+// deployment reconciles), so their post-apply values cannot be predicted from
+// prior state; without this, an in-place update fails with "Provider produced
+// inconsistent result after apply" on the `updated` attribute. Create (nil prior
+// state) and destroy (nil plan) are skipped — the attributes are already unknown
+// on create and there is no planned state to modify on destroy — and a plan with
+// no change is left untouched so the resource keeps showing an empty plan.
+func (r *BlueprintResource) ModifyPlan(ctx context.Context, req resource.ModifyPlanRequest, resp *resource.ModifyPlanResponse) {
+	if req.State.Raw.IsNull() || req.Plan.Raw.IsNull() {
+		return
+	}
+
+	if req.Plan.Raw.Equal(req.State.Raw) {
+		return
+	}
+
+	resp.Diagnostics.Append(resp.Plan.SetAttribute(ctx, path.Root("updated"), types.StringUnknown())...)
+	resp.Diagnostics.Append(resp.Plan.SetAttribute(ctx, path.Root("deployment_state"), types.StringUnknown())...)
 }
 
 // ImportState handles the import of existing Blueprint resources.

--- a/internal/resources/blueprints/blueprint/resource_acceptance_test.go
+++ b/internal/resources/blueprints/blueprint/resource_acceptance_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/common/helpers"
 	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/testhelpers"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
@@ -531,6 +532,117 @@ func TestAccResource_Blueprint_LegacyPayloads(t *testing.T) {
 					resource.TestCheckResourceAttrSet("jamfplatform_blueprints_blueprint.test_legacy", "id"),
 					resource.TestCheckResourceAttr("jamfplatform_blueprints_blueprint.test_legacy", "name", name),
 				),
+			},
+		},
+	})
+}
+
+// TestAccResource_Blueprint_LegacyPayloads_NullFields_PlanStability is a
+// regression test for issue #282. A legacy payload whose settings contain
+// explicit nulls (here com.apple.notificationsettings) previously produced a
+// perpetual in-place update, and applying that update failed with "Provider
+// produced inconsistent result after apply" on the server-stamped `updated`
+// attribute. Step 1 creates the blueprint; step 2 re-applies the identical
+// config and asserts an empty plan (the dynamic null-typing reconcile); step 3
+// makes a genuine metadata change (description) that forces an in-place update
+// and must apply without an inconsistent-result error (ModifyPlan marks
+// `updated` unknown); step 4 confirms plan stability after that update; step 5
+// makes a genuine change to the payload itself, proving the reconcile surfaces
+// real payload edits rather than masking them; step 6 confirms stability again.
+func TestAccResource_Blueprint_LegacyPayloads_NullFields_PlanStability(t *testing.T) {
+	testhelpers.AccPreCheck(t)
+	suffix := testhelpers.RunSuffix()
+	name := "tf-acc-legacy-null-" + suffix
+	addr := "jamfplatform_blueprints_blueprint.test_legacy_null"
+
+	config := func(description string, firstNotificationsEnabled bool) string {
+		return testBlueprintConfig(smartGroupHCL("legacynull"), fmt.Sprintf(`
+			resource "jamfplatform_blueprints_blueprint" "test_legacy_null" {
+				name          = %q
+				description   = %q
+				deployed      = false
+				device_groups = [jamfplatform_device_group.scope.id]
+
+				legacy_payloads = [
+					{
+						payload_type = "com.apple.notificationsettings"
+						settings = {
+							NotificationSettings = [
+								{
+									AlertType                = 0
+									PreviewType              = null
+									GroupingType             = null
+									BadgesEnabled            = null
+									ShowInCarPlay            = null
+									SoundsEnabled            = null
+									BundleIdentifier         = "_SYSTEM_CENTER_:com.apple.followup.alert"
+									ShowInLockScreen         = false
+									CriticalAlertEnabled     = null
+									NotificationsEnabled     = %t
+									ShowInNotificationCenter = false
+								},
+								{
+									AlertType                = 2
+									PreviewType              = null
+									GroupingType             = null
+									BadgesEnabled            = true
+									ShowInCarPlay            = null
+									SoundsEnabled            = true
+									BundleIdentifier         = "au.bartreardon.dialog"
+									ShowInLockScreen         = false
+									CriticalAlertEnabled     = true
+									NotificationsEnabled     = true
+									ShowInNotificationCenter = true
+								},
+							]
+						}
+					},
+				]
+			}
+		`, name, description, firstNotificationsEnabled))
+	}
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testhelpers.AccTestProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckBlueprintResourcesDestroy(t),
+		Steps: []resource.TestStep{
+			{
+				Config: config("Acceptance test — safe to delete", false),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet(addr, "id"),
+					resource.TestCheckResourceAttr(addr, "name", name),
+					resource.TestCheckResourceAttrSet(addr, "updated"),
+				),
+			},
+			{
+				Config: config("Acceptance test — safe to delete", false),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{plancheck.ExpectEmptyPlan()},
+				},
+			},
+			{
+				Config: config("Updated description", false),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(addr, "description", "Updated description"),
+				),
+			},
+			{
+				Config: config("Updated description", false),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{plancheck.ExpectEmptyPlan()},
+				},
+			},
+			{
+				Config: config("Updated description", true),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{plancheck.ExpectNonEmptyPlan()},
+				},
+			},
+			{
+				Config: config("Updated description", true),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{plancheck.ExpectEmptyPlan()},
+				},
 			},
 		},
 	})

--- a/internal/resources/blueprints/blueprint/state_builders.go
+++ b/internal/resources/blueprints/blueprint/state_builders.go
@@ -4,6 +4,7 @@
 package blueprint
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"strings"
@@ -172,6 +173,11 @@ func parseComponentConfiguration(apiComponentsByID map[string]blueprints.Compone
 }
 
 // updateLegacyPayloadsFromAPI handles the special case of legacy payloads component.
+// Legacy payloads round-trip through a dynamic attribute, where a JSON null from
+// the server is typed as a string while the same null in configuration is untyped;
+// that mismatch alone would cause a perpetual diff. When the server response is
+// semantically identical to the incoming plan/state value it therefore preserves
+// that configuration-shaped value rather than overwriting it (see dynamicPayloadsMatchJSON).
 func updateLegacyPayloadsFromAPI(ctx context.Context, model *BlueprintResourceModel, apiComponentsByID map[string]blueprints.Component, rawIdentifiers map[string]struct{}) {
 	if _, handledAsRaw := rawIdentifiers["com.jamf.ddm-configuration-profile"]; handledAsRaw {
 		return
@@ -228,17 +234,51 @@ func updateLegacyPayloadsFromAPI(ctx context.Context, model *BlueprintResourceMo
 		resultItems = append(resultItems, entry)
 	}
 
-	if len(resultItems) > 0 {
-		dynVal, err := helpers.JSONToTerraformDynamic(resultItems)
-		if err != nil {
-			tflog.Warn(ctx, "Failed to convert legacy payloads to dynamic", map[string]any{
-				"error": err.Error(),
-			})
-			model.LegacyPayloads = types.DynamicNull()
-			return
-		}
-		model.LegacyPayloads = dynVal
-	} else {
+	if len(resultItems) == 0 {
 		model.LegacyPayloads = types.DynamicNull()
+		return
 	}
+
+	if dynamicPayloadsMatchJSON(model.LegacyPayloads, resultItems) {
+		return
+	}
+
+	dynVal, err := helpers.JSONToTerraformDynamic(resultItems)
+	if err != nil {
+		tflog.Warn(ctx, "Failed to convert legacy payloads to dynamic", map[string]any{
+			"error": err.Error(),
+		})
+		model.LegacyPayloads = types.DynamicNull()
+		return
+	}
+	model.LegacyPayloads = dynVal
+}
+
+// dynamicPayloadsMatchJSON reports whether the prior dynamic value is
+// semantically identical to the server-derived payload items, comparing their
+// canonical JSON encodings. Numbers normalise to float64 on both sides and
+// json.Marshal sorts object keys, so the comparison is order-independent for
+// object keys and insensitive to the dynamic null-typing that otherwise causes
+// a perpetual diff.
+func dynamicPayloadsMatchJSON(prior types.Dynamic, apiItems []any) bool {
+	if prior.IsNull() || prior.IsUnknown() {
+		return false
+	}
+
+	priorJSON, err := helpers.TerraformDynamicToJSON(prior)
+	if err != nil {
+		return false
+	}
+
+	priorBytes, err := json.Marshal(priorJSON)
+	if err != nil {
+		return false
+	}
+
+	apiBytes, err := json.Marshal(apiItems)
+	if err != nil {
+		return false
+	}
+
+	return bytes.Equal(priorBytes, apiBytes)
 }

--- a/internal/resources/blueprints/blueprint/state_builders_test.go
+++ b/internal/resources/blueprints/blueprint/state_builders_test.go
@@ -303,3 +303,83 @@ func TestUpdateModelFromAPIResponse_NoSteps(t *testing.T) {
 		t.Error("expected nil components when no steps")
 	}
 }
+
+// TestUpdateLegacyPayloadsFromAPI_PreservesConfigShapeOnMatch pins the issue
+// #282 fix: when the server response is semantically identical to the incoming
+// (configuration-shaped) value, the reader keeps that value verbatim so the
+// dynamic null-typing does not manufacture a diff.
+func TestUpdateLegacyPayloadsFromAPI_PreservesConfigShapeOnMatch(t *testing.T) {
+	ctx := t.Context()
+
+	prior, err := helpers.JSONToTerraformDynamic([]any{
+		map[string]any{
+			"payload_type": "com.apple.notificationsettings",
+			"settings": map[string]any{
+				"NotificationSettings": []any{
+					map[string]any{
+						"BundleIdentifier":     "com.apple.tips",
+						"AlertType":            float64(0),
+						"BadgesEnabled":        nil,
+						"NotificationsEnabled": false,
+					},
+				},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("failed to build prior value: %v", err)
+	}
+
+	apiComponents := map[string]blueprints.Component{
+		"com.jamf.ddm-configuration-profile": {
+			Identifier:    "com.jamf.ddm-configuration-profile",
+			Configuration: json.RawMessage(`{"payloadContent":[{"payloadType":"com.apple.notificationsettings","payloadIdentifier":"generated-uuid","NotificationSettings":[{"BundleIdentifier":"com.apple.tips","AlertType":0,"BadgesEnabled":null,"NotificationsEnabled":false}]}]}`),
+		},
+	}
+
+	model := &BlueprintResourceModel{LegacyPayloads: prior}
+	updateLegacyPayloadsFromAPI(ctx, model, apiComponents, map[string]struct{}{})
+
+	if !model.LegacyPayloads.Equal(prior) {
+		t.Errorf("expected config-shaped prior value to be preserved on semantic match, got %#v", model.LegacyPayloads)
+	}
+}
+
+// TestUpdateLegacyPayloadsFromAPI_OverwritesOnMismatch verifies that a genuine
+// server-side difference is still surfaced rather than masked by the reconcile.
+func TestUpdateLegacyPayloadsFromAPI_OverwritesOnMismatch(t *testing.T) {
+	ctx := t.Context()
+
+	prior, err := helpers.JSONToTerraformDynamic([]any{
+		map[string]any{
+			"payload_type": "com.apple.notificationsettings",
+			"settings":     map[string]any{"BundleIdentifier": "com.apple.tips.old"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("failed to build prior value: %v", err)
+	}
+
+	apiComponents := map[string]blueprints.Component{
+		"com.jamf.ddm-configuration-profile": {
+			Identifier:    "com.jamf.ddm-configuration-profile",
+			Configuration: json.RawMessage(`{"payloadContent":[{"payloadType":"com.apple.notificationsettings","BundleIdentifier":"com.apple.tips.new"}]}`),
+		},
+	}
+
+	model := &BlueprintResourceModel{LegacyPayloads: prior}
+	updateLegacyPayloadsFromAPI(ctx, model, apiComponents, map[string]struct{}{})
+
+	if model.LegacyPayloads.Equal(prior) {
+		t.Fatal("expected differing server value to overwrite the prior value")
+	}
+
+	raw, err := helpers.TerraformDynamicToJSON(model.LegacyPayloads)
+	if err != nil {
+		t.Fatalf("failed to convert result: %v", err)
+	}
+	settings := raw.([]any)[0].(map[string]any)["settings"].(map[string]any)
+	if settings["BundleIdentifier"] != "com.apple.tips.new" {
+		t.Errorf("expected overwritten value 'com.apple.tips.new', got %v", settings["BundleIdentifier"])
+	}
+}


### PR DESCRIPTION
Fixes #282.

## Problem

Blueprints deploying legacy payloads that contain explicit nulls (e.g. `com.apple.notificationsettings`) showed a perpetual in-place update, and applying it failed with:

```
Provider produced inconsistent result after apply: .updated: was
cty.StringVal("…19:01:59Z"), but now cty.StringVal("…21:02:11Z").
```

Reproduced end-to-end against a live tenant before fixing.

## Root cause — two stacked defects

1. **Perpetual diff (the "mystery change").** `legacy_payloads` is a `DynamicAttribute`. A JSON `null` from the server round-trips as a *string*-typed null, whereas the same null in configuration is untyped. That type mismatch alone manufactured a diff on every plan, which is what kept triggering an update.
2. **The crash.** `updated` (and `deployment_state`) are re-stamped by the service on every write, but as bare `Computed` attributes they were planned as their prior-state value. Any in-place update then tripped Terraform's post-apply consistency check on `updated`.

## Fix

- **`state_builders.go`** — `updateLegacyPayloadsFromAPI` now preserves the incoming configuration-shaped value when the server response is semantically identical (canonical-JSON compare), so state never drifts to the string-null shape. Genuine payload edits still overwrite and surface a diff.
- **`resource.go`** — new `ModifyPlan` marks `updated` and `deployment_state` unknown whenever a change is planned, guarded (`req.Plan.Raw.Equal(req.State.Raw)`) so no-op plans stay empty.

## Verification (live, dev_overrides)

| Scenario | Before | After |
|---|---|---|
| Re-plan after create | perpetual "1 to change" | **No changes** |
| Metadata edit (description) | crash on `.updated` | applies clean, settles |
| Legit payload edit (`NotificationsEnabled false→true`) | — | **diff surfaced**, applies clean, settles |

## Tests

- **Acceptance** `TestAccResource_Blueprint_LegacyPayloads_NullFields_PlanStability`: create with the null-heavy payload → empty-plan → description update → empty-plan → **payload change (`ExpectNonEmptyPlan`)** → empty-plan.
- **Unit**: `…_PreservesConfigShapeOnMatch` and `…_OverwritesOnMismatch` pin both reconcile paths.

`make fix fmt lint test` clean. No schema descriptions changed, so `make generate` is not required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)