### PR TITLE
fix(scope): reject non-numeric object IDs at plan time

### DIFF
--- a/docs/resources/pro_ebook.md
+++ b/docs/resources/pro_ebook.md
@@ -133,17 +133,17 @@ Optional:
 
 Optional:
 
-- `building_ids` (Set of String) Set of Jamf Pro building IDs. Omit to leave this category as configured outside Terraform; set `[]` to clear it.
-- `computer_group_ids` (Set of String) Set of Jamf Pro computer group IDs. Omit to leave this category as configured outside Terraform; set `[]` to clear it.
-- `computer_ids` (Set of String) Set of Jamf Pro computer IDs. Omit to leave this category as configured outside Terraform; set `[]` to clear it.
-- `department_ids` (Set of String) Set of Jamf Pro department IDs. Omit to leave this category as configured outside Terraform; set `[]` to clear it.
+- `building_ids` (Set of String) Set of Jamf Pro building IDs (numeric). Omit to leave this category as configured outside Terraform; set `[]` to clear it.
+- `computer_group_ids` (Set of String) Set of Jamf Pro computer group IDs (numeric). Omit to leave this category as configured outside Terraform; set `[]` to clear it.
+- `computer_ids` (Set of String) Set of Jamf Pro computer IDs (numeric). Omit to leave this category as configured outside Terraform; set `[]` to clear it.
+- `department_ids` (Set of String) Set of Jamf Pro department IDs (numeric). Omit to leave this category as configured outside Terraform; set `[]` to clear it.
 - `directory_service_or_local_user_names` (Set of String) Set of directory service or local user names. Omit to leave this category as configured outside Terraform; set `[]` to clear it.
 - `directory_service_user_group_names` (Set of String) Set of directory service user group names. Omit to leave this category as configured outside Terraform; set `[]` to clear it.
-- `mobile_device_group_ids` (Set of String) Set of Jamf Pro mobile device group IDs. Omit to leave this category as configured outside Terraform; set `[]` to clear it.
-- `mobile_device_ids` (Set of String) Set of Jamf Pro mobile device IDs. Omit to leave this category as configured outside Terraform; set `[]` to clear it.
-- `network_segment_ids` (Set of String) Set of Jamf Pro network segment IDs. Omit to leave this category as configured outside Terraform; set `[]` to clear it.
-- `user_group_ids` (Set of String) Set of Jamf Pro user group IDs. Omit to leave this category as configured outside Terraform; set `[]` to clear it.
-- `user_ids` (Set of String) Set of Jamf Pro user IDs. Omit to leave this category as configured outside Terraform; set `[]` to clear it.
+- `mobile_device_group_ids` (Set of String) Set of Jamf Pro mobile device group IDs (numeric). Omit to leave this category as configured outside Terraform; set `[]` to clear it.
+- `mobile_device_ids` (Set of String) Set of Jamf Pro mobile device IDs (numeric). Omit to leave this category as configured outside Terraform; set `[]` to clear it.
+- `network_segment_ids` (Set of String) Set of Jamf Pro network segment IDs (numeric). Omit to leave this category as configured outside Terraform; set `[]` to clear it.
+- `user_group_ids` (Set of String) Set of Jamf Pro user group IDs (numeric). Omit to leave this category as configured outside Terraform; set `[]` to clear it.
+- `user_ids` (Set of String) Set of Jamf Pro user IDs (numeric). Omit to leave this category as configured outside Terraform; set `[]` to clear it.
 
 
 <a id="nestedatt--scope--limitations"></a>
@@ -153,7 +153,7 @@ Optional:
 
 - `directory_service_or_local_user_names` (Set of String) Set of directory service or local user names. Omit to leave this category as configured outside Terraform; set `[]` to clear it.
 - `directory_service_user_group_names` (Set of String) Set of directory service user group names. Omit to leave this category as configured outside Terraform; set `[]` to clear it.
-- `network_segment_ids` (Set of String) Set of Jamf Pro network segment IDs. Omit to leave this category as configured outside Terraform; set `[]` to clear it.
+- `network_segment_ids` (Set of String) Set of Jamf Pro network segment IDs (numeric). Omit to leave this category as configured outside Terraform; set `[]` to clear it.
 
 
 <a id="nestedatt--scope--targets"></a>
@@ -164,15 +164,15 @@ Optional:
 - `all_computers` (Boolean) Scope to every computer in the tenant. Forbids `computer_ids` / `computer_group_ids` when true. Omit to leave the toggle as configured outside Terraform.
 - `all_jss_users` (Boolean) Scope to every Jamf Pro user in the tenant. Forbids `user_ids` / `user_group_ids` when true. Omit to leave the toggle as configured outside Terraform.
 - `all_mobile_devices` (Boolean) Scope to every mobile device in the tenant. Forbids `mobile_device_ids` / `mobile_device_group_ids` when true. Omit to leave the toggle as configured outside Terraform.
-- `building_ids` (Set of String) Set of Jamf Pro building IDs. Omit to leave this category as configured outside Terraform; set `[]` to clear it.
-- `class_ids` (Set of String) Set of Jamf Pro class IDs. Omit to leave this category as configured outside Terraform; set `[]` to clear it.
-- `computer_group_ids` (Set of String) Set of Jamf Pro computer group IDs. Omit to leave this category as configured outside Terraform; set `[]` to clear it.
-- `computer_ids` (Set of String) Set of Jamf Pro computer IDs. Omit to leave this category as configured outside Terraform; set `[]` to clear it.
-- `department_ids` (Set of String) Set of Jamf Pro department IDs. Omit to leave this category as configured outside Terraform; set `[]` to clear it.
-- `mobile_device_group_ids` (Set of String) Set of Jamf Pro mobile device group IDs. Omit to leave this category as configured outside Terraform; set `[]` to clear it.
-- `mobile_device_ids` (Set of String) Set of Jamf Pro mobile device IDs. Omit to leave this category as configured outside Terraform; set `[]` to clear it.
-- `user_group_ids` (Set of String) Set of Jamf Pro user group IDs. Omit to leave this category as configured outside Terraform; set `[]` to clear it.
-- `user_ids` (Set of String) Set of Jamf Pro user IDs. Omit to leave this category as configured outside Terraform; set `[]` to clear it.
+- `building_ids` (Set of String) Set of Jamf Pro building IDs (numeric). Omit to leave this category as configured outside Terraform; set `[]` to clear it.
+- `class_ids` (Set of String) Set of Jamf Pro class IDs (numeric). Omit to leave this category as configured outside Terraform; set `[]` to clear it.
+- `computer_group_ids` (Set of String) Set of Jamf Pro computer group IDs (numeric). Omit to leave this category as configured outside Terraform; set `[]` to clear it.
+- `computer_ids` (Set of String) Set of Jamf Pro computer IDs (numeric). Omit to leave this category as configured outside Terraform; set `[]` to clear it.
+- `department_ids` (Set of String) Set of Jamf Pro department IDs (numeric). Omit to leave this category as configured outside Terraform; set `[]` to clear it.
+- `mobile_device_group_ids` (Set of String) Set of Jamf Pro mobile device group IDs (numeric). Omit to leave this category as configured outside Terraform; set `[]` to clear it.
+- `mobile_device_ids` (Set of String) Set of Jamf Pro mobile device IDs (numeric). Omit to leave this category as configured outside Terraform; set `[]` to clear it.
+- `user_group_ids` (Set of String) Set of Jamf Pro user group IDs (numeric). Omit to leave this category as configured outside Terraform; set `[]` to clear it.
+- `user_ids` (Set of String) Set of Jamf Pro user IDs (numeric). Omit to leave this category as configured outside Terraform; set `[]` to clear it.
 
 
 

