### PR TITLE
fix(account_privileges): dedupe data source privilege sets (#290)

### DIFF
--- a/internal/common/accountprivileges/accountprivileges_test.go
+++ b/internal/common/accountprivileges/accountprivileges_test.go
@@ -18,9 +18,9 @@ import (
 
 func mustSet(t *testing.T, vals ...string) types.Set {
 	t.Helper()
-	s, diags := newStringSet(vals)
+	s, diags := NewStringSet(vals)
 	if diags.HasError() {
-		t.Fatalf("newStringSet(%v): %v", vals, diags)
+		t.Fatalf("NewStringSet(%v): %v", vals, diags)
 	}
 	return s
 }
@@ -139,7 +139,7 @@ func TestIntersectIntoState_ImportMaterialisesFullGrid(t *testing.T) {
 // TestIntersectIntoState_ImportDedupesServerDuplicates guards the genconfig /
 // import path: the classic /accounts endpoint can echo the same privilege
 // string more than once within a category, and types.SetValue rejects duplicate
-// elements with a hard "Duplicate Set Element" error. newStringSet must collapse
+// elements with a hard "Duplicate Set Element" error. NewStringSet must collapse
 // the duplicates so hydration succeeds.
 func TestIntersectIntoState_ImportDedupesServerDuplicates(t *testing.T) {
 	server := map[string][]string{
@@ -151,6 +151,59 @@ func TestIntersectIntoState_ImportDedupesServerDuplicates(t *testing.T) {
 	}
 	if got, want := setStrings(t, out.JamfProServerObjects), []string{"Create/Read/Update Cloud Distribution Point", "Read Buildings"}; !reflect.DeepEqual(got, want) {
 		t.Errorf("duplicate server privileges should collapse, got %v want %v", got, want)
+	}
+}
+
+// TestCategorizedSets_DedupesWithinCategoryAndUnion is the regression guard for
+// issue #290: the account_privileges data source projected the discovered
+// catalog into state with its own set builder that called types.SetValue
+// directly, so the classic Administrator grid's within-category duplicates
+// (Create/Read/Update Cloud Distribution Point, Read/Update Computer Check-In —
+// each echoed twice) produced a hard "Duplicate Set Element" error at apply and
+// the data source never landed in state. CategorizedSets must collapse the
+// duplicates in every category and in the flat union.
+func TestCategorizedSets_DedupesWithinCategoryAndUnion(t *testing.T) {
+	catalog := map[string][]string{
+		"jss_objects": {
+			"Create Cloud Distribution Point", "Create Cloud Distribution Point",
+			"Read Cloud Distribution Point", "Read Cloud Distribution Point",
+			"Update Cloud Distribution Point", "Update Cloud Distribution Point",
+			"Read Buildings",
+		},
+		"jss_settings": {
+			"Read Computer Check-In", "Read Computer Check-In",
+			"Update Computer Check-In", "Update Computer Check-In",
+		},
+	}
+	sets, all, diags := CategorizedSets(catalog)
+	if diags.HasError() {
+		t.Fatalf("CategorizedSets with duplicate wire values: %v", diags)
+	}
+
+	wantObjects := []string{
+		"Create Cloud Distribution Point",
+		"Read Buildings",
+		"Read Cloud Distribution Point",
+		"Update Cloud Distribution Point",
+	}
+	if got := setStrings(t, sets["jss_objects"]); !reflect.DeepEqual(got, wantObjects) {
+		t.Errorf("jss_objects: got %v want %v", got, wantObjects)
+	}
+	wantSettings := []string{"Read Computer Check-In", "Update Computer Check-In"}
+	if got := setStrings(t, sets["jss_settings"]); !reflect.DeepEqual(got, wantSettings) {
+		t.Errorf("jss_settings: got %v want %v", got, wantSettings)
+	}
+
+	// Absent categories still yield an empty (non-null) set.
+	if s := sets["recon"]; s.IsNull() || len(s.Elements()) != 0 {
+		t.Errorf("absent category recon should be empty non-null set, got %v", s)
+	}
+
+	// The flat union carries every distinct privilege exactly once.
+	wantAll := append(append([]string(nil), wantObjects...), wantSettings...)
+	sort.Strings(wantAll)
+	if got := setStrings(t, all); !reflect.DeepEqual(got, wantAll) {
+		t.Errorf("all union: got %v want %v", got, wantAll)
 	}
 }
 

--- a/internal/common/accountprivileges/model.go
+++ b/internal/common/accountprivileges/model.go
@@ -105,13 +105,16 @@ func (m *Model) IsEmpty() bool {
 	return true
 }
 
-// newStringSet builds a types.Set of strings from a slice (sorted and
+// NewStringSet builds a types.Set of strings from a slice (sorted and
 // de-duplicated for stable output). A nil slice yields an empty (non-null) set.
 // Deduping is required because the classic /accounts endpoint can echo the same
-// privilege string more than once within a category (wire-probed 2026-06-12);
-// types.SetValue rejects duplicate elements with a hard "Duplicate Set Element"
-// error, which previously aborted import / terraform query hydration.
-func newStringSet(vals []string) (types.Set, diag.Diagnostics) {
+// privilege string more than once within a category (wire-probed 2026-06-12:
+// the Administrator grid returns Create/Read/Update Cloud Distribution Point and
+// Read/Update Computer Check-In twice each); types.SetValue rejects duplicate
+// elements with a hard "Duplicate Set Element" error, which previously aborted
+// import, terraform query hydration, and the account_privileges data source
+// (issue #290).
+func NewStringSet(vals []string) (types.Set, diag.Diagnostics) {
 	sorted := append([]string(nil), vals...)
 	sort.Strings(sorted)
 	elems := make([]attr.Value, 0, len(sorted))

--- a/internal/common/accountprivileges/sdk.go
+++ b/internal/common/accountprivileges/sdk.go
@@ -170,7 +170,7 @@ func IntersectIntoState(ctx context.Context, prior *Model, server map[string][]s
 				*out.setPtr(c.WireKey) = types.SetNull(types.StringType)
 				continue
 			}
-			set, d := newStringSet(serverVals)
+			set, d := NewStringSet(serverVals)
 			diags.Append(d...)
 			*out.setPtr(c.WireKey) = set
 			continue
@@ -189,7 +189,7 @@ func IntersectIntoState(ctx context.Context, prior *Model, server map[string][]s
 			return out, diags
 		}
 
-		set, d := newStringSet(intersect(declared, serverVals))
+		set, d := NewStringSet(intersect(declared, serverVals))
 		diags.Append(d...)
 		*out.setPtr(c.WireKey) = set
 	}
@@ -197,7 +197,7 @@ func IntersectIntoState(ctx context.Context, prior *Model, server map[string][]s
 }
 
 // intersect returns the elements of declared that are also present in server,
-// preserving declared's membership (order is normalised by newStringSet).
+// preserving declared's membership (order is normalised by NewStringSet).
 func intersect(declared, server []string) []string {
 	have := make(map[string]struct{}, len(server))
 	for _, s := range server {
@@ -210,4 +210,28 @@ func intersect(declared, server []string) []string {
 		}
 	}
 	return out
+}
+
+// CategorizedSets converts a wire-keyed catalog map into a per-category map of
+// string Sets (keyed by wire key) plus a flat union Set of every privilege
+// across all categories. Every returned Set is sorted and de-duplicated via
+// NewStringSet — mandatory because the classic Administrator grid echoes some
+// privilege strings more than once within a category, which types.SetValue
+// would otherwise reject with a "Duplicate Set Element" error (issue #290).
+// Used by the account_privileges data source to project the discovered catalog
+// into state.
+func CategorizedSets(catalog map[string][]string) (map[string]types.Set, types.Set, diag.Diagnostics) {
+	var diags diag.Diagnostics
+	sets := make(map[string]types.Set, len(Categories))
+	var all []string
+	for _, c := range Categories {
+		vals := catalog[c.WireKey]
+		all = append(all, vals...)
+		s, d := NewStringSet(vals)
+		diags.Append(d...)
+		sets[c.WireKey] = s
+	}
+	allSet, d := NewStringSet(all)
+	diags.Append(d...)
+	return sets, allSet, diags
 }

--- a/internal/resources/pro/account_privileges/data_source.go
+++ b/internal/resources/pro/account_privileges/data_source.go
@@ -16,7 +16,6 @@ import (
 
 	"github.com/Jamf-Concepts/jamfplatform-go-sdk/jamfplatform/proclassic"
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/datasource/timeouts"
-	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -122,26 +121,24 @@ func (d *AccountPrivilegesDataSource) Read(ctx context.Context, req datasource.R
 		return
 	}
 
-	var allElems []attr.Value
-	setFor := func(wireKey string) types.Set {
-		vals := catalog[wireKey]
-		elems := make([]attr.Value, 0, len(vals))
-		for _, v := range vals {
-			elems = append(elems, types.StringValue(v))
-			allElems = append(allElems, types.StringValue(v))
-		}
-		s, _ := types.SetValue(types.StringType, elems)
-		return s
+	// CategorizedSets sorts and de-duplicates every category and the union. The
+	// dedup is load-bearing: the classic Administrator grid echoes some privilege
+	// strings twice within a category (e.g. Create/Read/Update Cloud Distribution
+	// Point), which types.SetValue rejects as a "Duplicate Set Element" (#290).
+	sets, allSet, diags := accountprivileges.CategorizedSets(catalog)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
 	}
-	data.JamfProServerObjects = setFor("jss_objects")
-	data.JamfProServerSettings = setFor("jss_settings")
-	data.JamfProServerActions = setFor("jss_actions")
-	data.CasperAdmin = setFor("casper_admin")
-	data.CasperRemote = setFor("casper_remote")
-	data.CasperImaging = setFor("casper_imaging")
-	data.Recon = setFor("recon")
-	data.All, _ = types.SetValue(types.StringType, allElems)
+	data.JamfProServerObjects = sets["jss_objects"]
+	data.JamfProServerSettings = sets["jss_settings"]
+	data.JamfProServerActions = sets["jss_actions"]
+	data.CasperAdmin = sets["casper_admin"]
+	data.CasperRemote = sets["casper_remote"]
+	data.CasperImaging = sets["casper_imaging"]
+	data.Recon = sets["recon"]
+	data.All = allSet
 
-	tflog.Trace(ctx, "read Jamf Pro account privileges catalog", map[string]any{"count": len(allElems)})
+	tflog.Trace(ctx, "read Jamf Pro account privileges catalog", map[string]any{"count": len(allSet.Elements())})
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }

--- a/internal/resources/pro/account_privileges/data_source_acceptance_test.go
+++ b/internal/resources/pro/account_privileges/data_source_acceptance_test.go
@@ -1,0 +1,47 @@
+// Copyright Jamf Software LLC 2026
+// SPDX-License-Identifier: MPL-2.0
+
+//go:build acceptance
+
+package account_privileges_test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+
+	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/testhelpers"
+)
+
+const privsAddr = "data.jamfplatform_pro_account_privileges.test"
+
+// TestAccDataSource_ProAccountPrivileges_Read reads the tenant privilege catalog
+// end-to-end. This is the regression guard for issue #290: the classic
+// Administrator grid echoes some privilege strings twice within a category
+// (Create/Read/Update Cloud Distribution Point, Read/Update Computer Check-In),
+// which previously produced a "Duplicate Set Element" error so the data source
+// never landed in state. A successful apply with populated sets proves the
+// dedup holds; the set-element checks assert the once-duplicated CDP privileges
+// are each present exactly once.
+func TestAccDataSource_ProAccountPrivileges_Read(t *testing.T) {
+	testhelpers.AccPreCheck(t)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testhelpers.AccTestProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: `
+					data "jamfplatform_pro_account_privileges" "test" {}
+				`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet(privsAddr, "jamf_pro_server_objects.#"),
+					resource.TestCheckResourceAttrSet(privsAddr, "jamf_pro_server_settings.#"),
+					resource.TestCheckResourceAttrSet(privsAddr, "all.#"),
+					resource.TestCheckTypeSetElemAttr(privsAddr, "jamf_pro_server_objects.*", "Create Cloud Distribution Point"),
+					resource.TestCheckTypeSetElemAttr(privsAddr, "jamf_pro_server_objects.*", "Read Cloud Distribution Point"),
+					resource.TestCheckTypeSetElemAttr(privsAddr, "jamf_pro_server_objects.*", "Update Cloud Distribution Point"),
+				),
+			},
+		},
+	})
+}


