### PR TITLE
fix(mobileconfig): stop injecting PayloadEnabled into sub-payloads

### DIFF
--- a/internal/functions/mobileconfig/assemble.go
+++ b/internal/functions/mobileconfig/assemble.go
@@ -80,7 +80,16 @@ func Assemble(p Profile) ([]byte, error) {
 		setIfAbsent(norm, "PayloadUUID", payloadUUID)
 		setIfAbsent(norm, "PayloadIdentifier", payloadUUID)
 		setIfAbsent(norm, "PayloadVersion", 1)
-		setIfAbsent(norm, "PayloadEnabled", true)
+		// PayloadEnabled is intentionally not injected per sub-payload. It is not
+		// one of Apple's CommonPayloadKeys, so Jamf Pro keeps an author-supplied
+		// value but flags it as unrecognised in the profile UI. It is also not in
+		// the payload diff mask's per-payload drop-list, so the resource's
+		// three-way drift compare (payloadhelpers.ThreeWayCompare) strict-compares
+		// it: once an admin removes it via the UI, the server payload diverges
+		// from the last-applied canonical and every subsequent plan reports drift
+		// (wire-confirmed against Jamf Pro, 2026-07-15). Omitting the forced
+		// default avoids both. An author may still set it explicitly (e.g.
+		// PayloadEnabled=false to disable a single payload).
 
 		payloads = append(payloads, norm)
 	}

--- a/internal/functions/mobileconfig/assemble_test.go
+++ b/internal/functions/mobileconfig/assemble_test.go
@@ -196,3 +196,43 @@ func TestAssemble_DistinctIdentifiersDoNotCollide(t *testing.T) {
 		t.Fatal("distinct identifiers produced the same payload PayloadUUID (collision)")
 	}
 }
+
+// TestAssemble_DoesNotForceSubPayloadEnabled verifies the forced-default
+// PayloadEnabled is no longer injected into sub-payloads (Jamf Pro flags it as
+// an unrecognised key and it drives plan drift once removed in the UI), while
+// the top-level PayloadEnabled is still set and an author-supplied per-payload
+// value is preserved.
+func TestAssemble_DoesNotForceSubPayloadEnabled(t *testing.T) {
+	out, err := Assemble(Profile{
+		Identifier: "com.example.enabledtest",
+		Payloads: []map[string]any{
+			{"PayloadType": "com.apple.dock", "tilesize": int64(48)},
+		},
+	})
+	if err != nil {
+		t.Fatalf("assemble: %v", err)
+	}
+	doc := parseDoc(t, out)
+	if _, ok := doc["PayloadEnabled"]; !ok {
+		t.Error("top-level PayloadEnabled should still be set")
+	}
+	sub := payloadArray(t, doc)[0].(map[string]any)
+	if v, ok := sub["PayloadEnabled"]; ok {
+		t.Errorf("sub-payload PayloadEnabled should not be injected; got %v", v)
+	}
+
+	// An explicitly authored value must survive (e.g. disabling one payload).
+	out2, err := Assemble(Profile{
+		Identifier: "com.example.enabledtest",
+		Payloads: []map[string]any{
+			{"PayloadType": "com.apple.dock", "PayloadEnabled": false},
+		},
+	})
+	if err != nil {
+		t.Fatalf("assemble (author-supplied): %v", err)
+	}
+	sub2 := payloadArray(t, parseDoc(t, out2))[0].(map[string]any)
+	if v, ok := sub2["PayloadEnabled"].(bool); !ok || v != false {
+		t.Errorf("author-supplied sub-payload PayloadEnabled=false must be preserved; got %v (ok=%v)", sub2["PayloadEnabled"], ok)
+	}
+}


### PR DESCRIPTION
The `mcx_forced_payload` and `mobileconfig` functions add `PayloadEnabled` to every sub-payload. `PayloadEnabled` isn't one of Apple's `CommonPayloadKeys`, so Jamf Pro flags it as an unrecognised key in the profile UI. It also isn't dropped by the payload diff mask, so once an admin removes it in the UI, every plan reports drift.

This drops the forced default on sub-payloads. Top-level `PayloadEnabled` is unchanged, and you can still set it explicitly on a payload (for example `PayloadEnabled = false` to disable one).

Verified against Jamf Pro: the nested key is stored and flagged in the UI, and removing it there is what triggers the drift.

Note: profiles created before this show a one-time payloads diff and re-apply once after upgrading, since the stored last-applied input no longer matches.

[^x]: <sub>James (LLM) did the typing; the human only turned up to press the fingerprint reader.</sub>