--- a/docs/resources/pro_mac_app_store_app.md
+++ b/docs/resources/pro_mac_app_store_app.md
@@ -158,15 +158,15 @@ Optional:
 
 Optional:
 
-- `building_ids` (Set of String) Set of Jamf Pro building IDs. Omit to leave this category as configured outside Terraform; set `[]` to clear it.
-- `computer_group_ids` (Set of String) Set of Jamf Pro computer group IDs. Omit to leave this category as configured outside Terraform; set `[]` to clear it.
-- `computer_ids` (Set of String) Set of Jamf Pro computer IDs. Omit to leave this category as configured outside Terraform; set `[]` to clear it.
-- `department_ids` (Set of String) Set of Jamf Pro department IDs. Omit to leave this category as configured outside Terraform; set `[]` to clear it.
+- `building_ids` (Set of String) Set of Jamf Pro building IDs (numeric). Omit to leave this category as configured outside Terraform; set `[]` to clear it.
+- `computer_group_ids` (Set of String) Set of Jamf Pro computer group IDs (numeric). Omit to leave this category as configured outside Terraform; set `[]` to clear it.
+- `computer_ids` (Set of String) Set of Jamf Pro computer IDs (numeric). Omit to leave this category as configured outside Terraform; set `[]` to clear it.
+- `department_ids` (Set of String) Set of Jamf Pro department IDs (numeric). Omit to leave this category as configured outside Terraform; set `[]` to clear it.
 - `directory_service_or_local_user_names` (Set of String) Set of directory service or local user names. Omit to leave this category as configured outside Terraform; set `[]` to clear it.
 - `directory_service_user_group_names` (Set of String) Set of directory service user group names. Omit to leave this category as configured outside Terraform; set `[]` to clear it.
-- `network_segment_ids` (Set of String) Set of Jamf Pro network segment IDs. Omit to leave this category as configured outside Terraform; set `[]` to clear it.
-- `user_group_ids` (Set of String) Set of Jamf Pro user group IDs. Omit to leave this category as configured outside Terraform; set `[]` to clear it.
-- `user_ids` (Set of String) Set of Jamf Pro user IDs. Omit to leave this category as configured outside Terraform; set `[]` to clear it.
+- `network_segment_ids` (Set of String) Set of Jamf Pro network segment IDs (numeric). Omit to leave this category as configured outside Terraform; set `[]` to clear it.
+- `user_group_ids` (Set of String) Set of Jamf Pro user group IDs (numeric). Omit to leave this category as configured outside Terraform; set `[]` to clear it.
+- `user_ids` (Set of String) Set of Jamf Pro user IDs (numeric). Omit to leave this category as configured outside Terraform; set `[]` to clear it.
 
 
 <a id="nestedatt--scope--limitations"></a>
@@ -176,7 +176,7 @@ Optional:
 
 - `directory_service_or_local_user_names` (Set of String) Set of directory service or local user names. Omit to leave this category as configured outside Terraform; set `[]` to clear it.
 - `directory_service_user_group_names` (Set of String) Set of directory service user group names. Omit to leave this category as configured outside Terraform; set `[]` to clear it.
-- `network_segment_ids` (Set of String) Set of Jamf Pro network segment IDs. Omit to leave this category as configured outside Terraform; set `[]` to clear it.
+- `network_segment_ids` (Set of String) Set of Jamf Pro network segment IDs (numeric). Omit to leave this category as configured outside Terraform; set `[]` to clear it.
 
 
 <a id="nestedatt--scope--targets"></a>
@@ -186,12 +186,12 @@ Optional:
 
 - `all_computers` (Boolean) Scope to every computer in the tenant. Forbids per-computer / per-group / per-building / per-department targets when true. Omit to leave the toggle as configured outside Terraform.
 - `all_jss_users` (Boolean) Scope to every Jamf Pro user in the tenant. Equivalent to the admin UI's "All Users" toggle. Forbids per-user / per-user-group targets when true. Omit to leave the toggle as configured outside Terraform.
-- `building_ids` (Set of String) Set of Jamf Pro building IDs. Omit to leave this category as configured outside Terraform; set `[]` to clear it.
-- `computer_group_ids` (Set of String) Set of Jamf Pro computer group IDs. Omit to leave this category as configured outside Terraform; set `[]` to clear it.
-- `computer_ids` (Set of String) Set of Jamf Pro computer IDs. Omit to leave this category as configured outside Terraform; set `[]` to clear it.
-- `department_ids` (Set of String) Set of Jamf Pro department IDs. Omit to leave this category as configured outside Terraform; set `[]` to clear it.
-- `user_group_ids` (Set of String) Set of Jamf Pro user group IDs. Omit to leave this category as configured outside Terraform; set `[]` to clear it.
-- `user_ids` (Set of String) Set of Jamf Pro user IDs. Omit to leave this category as configured outside Terraform; set `[]` to clear it.
+- `building_ids` (Set of String) Set of Jamf Pro building IDs (numeric). Omit to leave this category as configured outside Terraform; set `[]` to clear it.
+- `computer_group_ids` (Set of String) Set of Jamf Pro computer group IDs (numeric). Omit to leave this category as configured outside Terraform; set `[]` to clear it.
+- `computer_ids` (Set of String) Set of Jamf Pro computer IDs (numeric). Omit to leave this category as configured outside Terraform; set `[]` to clear it.
+- `department_ids` (Set of String) Set of Jamf Pro department IDs (numeric). Omit to leave this category as configured outside Terraform; set `[]` to clear it.
+- `user_group_ids` (Set of String) Set of Jamf Pro user group IDs (numeric). Omit to leave this category as configured outside Terraform; set `[]` to clear it.
+- `user_ids` (Set of String) Set of Jamf Pro user IDs (numeric). Omit to leave this category as configured outside Terraform; set `[]` to clear it.
 
 
 

--- a/docs/resources/pro_macos_configuration_profile.md
+++ b/docs/resources/pro_macos_configuration_profile.md
@@ -176,16 +176,16 @@ Optional:
 
 Optional:
 
-- `building_ids` (Set of String) Set of Jamf Pro building IDs. Omit to leave this category as configured outside Terraform; set `[]` to clear it.
-- `computer_group_ids` (Set of String) Set of Jamf Pro computer group IDs. Omit to leave this category as configured outside Terraform; set `[]` to clear it.
-- `computer_ids` (Set of String) Set of Jamf Pro computer IDs. Omit to leave this category as configured outside Terraform; set `[]` to clear it.
-- `department_ids` (Set of String) Set of Jamf Pro department IDs. Omit to leave this category as configured outside Terraform; set `[]` to clear it.
+- `building_ids` (Set of String) Set of Jamf Pro building IDs (numeric). Omit to leave this category as configured outside Terraform; set `[]` to clear it.
+- `computer_group_ids` (Set of String) Set of Jamf Pro computer group IDs (numeric). Omit to leave this category as configured outside Terraform; set `[]` to clear it.
+- `computer_ids` (Set of String) Set of Jamf Pro computer IDs (numeric). Omit to leave this category as configured outside Terraform; set `[]` to clear it.
+- `department_ids` (Set of String) Set of Jamf Pro department IDs (numeric). Omit to leave this category as configured outside Terraform; set `[]` to clear it.
 - `directory_service_or_local_user_names` (Set of String) Set of directory service or local user names. Omit to leave this category as configured outside Terraform; set `[]` to clear it.
 - `directory_service_user_group_names` (Set of String) Set of directory service user group names. Omit to leave this category as configured outside Terraform; set `[]` to clear it.
