### PR TITLE
fix(computer_extension_attribute): omit manage_existing_data on create

### DIFF
--- a/internal/resources/pro/computer_extension_attribute/crud.go
+++ b/internal/resources/pro/computer_extension_attribute/crud.go
@@ -43,7 +43,7 @@ func (r *ComputerExtensionAttributeResource) Create(ctx context.Context, req res
 	createCtx, cancel := context.WithTimeout(ctx, createTimeout)
 	defer cancel()
 
-	input, inputDiags := buildComputerExtensionAttributeInput(createCtx, plan, cfg.ManageExistingData)
+	input, inputDiags := buildComputerExtensionAttributeInput(createCtx, plan, cfg.ManageExistingData, true)
 	resp.Diagnostics.Append(inputDiags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -175,7 +175,7 @@ func (r *ComputerExtensionAttributeResource) Update(ctx context.Context, req res
 	updateCtx, cancel := context.WithTimeout(ctx, updateTimeout)
 	defer cancel()
 
-	input, inputDiags := buildComputerExtensionAttributeInput(updateCtx, plan, cfg.ManageExistingData)
+	input, inputDiags := buildComputerExtensionAttributeInput(updateCtx, plan, cfg.ManageExistingData, false)
 	resp.Diagnostics.Append(inputDiags...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/resources/pro/computer_extension_attribute/input_builders.go
+++ b/internal/resources/pro/computer_extension_attribute/input_builders.go
@@ -25,8 +25,11 @@ import (
 // value into the plan, but the gate here drops it whenever input_type is no longer
 // POPUP, so a stale foreign value can never reach the wire (which would 400).
 // manageExistingData is the WriteOnly value, read from config by the caller (it
-// is null in plan/state, so it cannot come from `plan`).
-func buildComputerExtensionAttributeInput(ctx context.Context, plan ComputerExtensionAttributeResourceModel, manageExistingData types.String) (*pro.ComputerExtensionAttributes, diag.Diagnostics) {
+// is null in plan/state, so it cannot come from `plan`). isCreate must be true
+// only when building the Create payload: Jamf Pro 400s
+// ("This field should be blank for first time CEA creation.") if
+// manageExistingData is present on create, and only accepts it on update.
+func buildComputerExtensionAttributeInput(ctx context.Context, plan ComputerExtensionAttributeResourceModel, manageExistingData types.String, isCreate bool) (*pro.ComputerExtensionAttributes, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
 	inputType := plan.InputType.ValueString()
@@ -44,14 +47,18 @@ func buildComputerExtensionAttributeInput(ctx context.Context, plan ComputerExte
 	switch inputType {
 	case inputTypeScript:
 		ea.ScriptContents = helpers.OptionalStringPointer(plan.Script)
-		// manageExistingData is required (and only valid) for SCRIPT EAs: Jamf Pro
-		// 400s a SCRIPT update without it. Send the user's value, or RETAIN when
-		// omitted. Never send it for non-SCRIPT EAs.
-		mode := manageExistingDataDefault
-		if v := helpers.OptionalStringPointer(manageExistingData); v != nil {
-			mode = *v
+		// manageExistingData is required (and only valid) for SCRIPT EAs on
+		// update: Jamf Pro 400s a SCRIPT update without it, and 400s a SCRIPT
+		// create with it present. Send the user's value, or RETAIN when
+		// omitted, but only on update. Never send it for non-SCRIPT EAs or on
+		// create.
+		if !isCreate {
+			mode := manageExistingDataDefault
+			if v := helpers.OptionalStringPointer(manageExistingData); v != nil {
+				mode = *v
+			}
+			ea.ManageExistingData = &mode
 		}
-		ea.ManageExistingData = &mode
 	case inputTypeLDAP:
 		ea.LdapAttributeMapping = helpers.OptionalStringPointer(plan.DirectoryServiceAttribute)
 	case inputTypePopup:

--- a/internal/resources/pro/computer_extension_attribute/input_builders_test.go
+++ b/internal/resources/pro/computer_extension_attribute/input_builders_test.go
@@ -1,0 +1,41 @@
+// Copyright Jamf Software LLC 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package computer_extension_attribute
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+// TestBuildComputerExtensionAttributeInput_ManageExistingDataCreateVsUpdate
+// guards against the regression that produced
+// "[INVALID_CONTENT] manageExistingData: This field should be blank for
+// first time CEA creation." on live SCRIPT-EA create: Jamf Pro 400s if
+// manageExistingData is present on create, and requires it on update.
+func TestBuildComputerExtensionAttributeInput_ManageExistingDataCreateVsUpdate(t *testing.T) {
+	plan := ComputerExtensionAttributeResourceModel{
+		Name:      types.StringValue("zz-script"),
+		DataType:  types.StringValue("STRING"),
+		InputType: types.StringValue(inputTypeScript),
+		Script:    types.StringValue("#!/bin/sh\necho 1"),
+	}
+
+	created, diags := buildComputerExtensionAttributeInput(context.Background(), plan, types.StringNull(), true)
+	if diags.HasError() {
+		t.Fatalf("create diags: %v", diags)
+	}
+	if created.ManageExistingData != nil {
+		t.Fatalf("Create must omit manageExistingData, got %q", *created.ManageExistingData)
+	}
+
+	updated, diags := buildComputerExtensionAttributeInput(context.Background(), plan, types.StringNull(), false)
+	if diags.HasError() {
+		t.Fatalf("update diags: %v", diags)
+	}
+	if updated.ManageExistingData == nil || *updated.ManageExistingData != manageExistingDataDefault {
+		t.Fatalf("Update must default manageExistingData to %q, got %v", manageExistingDataDefault, updated.ManageExistingData)
+	}
+}


### PR DESCRIPTION
## Summary

Fixes a Jamf Pro API 400 that reproduced 100% of the time on the first live end-to-end run of the Jamf Foundations onboarder (`jamf/modular_onboarder`) against this provider — specifically on every `jamfplatform_pro_computer_extension_attribute` create for a SCRIPT-input-type EA.

## Root cause

```
Error: Error creating Jamf Pro computer extension attribute
CreateComputerExtensionAttributeV1: API request failed with status 400,
[INVALID_CONTENT] manageExistingData: This field should be blank for first
time CEA creation.
```

`buildComputerExtensionAttributeInput` (`internal/resources/pro/computer_extension_attribute/input_builders.go`) is shared by both `Create` and `Update` (`crud.go:46` and `crud.go:178`). For any `input_type = SCRIPT` EA it unconditionally set `ea.ManageExistingData`, defaulting to `"RETAIN"` when the user omitted `manage_existing_data` in HCL — there was no branch on create-vs-update. The existing code comment even said the field is "required (and only valid) for SCRIPT EAs" on **update**, but the implementation sent it on every write regardless. Jamf Pro 400s if the field is present on create.

Confirmed via a live run's captured GitHub Actions log — three CEAs failed identically in the same module (`ea_cis_lvl1_failed_count`, `ea_cis_lvl1_failed_list`, `ea_cis_lvl1_version`), all first-time creates.

## Fix

`buildComputerExtensionAttributeInput` now takes an `isCreate bool` parameter. `ManageExistingData` is only populated when `isCreate == false` (i.e. on Update). Both `crud.go` call sites pass the correct value (`true` from `Create`, `false` from `Update`).

## Testing

- Added `input_builders_test.go` asserting `Create` omits `manage_existing_data` and `Update` defaults it to `RETAIN` when the config field is unset.
- `go build ./...`, `go vet ./...`, and the full package test suite pass.
- Not yet re-verified against a live tenant (that's tracked separately in the onboarder repo's dev-docs) — this PR is the provider-side fix; a live re-run will confirm the 400 is gone.

## Related

Part of a 3-repo fix set for the Jamf Foundations onboarder's first live-run failures. See `jamf/modular_onboarder`'s `dev-docs/jamfplatform-provider-terraform-apply-failures.md` for the full failure catalogue and triage notes.