### PR DESCRIPTION
Fixes #290.

## Root cause

The `jamfplatform_pro_account_privileges` data source projected the discovered catalog into state with its own inline set builder (`setFor` closure) calling `types.SetValue` directly — no deduplication — plus an undeduped `all` union. Terraform Sets require unique elements, so the read aborted with `Duplicate Set Element` and the data source never landed in state.

The duplication is **within-category** (wire-probed against a live tenant):

- `jss_objects`: `Create/Read/Update Cloud Distribution Point` each echoed **×2** — exactly the three errors in the issue.
- `jss_settings`: `Read/Update Computer Check-In` each echoed **×2** — a second latent instance not yet reported.

The classic Administrator grid ships these duplicates. The **resource/import** path already handled this via `newStringSet` (sort+dedupe) and even had a regression test documenting the CDP quirk. The data source was a parallel, un-guarded code path that never routed through it.

## Why existing tests missed it

- **No acceptance test existed** for this data source.
- The unit tests `TestAccountPrivilegesDataSource_Metadata`/`_Schema` start with `TestAcc…` (because "Account" does) but are plain unit tests — no `//go:build acceptance`, no `TF_ACC`. They look like acc coverage but aren't.
- The one dedup regression test only covered `IntersectIntoState` (the resource path), never the data source's set construction.

## Fix

- Export `NewStringSet` (renamed from `newStringSet`) — the tested sort+dedupe helper.
- Add `CategorizedSets` to build the seven category sets + the `all` union, all deduped, in one place.
- Route the data source `Read` through `CategorizedSets`; delete the buggy inline builder and the now-unused `attr` import.
- Add `TestCategorizedSets_DedupesWithinCategoryAndUnion` (unit guard with the real wire-dup fixture) and `data_source_acceptance_test.go` that reads the live catalog and asserts the CDP privileges land exactly once — the guard that never existed.

## Testing

- `go build ./...`, `gofmt`, `golangci-lint run` (0 issues) — clean.
- Unit tests pass for `accountprivileges`, `account_privileges`, and the `account`/`account_group` consumers of the renamed `IntersectIntoState`.
- Acceptance test not run locally (maintainer runs against a tenant): `make testacc-run RUN=TestAccDataSource_ProAccountPrivileges_Read PKG=./internal/resources/pro/account_privileges/...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)