-- `ibeacon_ids` (Set of String) Set of Jamf Pro iBeacon IDs. Omit to leave this category as configured outside Terraform; set `[]` to clear it.
-- `network_segment_ids` (Set of String) Set of Jamf Pro network segment IDs. Omit to leave this category as configured outside Terraform; set `[]` to clear it.
-- `user_group_ids` (Set of String) Set of Jamf Pro user group IDs. Omit to leave this category as configured outside Terraform; set `[]` to clear it.
-- `user_ids` (Set of String) Set of Jamf Pro user IDs. Omit to leave this category as configured outside Terraform; set `[]` to clear it.
+- `ibeacon_ids` (Set of String) Set of Jamf Pro iBeacon IDs (numeric). Omit to leave this category as configured outside Terraform; set `[]` to clear it.
+- `network_segment_ids` (Set of String) Set of Jamf Pro network segment IDs (numeric). Omit to leave this category as configured outside Terraform; set `[]` to clear it.
+- `user_group_ids` (Set of String) Set of Jamf Pro user group IDs (numeric). Omit to leave this category as configured outside Terraform; set `[]` to clear it.
+- `user_ids` (Set of String) Set of Jamf Pro user IDs (numeric). Omit to leave this category as configured outside Terraform; set `[]` to clear it.
 
 
 <a id="nestedatt--scope--limitations"></a>
@@ -195,8 +195,8 @@ Optional:
 
 - `directory_service_or_local_user_names` (Set of String) Set of directory service or local user names. Omit to leave this category as configured outside Terraform; set `[]` to clear it.
 - `directory_service_user_group_names` (Set of String) Set of directory service user group names. Omit to leave this category as configured outside Terraform; set `[]` to clear it.
-- `ibeacon_ids` (Set of String) Set of Jamf Pro iBeacon IDs. Omit to leave this category as configured outside Terraform; set `[]` to clear it.
-- `network_segment_ids` (Set of String) Set of Jamf Pro network segment IDs. Omit to leave this category as configured outside Terraform; set `[]` to clear it.
+- `ibeacon_ids` (Set of String) Set of Jamf Pro iBeacon IDs (numeric). Omit to leave this category as configured outside Terraform; set `[]` to clear it.
+- `network_segment_ids` (Set of String) Set of Jamf Pro network segment IDs (numeric). Omit to leave this category as configured outside Terraform; set `[]` to clear it.
 
 
 <a id="nestedatt--scope--targets"></a>
@@ -206,12 +206,12 @@ Optional:
 
 - `all_computers` (Boolean) Scope to every computer in the tenant. Forbids per-computer / per-group / per-building / per-department targets when true. Omit to leave the toggle as configured outside Terraform.
 - `all_jss_users` (Boolean) Scope to every Jamf Pro user in the tenant. Equivalent to the admin UI's "All Users" toggle. Forbids per-user / per-user-group targets when true. Omit to leave the toggle as configured outside Terraform.
-- `building_ids` (Set of String) Set of Jamf Pro building IDs. Omit to leave this category as configured outside Terraform; set `[]` to clear it.
-- `computer_group_ids` (Set of String) Set of Jamf Pro computer group IDs. Omit to leave this category as configured outside Terraform; set `[]` to clear it.
-- `computer_ids` (Set of String) Set of Jamf Pro computer IDs. Omit to leave this category as configured outside Terraform; set `[]` to clear it.
-- `department_ids` (Set of String) Set of Jamf Pro department IDs. Omit to leave this category as configured outside Terraform; set `[]` to clear it.
-- `user_group_ids` (Set of String) Set of Jamf Pro user group IDs. Omit to leave this category as configured outside Terraform; set `[]` to clear it.
-- `user_ids` (Set of String) Set of Jamf Pro user IDs. Omit to leave this category as configured outside Terraform; set `[]` to clear it.
+- `building_ids` (Set of String) Set of Jamf Pro building IDs (numeric). Omit to leave this category as configured outside Terraform; set `[]` to clear it.
+- `computer_group_ids` (Set of String) Set of Jamf Pro computer group IDs (numeric). Omit to leave this category as configured outside Terraform; set `[]` to clear it.
+- `computer_ids` (Set of String) Set of Jamf Pro computer IDs (numeric). Omit to leave this category as configured outside Terraform; set `[]` to clear it.
+- `department_ids` (Set of String) Set of Jamf Pro department IDs (numeric). Omit to leave this category as configured outside Terraform; set `[]` to clear it.
+- `user_group_ids` (Set of String) Set of Jamf Pro user group IDs (numeric). Omit to leave this category as configured outside Terraform; set `[]` to clear it.
+- `user_ids` (Set of String) Set of Jamf Pro user IDs (numeric). Omit to leave this category as configured outside Terraform; set `[]` to clear it.
 
 
 

--- a/docs/resources/pro_mobile_device_app.md
+++ b/docs/resources/pro_mobile_device_app.md
@@ -197,15 +197,15 @@ Optional:
 
 Optional:
 
-- `building_ids` (Set of String) Set of Jamf Pro building IDs. Omit to leave this category as configured outside Terraform; set `[]` to clear it.
-- `department_ids` (Set of String) Set of Jamf Pro department IDs. Omit to leave this category as configured outside Terraform; set `[]` to clear it.
+- `building_ids` (Set of String) Set of Jamf Pro building IDs (numeric). Omit to leave this category as configured outside Terraform; set `[]` to clear it.
+- `department_ids` (Set of String) Set of Jamf Pro department IDs (numeric). Omit to leave this category as configured outside Terraform; set `[]` to clear it.
 - `directory_service_or_local_user_names` (Set of String) Set of directory service or local user names. Omit to leave this category as configured outside Terraform; set `[]` to clear it.
 - `directory_service_user_group_names` (Set of String) Set of directory service user group names. Omit to leave this category as configured outside Terraform; set `[]` to clear it.
-- `mobile_device_group_ids` (Set of String) Set of Jamf Pro mobile device group IDs. Omit to leave this category as configured outside Terraform; set `[]` to clear it.
-- `mobile_device_ids` (Set of String) Set of Jamf Pro mobile device IDs. Omit to leave this category as configured outside Terraform; set `[]` to clear it.
-- `network_segment_ids` (Set of String) Set of Jamf Pro network segment IDs. Omit to leave this category as configured outside Terraform; set `[]` to clear it.
-- `user_group_ids` (Set of String) Set of Jamf Pro user group IDs. Omit to leave this category as configured outside Terraform; set `[]` to clear it.
-- `user_ids` (Set of String) Set of Jamf Pro user IDs. Omit to leave this category as configured outside Terraform; set `[]` to clear it.
+- `mobile_device_group_ids` (Set of String) Set of Jamf Pro mobile device group IDs (numeric). Omit to leave this category as configured outside Terraform; set `[]` to clear it.
+- `mobile_device_ids` (Set of String) Set of Jamf Pro mobile device IDs (numeric). Omit to leave this category as configured outside Terraform; set `[]` to clear it.
+- `network_segment_ids` (Set of String) Set of Jamf Pro network segment IDs (numeric). Omit to leave this category as configured outside Terraform; set `[]` to clear it.
+- `user_group_ids` (Set of String) Set of Jamf Pro user group IDs (numeric). Omit to leave this category as configured outside Terraform; set `[]` to clear it.
+- `user_ids` (Set of String) Set of Jamf Pro user IDs (numeric). Omit to leave this category as configured outside Terraform; set `[]` to clear it.
 
 
 <a id="nestedatt--scope--limitations"></a>
@@ -215,7 +215,7 @@ Optional:
 
 - `directory_service_or_local_user_names` (Set of String) Set of directory service or local user names. Omit to leave this category as configured outside Terraform; set `[]` to clear it.
 - `directory_service_user_group_names` (Set of String) Set of directory service user group names. Omit to leave this category as configured outside Terraform; set `[]` to clear it.
-- `network_segment_ids` (Set of String) Set of Jamf Pro network segment IDs. Omit to leave this category as configured outside Terraform; set `[]` to clear it.
+- `network_segment_ids` (Set of String) Set of Jamf Pro network segment IDs (numeric). Omit to leave this category as configured outside Terraform; set `[]` to clear it.
 
 
 <a id="nestedatt--scope--targets"></a>
@@ -225,12 +225,12 @@ Optional:
 
 - `all_jss_users` (Boolean) Scope to every Jamf Pro user in the tenant. Equivalent to the admin UI's "All Users" toggle. Forbids per-user / per-user-group targets when true. Omit to leave the toggle as configured outside Terraform.
 - `all_mobile_devices` (Boolean) Scope to every mobile device in the tenant. Forbids per-device / per-group / per-building / per-department targets when true. Omit to leave the toggle as configured outside Terraform.
-- `building_ids` (Set of String) Set of Jamf Pro building IDs. Omit to leave this category as configured outside Terraform; set `[]` to clear it.
-- `department_ids` (Set of String) Set of Jamf Pro department IDs. Omit to leave this category as configured outside Terraform; set `[]` to clear it.
-- `mobile_device_group_ids` (Set of String) Set of Jamf Pro mobile device group IDs. Omit to leave this category as configured outside Terraform; set `[]` to clear it.
-- `mobile_device_ids` (Set of String) Set of Jamf Pro mobile device IDs. Omit to leave this category as configured outside Terraform; set `[]` to clear it.
-- `user_group_ids` (Set of String) Set of Jamf Pro user group IDs. Omit to leave this category as configured outside Terraform; set `[]` to clear it.
-- `user_ids` (Set of String) Set of Jamf Pro user IDs. Omit to leave this category as configured outside Terraform; set `[]` to clear it.
+- `building_ids` (Set of String) Set of Jamf Pro building IDs (numeric). Omit to leave this category as configured outside Terraform; set `[]` to clear it.
+- `department_ids` (Set of String) Set of Jamf Pro department IDs (numeric). Omit to leave this category as configured outside Terraform; set `[]` to clear it.
+- `mobile_device_group_ids` (Set of String) Set of Jamf Pro mobile device group IDs (numeric). Omit to leave this category as configured outside Terraform; set `[]` to clear it.
+- `mobile_device_ids` (Set of String) Set of Jamf Pro mobile device IDs (numeric). Omit to leave this category as configured outside Terraform; set `[]` to clear it.
+- `user_group_ids` (Set of String) Set of Jamf Pro user group IDs (numeric). Omit to leave this category as configured outside Terraform; set `[]` to clear it.
+- `user_ids` (Set of String) Set of Jamf Pro user IDs (numeric). Omit to leave this category as configured outside Terraform; set `[]` to clear it.
 
 
 

--- a/docs/resources/pro_mobile_device_configuration_profile.md
+++ b/docs/resources/pro_mobile_device_configuration_profile.md
@@ -162,16 +162,16 @@ Optional:
 
 Optional:
 
-- `building_ids` (Set of String) Set of Jamf Pro building IDs. Omit to leave this category as configured outside Terraform; set `[]` to clear it.
-- `department_ids` (Set of String) Set of Jamf Pro department IDs. Omit to leave this category as configured outside Terraform; set `[]` to clear it.
+- `building_ids` (Set of String) Set of Jamf Pro building IDs (numeric). Omit to leave this category as configured outside Terraform; set `[]` to clear it.
+- `department_ids` (Set of String) Set of Jamf Pro department IDs (numeric). Omit to leave this category as configured outside Terraform; set `[]` to clear it.
 - `directory_service_or_local_user_names` (Set of String) Set of directory service or local user names. Omit to leave this category as configured outside Terraform; set `[]` to clear it.
 - `directory_service_user_group_names` (Set of String) Set of directory service user group names. Omit to leave this category as configured outside Terraform; set `[]` to clear it.
-- `ibeacon_ids` (Set of String) Set of Jamf Pro iBeacon IDs. Omit to leave this category as configured outside Terraform; set `[]` to clear it.
-- `mobile_device_group_ids` (Set of String) Set of Jamf Pro mobile device group IDs. Omit to leave this category as configured outside Terraform; set `[]` to clear it.
-- `mobile_device_ids` (Set of String) Set of Jamf Pro mobile device IDs. Omit to leave this category as configured outside Terraform; set `[]` to clear it.
-- `network_segment_ids` (Set of String) Set of Jamf Pro network segment IDs. Omit to leave this category as configured outside Terraform; set `[]` to clear it.
-- `user_group_ids` (Set of String) Set of Jamf Pro user group IDs. Omit to leave this category as configured outside Terraform; set `[]` to clear it.
-- `user_ids` (Set of String) Set of Jamf Pro user IDs. Omit to leave this category as configured outside Terraform; set `[]` to clear it.
+- `ibeacon_ids` (Set of String) Set of Jamf Pro iBeacon IDs (numeric). Omit to leave this category as configured outside Terraform; set `[]` to clear it.
+- `mobile_device_group_ids` (Set of String) Set of Jamf Pro mobile device group IDs (numeric). Omit to leave this category as configured outside Terraform; set `[]` to clear it.
+- `mobile_device_ids` (Set of String) Set of Jamf Pro mobile device IDs (numeric). Omit to leave this category as configured outside Terraform; set `[]` to clear it.
+- `network_segment_ids` (Set of String) Set of Jamf Pro network segment IDs (numeric). Omit to leave this category as configured outside Terraform; set `[]` to clear it.
+- `user_group_ids` (Set of String) Set of Jamf Pro user group IDs (numeric). Omit to leave this category as configured outside Terraform; set `[]` to clear it.
+- `user_ids` (Set of String) Set of Jamf Pro user IDs (numeric). Omit to leave this category as configured outside Terraform; set `[]` to clear it.
 
 
 <a id="nestedatt--scope--limitations"></a>
@@ -181,8 +181,8 @@ Optional:
 
 - `directory_service_or_local_user_names` (Set of String) Set of directory service or local user names. Omit to leave this category as configured outside Terraform; set `[]` to clear it.
 - `directory_service_user_group_names` (Set of String) Set of directory service user group names. Omit to leave this category as configured outside Terraform; set `[]` to clear it.
-- `ibeacon_ids` (Set of String) Set of Jamf Pro iBeacon IDs. Omit to leave this category as configured outside Terraform; set `[]` to clear it.
-- `network_segment_ids` (Set of String) Set of Jamf Pro network segment IDs. Omit to leave this category as configured outside Terraform; set `[]` to clear it.
+- `ibeacon_ids` (Set of String) Set of Jamf Pro iBeacon IDs (numeric). Omit to leave this category as configured outside Terraform; set `[]` to clear it.
+- `network_segment_ids` (Set of String) Set of Jamf Pro network segment IDs (numeric). Omit to leave this category as configured outside Terraform; set `[]` to clear it.
 
 
 <a id="nestedatt--scope--targets"></a>
@@ -192,12 +192,12 @@ Optional:
 
 - `all_jss_users` (Boolean) Scope to every Jamf Pro user in the tenant. Equivalent to the admin UI's "All Users" toggle. Forbids per-user / per-user-group targets when true. Omit to leave the toggle as configured outside Terraform.
 - `all_mobile_devices` (Boolean) Scope to every mobile device in the tenant. Forbids per-device / per-group / per-building / per-department targets when true. Omit to leave the toggle as configured outside Terraform.
-- `building_ids` (Set of String) Set of Jamf Pro building IDs. Omit to leave this category as configured outside Terraform; set `[]` to clear it.
-- `department_ids` (Set of String) Set of Jamf Pro department IDs. Omit to leave this category as configured outside Terraform; set `[]` to clear it.
-- `mobile_device_group_ids` (Set of String) Set of Jamf Pro mobile device group IDs. Omit to leave this category as configured outside Terraform; set `[]` to clear it.
-- `mobile_device_ids` (Set of String) Set of Jamf Pro mobile device IDs. Omit to leave this category as configured outside Terraform; set `[]` to clear it.
-- `user_group_ids` (Set of String) Set of Jamf Pro user group IDs. Omit to leave this category as configured outside Terraform; set `[]` to clear it.
-- `user_ids` (Set of String) Set of Jamf Pro user IDs. Omit to leave this category as configured outside Terraform; set `[]` to clear it.
+- `building_ids` (Set of String) Set of Jamf Pro building IDs (numeric). Omit to leave this category as configured outside Terraform; set `[]` to clear it.
+- `department_ids` (Set of String) Set of Jamf Pro department IDs (numeric). Omit to leave this category as configured outside Terraform; set `[]` to clear it.
+- `mobile_device_group_ids` (Set of String) Set of Jamf Pro mobile device group IDs (numeric). Omit to leave this category as configured outside Terraform; set `[]` to clear it.
+- `mobile_device_ids` (Set of String) Set of Jamf Pro mobile device IDs (numeric). Omit to leave this category as configured outside Terraform; set `[]` to clear it.
+- `user_group_ids` (Set of String) Set of Jamf Pro user group IDs (numeric). Omit to leave this category as configured outside Terraform; set `[]` to clear it.
+- `user_ids` (Set of String) Set of Jamf Pro user IDs (numeric). Omit to leave this category as configured outside Terraform; set `[]` to clear it.
 
 
 

--- a/docs/resources/pro_patch_policy.md
+++ b/docs/resources/pro_patch_policy.md
@@ -177,12 +177,12 @@ Optional:
 
 Optional:
 
-- `building_ids` (Set of String) Set of Jamf Pro building IDs. Omit to leave this category as configured outside Terraform; set `[]` to clear it.
-- `computer_group_ids` (Set of String) Set of Jamf Pro computer group IDs. Omit to leave this category as configured outside Terraform; set `[]` to clear it.
-- `computer_ids` (Set of String) Set of Jamf Pro computer IDs. Omit to leave this category as configured outside Terraform; set `[]` to clear it.
-- `department_ids` (Set of String) Set of Jamf Pro department IDs. Omit to leave this category as configured outside Terraform; set `[]` to clear it.
-- `ibeacon_ids` (Set of String) Set of Jamf Pro iBeacon IDs. Omit to leave this category as configured outside Terraform; set `[]` to clear it.
-- `network_segment_ids` (Set of String) Set of Jamf Pro network segment IDs. Omit to leave this category as configured outside Terraform; set `[]` to clear it.
+- `building_ids` (Set of String) Set of Jamf Pro building IDs (numeric). Omit to leave this category as configured outside Terraform; set `[]` to clear it.
+- `computer_group_ids` (Set of String) Set of Jamf Pro computer group IDs (numeric). Omit to leave this category as configured outside Terraform; set `[]` to clear it.
+- `computer_ids` (Set of String) Set of Jamf Pro computer IDs (numeric). Omit to leave this category as configured outside Terraform; set `[]` to clear it.
+- `department_ids` (Set of String) Set of Jamf Pro department IDs (numeric). Omit to leave this category as configured outside Terraform; set `[]` to clear it.
+- `ibeacon_ids` (Set of String) Set of Jamf Pro iBeacon IDs (numeric). Omit to leave this category as configured outside Terraform; set `[]` to clear it.
+- `network_segment_ids` (Set of String) Set of Jamf Pro network segment IDs (numeric). Omit to leave this category as configured outside Terraform; set `[]` to clear it.
 
 
 <a id="nestedatt--scope--limitations"></a>
@@ -190,8 +190,8 @@ Optional:
 
 Optional:
 
-- `ibeacon_ids` (Set of String) Set of Jamf Pro iBeacon IDs. Omit to leave this category as configured outside Terraform; set `[]` to clear it.
-- `network_segment_ids` (Set of String) Set of Jamf Pro network segment IDs. Omit to leave this category as configured outside Terraform; set `[]` to clear it.
+- `ibeacon_ids` (Set of String) Set of Jamf Pro iBeacon IDs (numeric). Omit to leave this category as configured outside Terraform; set `[]` to clear it.
+- `network_segment_ids` (Set of String) Set of Jamf Pro network segment IDs (numeric). Omit to leave this category as configured outside Terraform; set `[]` to clear it.
 
 
 <a id="nestedatt--scope--targets"></a>
@@ -200,10 +200,10 @@ Optional:
 Optional:
 
 - `all_computers` (Boolean) Scope to every computer in the tenant. Forbids per-computer / per-group / per-building / per-department targets when true. Omit to leave the toggle as configured outside Terraform.
-- `building_ids` (Set of String) Set of Jamf Pro building IDs. Omit to leave this category as configured outside Terraform; set `[]` to clear it.
-- `computer_group_ids` (Set of String) Set of Jamf Pro computer group IDs. Omit to leave this category as configured outside Terraform; set `[]` to clear it.
-- `computer_ids` (Set of String) Set of Jamf Pro computer IDs. Omit to leave this category as configured outside Terraform; set `[]` to clear it.
-- `department_ids` (Set of String) Set of Jamf Pro department IDs. Omit to leave this category as configured outside Terraform; set `[]` to clear it.
+- `building_ids` (Set of String) Set of Jamf Pro building IDs (numeric). Omit to leave this category as configured outside Terraform; set `[]` to clear it.
+- `computer_group_ids` (Set of String) Set of Jamf Pro computer group IDs (numeric). Omit to leave this category as configured outside Terraform; set `[]` to clear it.
+- `computer_ids` (Set of String) Set of Jamf Pro computer IDs (numeric). Omit to leave this category as configured outside Terraform; set `[]` to clear it.
+- `department_ids` (Set of String) Set of Jamf Pro department IDs (numeric). Omit to leave this category as configured outside Terraform; set `[]` to clear it.
 
 
 

--- a/docs/resources/pro_policy.md
+++ b/docs/resources/pro_policy.md
@@ -470,16 +470,16 @@ Optional:
 
 Optional:
 
-- `building_ids` (Set of String) Set of Jamf Pro building IDs. Omit to leave this category as configured outside Terraform; set `[]` to clear it.
-- `computer_group_ids` (Set of String) Set of Jamf Pro computer group IDs. Omit to leave this category as configured outside Terraform; set `[]` to clear it.
-- `computer_ids` (Set of String) Set of Jamf Pro computer IDs. Omit to leave this category as configured outside Terraform; set `[]` to clear it.
-- `department_ids` (Set of String) Set of Jamf Pro department IDs. Omit to leave this category as configured outside Terraform; set `[]` to clear it.
+- `building_ids` (Set of String) Set of Jamf Pro building IDs (numeric). Omit to leave this category as configured outside Terraform; set `[]` to clear it.
+- `computer_group_ids` (Set of String) Set of Jamf Pro computer group IDs (numeric). Omit to leave this category as configured outside Terraform; set `[]` to clear it.
+- `computer_ids` (Set of String) Set of Jamf Pro computer IDs (numeric). Omit to leave this category as configured outside Terraform; set `[]` to clear it.
+- `department_ids` (Set of String) Set of Jamf Pro department IDs (numeric). Omit to leave this category as configured outside Terraform; set `[]` to clear it.
 - `directory_service_or_local_user_names` (Set of String) Set of directory service or local user names. Omit to leave this category as configured outside Terraform; set `[]` to clear it.
 - `directory_service_user_group_names` (Set of String) Set of directory service user group names. Omit to leave this category as configured outside Terraform; set `[]` to clear it.
-- `ibeacon_ids` (Set of String) Set of Jamf Pro iBeacon IDs. Omit to leave this category as configured outside Terraform; set `[]` to clear it.
-- `network_segment_ids` (Set of String) Set of Jamf Pro network segment IDs. Omit to leave this category as configured outside Terraform; set `[]` to clear it.
-- `user_group_ids` (Set of String) Set of Jamf Pro user group IDs. Omit to leave this category as configured outside Terraform; set `[]` to clear it.
-- `user_ids` (Set of String) Set of Jamf Pro user IDs. Omit to leave this category as configured outside Terraform; set `[]` to clear it.
+- `ibeacon_ids` (Set of String) Set of Jamf Pro iBeacon IDs (numeric). Omit to leave this category as configured outside Terraform; set `[]` to clear it.
+- `network_segment_ids` (Set of String) Set of Jamf Pro network segment IDs (numeric). Omit to leave this category as configured outside Terraform; set `[]` to clear it.
+- `user_group_ids` (Set of String) Set of Jamf Pro user group IDs (numeric). Omit to leave this category as configured outside Terraform; set `[]` to clear it.
+- `user_ids` (Set of String) Set of Jamf Pro user IDs (numeric). Omit to leave this category as configured outside Terraform; set `[]` to clear it.
 
 
 <a id="nestedatt--scope--limitations"></a>
@@ -489,8 +489,8 @@ Optional:
 
 - `directory_service_or_local_user_names` (Set of String) Set of directory service or local user names. Omit to leave this category as configured outside Terraform; set `[]` to clear it.
 - `directory_service_user_group_names` (Set of String) Set of directory service user group names. Omit to leave this category as configured outside Terraform; set `[]` to clear it.
-- `ibeacon_ids` (Set of String) Set of Jamf Pro iBeacon IDs. Omit to leave this category as configured outside Terraform; set `[]` to clear it.
-- `network_segment_ids` (Set of String) Set of Jamf Pro network segment IDs. Omit to leave this category as configured outside Terraform; set `[]` to clear it.
+- `ibeacon_ids` (Set of String) Set of Jamf Pro iBeacon IDs (numeric). Omit to leave this category as configured outside Terraform; set `[]` to clear it.
+- `network_segment_ids` (Set of String) Set of Jamf Pro network segment IDs (numeric). Omit to leave this category as configured outside Terraform; set `[]` to clear it.
 
 
 <a id="nestedatt--scope--targets"></a>
@@ -500,12 +500,12 @@ Optional:
 
 - `all_computers` (Boolean) Scope to every computer in the tenant. Forbids per-computer / per-group / per-building / per-department targets when true. Omit to leave the toggle as configured outside Terraform.
 - `all_jss_users` (Boolean) Scope to every Jamf Pro user in the tenant. Equivalent to the admin UI's "All Users" toggle. Forbids per-user / per-user-group targets when true. Omit to leave the toggle as configured outside Terraform.
-- `building_ids` (Set of String) Set of Jamf Pro building IDs. Omit to leave this category as configured outside Terraform; set `[]` to clear it.
-- `computer_group_ids` (Set of String) Set of Jamf Pro computer group IDs. Omit to leave this category as configured outside Terraform; set `[]` to clear it.
-- `computer_ids` (Set of String) Set of Jamf Pro computer IDs. Omit to leave this category as configured outside Terraform; set `[]` to clear it.
-- `department_ids` (Set of String) Set of Jamf Pro department IDs. Omit to leave this category as configured outside Terraform; set `[]` to clear it.
-- `user_group_ids` (Set of String) Set of Jamf Pro user group IDs. Omit to leave this category as configured outside Terraform; set `[]` to clear it.
-- `user_ids` (Set of String) Set of Jamf Pro user IDs. Omit to leave this category as configured outside Terraform; set `[]` to clear it.
+- `building_ids` (Set of String) Set of Jamf Pro building IDs (numeric). Omit to leave this category as configured outside Terraform; set `[]` to clear it.
+- `computer_group_ids` (Set of String) Set of Jamf Pro computer group IDs (numeric). Omit to leave this category as configured outside Terraform; set `[]` to clear it.
+- `computer_ids` (Set of String) Set of Jamf Pro computer IDs (numeric). Omit to leave this category as configured outside Terraform; set `[]` to clear it.
+- `department_ids` (Set of String) Set of Jamf Pro department IDs (numeric). Omit to leave this category as configured outside Terraform; set `[]` to clear it.
+- `user_group_ids` (Set of String) Set of Jamf Pro user group IDs (numeric). Omit to leave this category as configured outside Terraform; set `[]` to clear it.
+- `user_ids` (Set of String) Set of Jamf Pro user IDs (numeric). Omit to leave this category as configured outside Terraform; set `[]` to clear it.
 
 
 

--- a/docs/resources/pro_restricted_software.md
+++ b/docs/resources/pro_restricted_software.md
@@ -140,10 +140,10 @@ Optional:
 
 Optional:
 
-- `building_ids` (Set of String) Set of Jamf Pro building IDs. Omit to leave this category as configured outside Terraform; set `[]` to clear it.
-- `computer_group_ids` (Set of String) Set of Jamf Pro computer group IDs. Omit to leave this category as configured outside Terraform; set `[]` to clear it.
-- `computer_ids` (Set of String) Set of Jamf Pro computer IDs. Omit to leave this category as configured outside Terraform; set `[]` to clear it.
-- `department_ids` (Set of String) Set of Jamf Pro department IDs. Omit to leave this category as configured outside Terraform; set `[]` to clear it.
+- `building_ids` (Set of String) Set of Jamf Pro building IDs (numeric). Omit to leave this category as configured outside Terraform; set `[]` to clear it.
+- `computer_group_ids` (Set of String) Set of Jamf Pro computer group IDs (numeric). Omit to leave this category as configured outside Terraform; set `[]` to clear it.
+- `computer_ids` (Set of String) Set of Jamf Pro computer IDs (numeric). Omit to leave this category as configured outside Terraform; set `[]` to clear it.
+- `department_ids` (Set of String) Set of Jamf Pro department IDs (numeric). Omit to leave this category as configured outside Terraform; set `[]` to clear it.
 - `directory_service_or_local_user_names` (Set of String) Set of directory service or local user names. Omit to leave this category as configured outside Terraform; set `[]` to clear it.
 
 
@@ -153,10 +153,10 @@ Optional:
 Optional:
 
 - `all_computers` (Boolean) Scope to every computer in the tenant. Forbids per-computer / per-group / per-building / per-department targets when true. Omit to leave the toggle as configured outside Terraform.
-- `building_ids` (Set of String) Set of Jamf Pro building IDs. Omit to leave this category as configured outside Terraform; set `[]` to clear it.
-- `computer_group_ids` (Set of String) Set of Jamf Pro computer group IDs. Omit to leave this category as configured outside Terraform; set `[]` to clear it.
-- `computer_ids` (Set of String) Set of Jamf Pro computer IDs. Omit to leave this category as configured outside Terraform; set `[]` to clear it.
-- `department_ids` (Set of String) Set of Jamf Pro department IDs. Omit to leave this category as configured outside Terraform; set `[]` to clear it.
+- `building_ids` (Set of String) Set of Jamf Pro building IDs (numeric). Omit to leave this category as configured outside Terraform; set `[]` to clear it.
+- `computer_group_ids` (Set of String) Set of Jamf Pro computer group IDs (numeric). Omit to leave this category as configured outside Terraform; set `[]` to clear it.
+- `computer_ids` (Set of String) Set of Jamf Pro computer IDs (numeric). Omit to leave this category as configured outside Terraform; set `[]` to clear it.
+- `department_ids` (Set of String) Set of Jamf Pro department IDs (numeric). Omit to leave this category as configured outside Terraform; set `[]` to clear it.
 
 
 

--- a/docs/resources/pro_vpp_assignment.md
+++ b/docs/resources/pro_vpp_assignment.md
@@ -113,8 +113,8 @@ Optional:
 Optional:
 
 - `directory_service_user_group_names` (Set of String) Set of directory service (LDAP) user group names. Omit to leave this category as configured outside Terraform; set `[]` to clear it.
-- `jss_user_group_ids` (Set of String) Set of Jamf Pro user group IDs. Omit to leave this category as configured outside Terraform; set `[]` to clear it.
-- `jss_user_ids` (Set of String) Set of Jamf Pro user IDs. Omit to leave this category as configured outside Terraform; set `[]` to clear it.
+- `jss_user_group_ids` (Set of String) Set of Jamf Pro user group IDs (numeric). Omit to leave this category as configured outside Terraform; set `[]` to clear it.
+- `jss_user_ids` (Set of String) Set of Jamf Pro user IDs (numeric). Omit to leave this category as configured outside Terraform; set `[]` to clear it.
 
 
 <a id="nestedatt--scope--limitations"></a>
@@ -131,8 +131,8 @@ Optional:
 Optional:
 
 - `all_jss_users` (Boolean) Target all Jamf Pro users. Conflicts with `jss_user_ids` / `jss_user_group_ids`. Omit to leave the toggle as configured outside Terraform.
-- `jss_user_group_ids` (Set of String) Set of Jamf Pro user group IDs. Omit to leave this category as configured outside Terraform; set `[]` to clear it.
-- `jss_user_ids` (Set of String) Set of Jamf Pro user IDs. Omit to leave this category as configured outside Terraform; set `[]` to clear it.
+- `jss_user_group_ids` (Set of String) Set of Jamf Pro user group IDs (numeric). Omit to leave this category as configured outside Terraform; set `[]` to clear it.
+- `jss_user_ids` (Set of String) Set of Jamf Pro user IDs (numeric). Omit to leave this category as configured outside Terraform; set `[]` to clear it.
 
 
 

--- a/docs/resources/pro_vpp_invitation.md
+++ b/docs/resources/pro_vpp_invitation.md
@@ -124,8 +124,8 @@ Optional:
 Optional:
 
 - `directory_service_user_group_names` (Set of String) Set of directory service (LDAP) user group names. Omit to leave this category as configured outside Terraform; set `[]` to clear it.
-- `jss_user_group_ids` (Set of String) Set of Jamf Pro user group IDs. Omit to leave this category as configured outside Terraform; set `[]` to clear it.
-- `jss_user_ids` (Set of String) Set of Jamf Pro user IDs. Omit to leave this category as configured outside Terraform; set `[]` to clear it.
+- `jss_user_group_ids` (Set of String) Set of Jamf Pro user group IDs (numeric). Omit to leave this category as configured outside Terraform; set `[]` to clear it.
+- `jss_user_ids` (Set of String) Set of Jamf Pro user IDs (numeric). Omit to leave this category as configured outside Terraform; set `[]` to clear it.
 
 
 <a id="nestedatt--scope--limitations"></a>
@@ -142,8 +142,8 @@ Optional:
 Optional:
 
 - `all_jss_users` (Boolean) Target all Jamf Pro users. Conflicts with `jss_user_ids` / `jss_user_group_ids`. Omit to leave the toggle as configured outside Terraform.
-- `jss_user_group_ids` (Set of String) Set of Jamf Pro user group IDs. Omit to leave this category as configured outside Terraform; set `[]` to clear it.
-- `jss_user_ids` (Set of String) Set of Jamf Pro user IDs. Omit to leave this category as configured outside Terraform; set `[]` to clear it.
+- `jss_user_group_ids` (Set of String) Set of Jamf Pro user group IDs (numeric). Omit to leave this category as configured outside Terraform; set `[]` to clear it.
+- `jss_user_ids` (Set of String) Set of Jamf Pro user IDs (numeric). Omit to leave this category as configured outside Terraform; set `[]` to clear it.
 
 
 

--- a/internal/common/scope/builders.go
+++ b/internal/common/scope/builders.go
@@ -5,6 +5,7 @@ package scope
 
 import (
 	"context"
+	"fmt"
 	"strconv"
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
@@ -65,8 +66,8 @@ func BuildIDSlice[T any](
 		id, err := strconv.Atoi(raw)
 		if err != nil {
 			diags.AddError(
-				"Invalid ID in set",
-				err.Error(),
+				"Invalid Jamf Pro object ID",
+				fmt.Sprintf("%q is not a valid ID. Jamf Pro object IDs are numeric (e.g. \"42\"); this looks like a UUID or other non-numeric handle. When referencing another resource, use its `.id` attribute, which is the numeric ID.", raw),
 			)
 			parseFailed = true
 			continue

--- a/internal/common/scope/schema.go
+++ b/internal/common/scope/schema.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
@@ -35,7 +36,10 @@ func IDSetAttribute(attrLabel string) schema.SetAttribute {
 	return schema.SetAttribute{
 		ElementType:         types.StringType,
 		Optional:            true,
-		MarkdownDescription: fmt.Sprintf("Set of Jamf Pro %s IDs. Omit to leave this category as configured outside Terraform; set `[]` to clear it.", attrLabel),
+		MarkdownDescription: fmt.Sprintf("Set of Jamf Pro %s IDs (numeric). Omit to leave this category as configured outside Terraform; set `[]` to clear it.", attrLabel),
+		Validators: []validator.Set{
+			NumericIDs(),
+		},
 	}
 }
 

--- a/internal/common/scope/validators.go
+++ b/internal/common/scope/validators.go
@@ -6,6 +6,7 @@ package scope
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -86,6 +87,63 @@ func (v allFlagConflictsWithValidator) ValidateBool(ctx context.Context, req val
 				p,
 				"Conflicts with all-flag",
 				fmt.Sprintf("%s must be null or empty when %s is true.", p, req.Path),
+			)
+		}
+	}
+}
+
+// NumericIDs is the element validator for the ID-bearing scope target
+// categories (IDSetAttribute). Every Jamf Pro object referenced by ID —
+// computers, groups, buildings, departments, users, network segments, iBeacons
+// — carries a numeric integer identifier. This catches the common footgun of
+// passing a UUID (or any other non-numeric handle) where a numeric ID is
+// required: without it the mistake surfaces only during apply as an opaque
+// `strconv.Atoi: parsing "…": invalid syntax` from the input builder, with no
+// attribute path. Here it is reported at plan time, pinned to the offending
+// element, with actionable guidance.
+//
+// The parse mirrors the input builder (BuildIDSlice → strconv.Atoi) exactly, so
+// the validator rejects precisely the values that would fail the write and
+// nothing more — no false rejects. Null/unknown elements are deferred per
+// STYLE_GUIDE §Config-time validators, so IDs sourced from other resources or
+// variables are not flagged before they resolve.
+func NumericIDs() validator.Set {
+	return numericIDsValidator{}
+}
+
+// numericIDsValidator is the concrete validator returned by NumericIDs.
+type numericIDsValidator struct{}
+
+var _ validator.Set = numericIDsValidator{}
+
+// Description returns a plain-text description of the validator's rule.
+func (numericIDsValidator) Description(_ context.Context) string {
+	return "every element must be a numeric Jamf Pro object ID"
+}
+
+// MarkdownDescription returns the markdown description of the validator's rule.
+func (v numericIDsValidator) MarkdownDescription(ctx context.Context) string {
+	return v.Description(ctx)
+}
+
+// ValidateSet implements validator.Set. It defers on a null/unknown set and on
+// null/unknown elements, and records one error per non-numeric element, pinned
+// to that element's path.
+func (numericIDsValidator) ValidateSet(_ context.Context, req validator.SetRequest, resp *validator.SetResponse) {
+	if req.ConfigValue.IsNull() || req.ConfigValue.IsUnknown() {
+		return
+	}
+	for _, elem := range req.ConfigValue.Elements() {
+		str, ok := elem.(types.String)
+		if !ok || str.IsNull() || str.IsUnknown() {
+			continue
+		}
+		raw := str.ValueString()
+		if _, err := strconv.Atoi(raw); err != nil {
+			resp.Diagnostics.AddAttributeError(
+				req.Path.AtSetValue(elem),
+				"Invalid Jamf Pro object ID",
+				fmt.Sprintf("%q is not a valid ID. Jamf Pro object IDs are numeric (e.g. \"42\"); this looks like a UUID or other non-numeric handle. When referencing another resource, use its `.id` attribute, which is the numeric ID.", raw),
 			)
 		}
 	}

--- a/internal/common/scope/validators_test.go
+++ b/internal/common/scope/validators_test.go
@@ -169,3 +169,84 @@ func TestAllFlagConflictsWith_Describer(t *testing.T) {
 		t.Error("expected non-empty MarkdownDescription")
 	}
 }
+
+// runNumericIDs drives NumericIDs against a synthetic Set<String> request. Pass
+// nil for a null set; an empty slice for the zero-element set.
+func runNumericIDs(t *testing.T, values []string) validator.SetResponse {
+	t.Helper()
+	set, diags := types.SetValueFrom(context.Background(), types.StringType, values)
+	if diags.HasError() {
+		t.Fatalf("building set value: %v", diags)
+	}
+	if values == nil {
+		set = types.SetNull(types.StringType)
+	}
+	req := validator.SetRequest{
+		Path:        path.Root("computer_ids"),
+		ConfigValue: set,
+	}
+	var resp validator.SetResponse
+	NumericIDs().ValidateSet(context.Background(), req, &resp)
+	return resp
+}
+
+func TestNumericIDs_AllNumeric_NoError(t *testing.T) {
+	resp := runNumericIDs(t, []string{"1", "42", "1000"})
+	if resp.Diagnostics.HasError() {
+		t.Errorf("expected no diagnostics, got: %v", resp.Diagnostics)
+	}
+}
+
+func TestNumericIDs_NullSet_NoError(t *testing.T) {
+	resp := runNumericIDs(t, nil)
+	if resp.Diagnostics.HasError() {
+		t.Errorf("expected no diagnostics for null set, got: %v", resp.Diagnostics)
+	}
+}
+
+func TestNumericIDs_EmptySet_NoError(t *testing.T) {
+	resp := runNumericIDs(t, []string{})
+	if resp.Diagnostics.HasError() {
+		t.Errorf("expected no diagnostics for empty set, got: %v", resp.Diagnostics)
+	}
+}
+
+func TestNumericIDs_UnknownSet_NoError(t *testing.T) {
+	req := validator.SetRequest{
+		Path:        path.Root("computer_ids"),
+		ConfigValue: types.SetUnknown(types.StringType),
+	}
+	var resp validator.SetResponse
+	NumericIDs().ValidateSet(context.Background(), req, &resp)
+	if resp.Diagnostics.HasError() {
+		t.Errorf("expected no diagnostics for unknown set, got: %v", resp.Diagnostics)
+	}
+}
+
+func TestNumericIDs_UUID_OneError(t *testing.T) {
+	resp := runNumericIDs(t, []string{"f04ba6b4-943d-43d0-be87-d4a0df824e66"})
+	if resp.Diagnostics.ErrorsCount() != 1 {
+		t.Fatalf("expected exactly 1 error, got %d: %v", resp.Diagnostics.ErrorsCount(), resp.Diagnostics)
+	}
+}
+
+func TestNumericIDs_MixedValidAndUUID_OneErrorPerBadElement(t *testing.T) {
+	resp := runNumericIDs(t, []string{
+		"42",
+		"f04ba6b4-943d-43d0-be87-d4a0df824e66",
+		"794ff992-fce5-413a-878e-073930353f1c",
+	})
+	if resp.Diagnostics.ErrorsCount() != 2 {
+		t.Errorf("expected exactly 2 errors, got %d: %v", resp.Diagnostics.ErrorsCount(), resp.Diagnostics)
+	}
+}
+
+func TestNumericIDs_Describer(t *testing.T) {
+	v := NumericIDs()
+	if v.Description(context.Background()) == "" {
+		t.Error("expected non-empty Description")
+	}
+	if v.MarkdownDescription(context.Background()) == "" {
+		t.Error("expected non-empty MarkdownDescription")
+	}
+}


### PR DESCRIPTION
## Problem

Jamf Pro object IDs (computers, groups, buildings, departments, users, network segments, iBeacons) are always numeric. Passing a UUID into a scope ID set slipped through plan entirely and blew up **mid-apply** with an opaque, path-less error from the input builder:

```
│ Error: Invalid ID in set
│   with jamfplatform_pro_macos_configuration_profile.claude_desktop_managed_prefs,
│   on config_profile-ai_tools_platform.tf line 65 ...
│ strconv.Atoi: parsing "f04ba6b4-943d-43d0-be87-d4a0df824e66": invalid syntax
```

No attribute path, no indication of what to fix.

## Fix

- **New `scope.NumericIDs()` `validator.Set`** (`internal/common/scope/validators.go`) attached to the shared `IDSetAttribute` helper — so it covers **every** scope ID set across computer, mobile, and user scopes in one place. Rejects non-numeric values at **plan time**, pinned to the offending element, with actionable text:
  > `"f04ba6b4-…"` is not a valid ID. Jamf Pro object IDs are numeric (e.g. `"42"`); this looks like a UUID or other non-numeric handle. When referencing another resource, use its `.id` attribute, which is the numeric ID.
- Parse **mirrors the input builder** (`BuildIDSlice` → `strconv.Atoi`) exactly, so it rejects precisely the values that would fail the write — no false rejects. Defers on null/unknown elements (config-time validator policy), so IDs sourced from other resources/variables aren't flagged before they resolve.
- **Hardened `BuildIDSlice`** runtime message as defense-in-depth for values unknown at plan that resolve non-numeric at apply.
- Descriptions annotated `(numeric)`; docs regenerated for the 10 scope-bearing resources.

## Why `Set<String>`, not `Set<Int64>`

Every resource's `.id` is a `types.String`. Keeping ID sets as strings means `computer_group_ids = [jamfplatform_pro_smart_computer_group.eng.id]` composes cleanly; `Set<Int64>` would force `tonumber()` on every reference. It also matches the all-string scope model and the mixed id/name blocks (e.g. `computer_ids` next to `directory_service_user_group_names`). The validator delivers the type-safety of `Int64` without the interop cost.

## Testing

- New unit tests: all-numeric, null, empty, unknown set, single UUID (1 error), mixed valid+UUID (one error per bad element), describer.
- `go fix`, `gofmt`, `golangci-lint run ./...` (0 issues), `go test ./internal/...` all green.
- Acceptance tests not run (per repo convention, maintainer runs `make testacc`). No wire behavior changed — plan-time validation + error-message text only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)