### PR TITLE
fix(criteria): gate Jamf-group member-of workaround to the 11.29 window (PI-1394)

### DIFF
--- a/internal/common/criteria/groupref.go
+++ b/internal/common/criteria/groupref.go
@@ -11,6 +11,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
 	"github.com/Jamf-Concepts/jamfplatform-go-sdk/jamfplatform/proclassic"
+
+	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/common/helpers"
 )
 
 // Jamf-group "member of" criteria reference a Jamf group (computer / mobile-device
@@ -20,22 +22,60 @@ import (
 // where it previously round-tripped the name. Left unmapped this trips "Provider
 // produced inconsistent result after apply" and then a perpetual name-vs-id diff.
 //
+// The regression (PI-1394) is a WINDOW: 11.30.1 restored the pre-11.29 behaviour
+// (the endpoint resolves the group name itself and echoes it back), wire-probed
+// live — see GroupRefWorkaroundApplies. So the workaround engages only for
+// [11.29.0, 11.30.1); 11.30.1+ and pre-11.29 pass the name through directly.
+//
 // This file maps the wire value back to the authored group name on read. The
 // mapping is a FALLBACK, never a blind "the wire is an id": when the wire already
-// equals the configured value it is kept verbatim with no lookup, so the same code
-// path serves both pre-11.29 Jamf Pro (returns the name) and 11.29+ (returns the
-// id) with no version branch. See spike/JAMF_GROUP_MEMBER_OF_CRITERIA_SPIKE.md for
-// the per-surface wire-probe matrix. Only two (surface, criterion) pairs regress
-// and are wired: user_group/"User Group" and device_group/"Computer Group" (the
-// COMPUTER device type — MOBILE is clean but shares device_group's code path, where
-// wire==config holds so the resolver never fires). The three advanced searches are
-// confirmed clean and intentionally NOT wired; if a future Jamf release flips one,
-// the criterion name is already mapped per object class in jamfGroupCriterionName.
+// equals the configured value it is kept verbatim with no lookup, so the read path
+// serves pre-11.29 Jamf Pro (returns the name), the 11.29 window (returns the id),
+// and 11.30.1+ (returns the name again) with no version branch — it simply
+// short-circuits when the server echoes the name. See
+// spike/JAMF_GROUP_MEMBER_OF_CRITERIA_SPIKE.md for the per-surface wire-probe
+// matrix. Only two (surface, criterion) pairs regress and are wired:
+// user_group/"User Group" and device_group/"Computer Group" (the COMPUTER device
+// type — MOBILE is clean but shares device_group's code path, where wire==config
+// holds so the resolver never fires). The three advanced searches are confirmed
+// clean and intentionally NOT wired; if a future Jamf release flips one, the
+// criterion name is already mapped per object class in jamfGroupCriterionName.
 //
-// Unlike dsgroup, the WRITE is a pure pass-through: the server accepts the group
-// name verbatim and stores the id itself, so there is no name->wire resolution at
-// apply — only the read-side id->name reverse-resolve, plus a ModifyPlan no-op
-// suppression for the case where a user pastes the equivalent id.
+// The WRITE differs by surface. On classic /usergroups (user_group) the server
+// accepts the group name verbatim and stores the id itself, so the write is a pure
+// pass-through and the workaround only builds an id->name restore map for the
+// post-create/update read-back within the window. The Platform /device-groups
+// endpoint (device_group) instead REQUIRED the numeric id inside the window (PATCH
+// rejected the name), so there the write resolves name->id — see
+// resolveGroupRefWireIDs. Both write-side resolves are gated on
+// GroupRefWorkaroundApplies so 11.30.1+ sends the name directly. The read-side
+// reverse-resolve and the ModifyPlan no-op suppression (for a user who pastes the
+// equivalent id) stay version-agnostic — they are soft no-ops when the server
+// echoes the name.
+
+// GroupRefRegressionVersion is the first Jamf Pro version to echo a Jamf-group
+// member-of value back as the numeric group id (the 11.29 nested-smart-group
+// rework regression — PI-1394; JPRO-20813 / JPRO-20814).
+const GroupRefRegressionVersion = "11.29.0"
+
+// GroupRefFixedVersion is the Jamf Pro version that resolved PI-1394 and restored
+// the pre-11.29 behaviour: the group name round-trips again on both classic
+// /usergroups and the Platform /device-groups endpoint (wire-probed live on 11.30.1
+// — POST/PATCH by name round-trip the name; the numeric id is also accepted and
+// normalised back to the name on read).
+const GroupRefFixedVersion = "11.30.1"
+
+// GroupRefWorkaroundApplies reports whether the Jamf-group member-of name<->id
+// write workaround should engage for a tenant reporting version. True only inside
+// the regressed window [GroupRefRegressionVersion, GroupRefFixedVersion): 11.30.1+
+// and pre-11.29 pass the authored name through directly. FAIL-OPEN via
+// helpers.JamfProVersionInRange (unknown/unparseable version -> true): the numeric
+// id is accepted across the whole supported range (the fixed endpoint normalises it
+// back to the name), so keeping the workaround engaged on an unknown version is
+// safe, whereas sending the name would fail inside the window.
+func GroupRefWorkaroundApplies(version string) bool {
+	return helpers.JamfProVersionInRange(version, GroupRefRegressionVersion, GroupRefFixedVersion)
+}
 
 // GroupResolver maps a Jamf group between its name and numeric id for the
 // ObjectType-appropriate collection (computer / mobile-device / user groups).

--- a/internal/common/criteria/groupref_test.go
+++ b/internal/common/criteria/groupref_test.go
@@ -85,6 +85,40 @@ func TestIsJamfGroupCriterion(t *testing.T) {
 	}
 }
 
+// TestGroupRefWorkaroundApplies pins the regressed-window boundary: every patch of
+// 11.29 and 11.30.0 must trigger the workaround (id echoed back), while 11.30.1 (the
+// fix, PI-1394) and later, and anything pre-11.29, must not. Unknown/unparseable
+// fails open to engaged.
+func TestGroupRefWorkaroundApplies(t *testing.T) {
+	tests := []struct {
+		version string
+		want    bool
+	}{
+		{"11.28.0", false},                // pre-regression
+		{"11.28.99", false},               // pre-regression, high patch
+		{"11.29.0", true},                 // window start (inclusive)
+		{"11.29.1", true},                 // inside window
+		{"11.29.2", true},                 // inside window
+		{"11.29.999", true},               // inside window, high patch
+		{"11.30.0", true},                 // inside window (last regressed minor.patch)
+		{"11.30.1", false},                // fix (window end, exclusive)
+		{"11.30.2", false},                // after fix
+		{"11.31.0", false},                // after fix
+		{"12.0.0", false},                 // after fix, next major
+		{"11.30.1-t1784555528405", false}, // fixed build (suffix stripped) — this tenant
+		{"11.29.0-t1700000000", true},     // regressed build (suffix stripped)
+		{"", true},                        // unknown -> fail open (engaged)
+		{"garbage", true},                 // unparseable -> fail open (engaged)
+	}
+	for _, tt := range tests {
+		t.Run(tt.version, func(t *testing.T) {
+			if got := GroupRefWorkaroundApplies(tt.version); got != tt.want {
+				t.Fatalf("GroupRefWorkaroundApplies(%q) = %v, want %v", tt.version, got, tt.want)
+			}
+		})
+	}
+}
+
 // TestReadGroupValue_BackwardCompatNoLookup is the load-bearing backward-compat
 // assertion: when the wire value already equals the configured value (a pre-11.29
 // server returning the name, or the steady state), the value is kept verbatim and

--- a/internal/common/helpers/pro_version.go
+++ b/internal/common/helpers/pro_version.go
@@ -98,6 +98,32 @@ func AtLeastJamfProVersion(actual, min string) bool {
 	return compareSemver(a, b) >= 0
 }
 
+// JamfProVersionInRange reports whether actual falls in the half-open version
+// window [minInclusive, maxExclusive) (semver-prefix compare, build suffixes
+// stripped). FAIL-OPEN: on any parse failure it returns true. Callers use this to
+// gate a workaround that applies only to a specific version WINDOW — a regression
+// introduced at one Jamf Pro version and fixed at a later one — so an
+// unknown/unparseable tenant version keeps the workaround engaged, matching
+// AtLeastJamfProVersion's fail-open convention. Choosing the fail-open default is
+// the caller's responsibility: it is safe only when the workaround's behaviour is
+// tolerated across the whole supported range (e.g. sending the numeric id is
+// accepted both in the regressed window and after the fix).
+func JamfProVersionInRange(actual, minInclusive, maxExclusive string) bool {
+	a, err := parseSemverPrefix(actual)
+	if err != nil {
+		return true
+	}
+	lo, err := parseSemverPrefix(minInclusive)
+	if err != nil {
+		return true
+	}
+	hi, err := parseSemverPrefix(maxExclusive)
+	if err != nil {
+		return true
+	}
+	return compareSemver(a, lo) >= 0 && compareSemver(a, hi) < 0
+}
+
 type semver struct {
 	major, minor, patch int
 }

--- a/internal/common/helpers/pro_version_test.go
+++ b/internal/common/helpers/pro_version_test.go
@@ -75,6 +75,38 @@ func TestAtLeastJamfProVersion(t *testing.T) {
 	}
 }
 
+// TestJamfProVersionInRange pins the half-open window semantics against the
+// Jamf-group member-of workaround window [11.29.0, 11.30.1): the 11.29 regression,
+// fixed in 11.30.1 (PI-1394).
+func TestJamfProVersionInRange(t *testing.T) {
+	tests := []struct {
+		name string
+		lo   string
+		hi   string
+		in   string
+		want bool
+	}{
+		{"at lower bound (inclusive)", "11.29.0", "11.30.1", "11.29.0", true},
+		{"inside window (minor)", "11.29.0", "11.30.1", "11.29.5", true},
+		{"just below upper bound", "11.29.0", "11.30.1", "11.30.0", true},
+		{"at upper bound (exclusive) -> fixed", "11.29.0", "11.30.1", "11.30.1", false},
+		{"above upper bound -> fixed", "11.29.0", "11.30.1", "11.31.0", false},
+		{"below lower bound -> pre-regression", "11.29.0", "11.30.1", "11.28.0", false},
+		{"build suffix stripped, at lower bound", "11.29.0", "11.30.1", "11.29.0-t1700000000", true},
+		{"build suffix stripped, at fixed version", "11.29.0", "11.30.1", "11.30.1-t1784555528405", false},
+		{"actual unparseable fails open", "11.29.0", "11.30.1", "garbage", true},
+		{"lower bound unparseable fails open", "garbage", "11.30.1", "11.30.1", true},
+		{"upper bound unparseable fails open", "11.29.0", "garbage", "11.30.1", true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := JamfProVersionInRange(tc.in, tc.lo, tc.hi); got != tc.want {
+				t.Fatalf("JamfProVersionInRange(%q, %q, %q) = %v, want %v", tc.in, tc.lo, tc.hi, got, tc.want)
+			}
+		})
+	}
+}
+
 func TestWarnIfBelowProviderFloor(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/internal/resources/device_group/crud.go
+++ b/internal/resources/device_group/crud.go
@@ -158,11 +158,6 @@ func (r *DeviceGroupResource) Create(ctx context.Context, req resource.CreateReq
 		}
 		plan.Criteria = resolved
 		authoredDSGroups = authored
-		// On Jamf Pro >= 11.29 the wire value must be the group ID (the endpoint
-		// rejects names — wire-probed); resolve name->id for the request and keep the
-		// id->name map to restore the authored name after the flatten. Pre-11.29 the
-		// endpoint resolves the name itself (and rejects the id), so pass the name
-		// through unchanged.
 		var wireCriteria []DeviceGroupCriteriaModel
 		wireCriteria, authoredGroupRefs = resolveGroupRefWireIDs(createCtx, r.groupRef, dsObjectType(plan.DeviceType.ValueString()), plan.Criteria, r.groupRefWriteSendsID(createCtx))
 		criteria := expandDeviceGroupCriteria(wireCriteria)
@@ -357,11 +352,6 @@ func (r *DeviceGroupResource) Update(ctx context.Context, req resource.UpdateReq
 		}
 		plan.Criteria = resolved
 		authoredDSGroups = authored
-		// On Jamf Pro >= 11.29 the UPDATE (PATCH) requires the group ID, not the name
-		// (wire-probed: PATCH with a name 400s). Resolve name->id for the request and
-		// keep the id->name map to restore the authored name after the flatten.
-		// Pre-11.29 the endpoint resolves the name itself (and rejects the id), so
-		// pass the name through unchanged.
 		var wireCriteria []DeviceGroupCriteriaModel
 		wireCriteria, authoredGroupRefs = resolveGroupRefWireIDs(updateCtx, r.groupRef, dsObjectType(plan.DeviceType.ValueString()), plan.Criteria, r.groupRefWriteSendsID(updateCtx))
 		criteria := expandDeviceGroupCriteria(wireCriteria)

--- a/internal/resources/device_group/groupref.go
+++ b/internal/resources/device_group/groupref.go
@@ -9,21 +9,18 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
 	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/common/criteria"
-	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/common/helpers"
 )
 
-// groupRefMinIDVersion is the Jamf Pro version at/after which the /device-groups
-// membership criterion stores and requires the numeric group id on the wire rather
-// than the group name (the 11.29 regression — see resolveGroupRefWireIDs). Below
-// this the endpoint resolves the name itself and rejects the classic group id.
-const groupRefMinIDVersion = "11.29.0"
-
 // groupRefWriteSendsID reports whether the device-groups write path must send the
-// numeric group id (Jamf Pro >= 11.29) rather than the authored group name. Soft:
-// when the tenant version is unavailable/unparseable it returns true (the provider
-// floor is 11.29.0, so an unknown version is treated as modern — the workaround
-// stays engaged). Version is read from the cached providerdata, so this is a
-// no-network call after the first lookup in a run.
+// numeric group id rather than the authored group name. True only inside the 11.29
+// regressed window [11.29.0, 11.30.1) (criteria.GroupRefWorkaroundApplies): there
+// the endpoint requires the id and rejects the name. 11.30.1+ restored the
+// pre-11.29 behaviour (the endpoint resolves the name itself and echoes it back),
+// so the authored name is sent directly. Soft: when the tenant version is
+// unavailable/unparseable it returns true — the id is accepted across the whole
+// supported range (the fixed endpoint normalises it back to the name), so keeping
+// it engaged on an unknown version is the safe default. Version is read from the
+// cached providerdata, so this is a no-network call after the first lookup in a run.
 func (r *DeviceGroupResource) groupRefWriteSendsID(ctx context.Context) bool {
 	if r.pd == nil {
 		return true
@@ -32,7 +29,7 @@ func (r *DeviceGroupResource) groupRefWriteSendsID(ctx context.Context) bool {
 	if err != nil {
 		return true
 	}
-	return helpers.AtLeastJamfProVersion(v, groupRefMinIDVersion)
+	return criteria.GroupRefWorkaroundApplies(v)
 }
 
 // Jamf-group "member of" criteria on a Platform device group reference a Jamf
@@ -53,15 +50,18 @@ func (r *DeviceGroupResource) groupRefWriteSendsID(ctx context.Context) bool {
 // id->authoredValue map for the post-flatten restore.
 //
 // VERSION-GATED (resolveToID). The name->id rewrite is a workaround for the Jamf
-// Pro 11.29 regression only: from 11.29 the /device-groups endpoint REQUIRES the id
-// — wire-probed, PATCH with a name 400s ("Computer/Mobile Group depends on Group
-// (<name>) which does not exist") while the id succeeds on POST and PATCH (see
-// spike/PLATFORM_API_FEEDBACK_device_groups_member_of.md). PRE-11.29 the endpoint
-// resolves the name itself and does NOT recognise the classic computer-group id, so
-// sending the id 400s ("Group (<id>) does not exist") — there the value must pass
-// through as the authored NAME. Callers pass resolveToID = (tenant >= 11.29); when
-// false this is a pure passthrough (in, nil) and the pre-11.29 name round-trips
-// unchanged (read returns the name, readback short-circuits, no restore needed).
+// Pro 11.29 regression only, active inside the window [11.29.0, 11.30.1): there the
+// /device-groups endpoint REQUIRES the id — wire-probed, PATCH with a name 400s
+// ("Computer/Mobile Group depends on Group (<name>) which does not exist") while the
+// id succeeds on POST and PATCH (see spike/PLATFORM_API_FEEDBACK_device_groups_member_of.md).
+// PRE-11.29 the endpoint resolves the name itself and does NOT recognise the classic
+// computer-group id, so sending the id 400s ("Group (<id>) does not exist"); 11.30.1+
+// restored that behaviour (name round-trips; the id is also accepted and normalised
+// back to the name on read — wire-probed live). Outside the window the value must
+// pass through as the authored NAME. Callers pass resolveToID =
+// groupRefWriteSendsID (= criteria.GroupRefWorkaroundApplies); when false this is a
+// pure passthrough (in, nil) and the name round-trips unchanged (read returns the
+// name, readback short-circuits, no restore needed).
 //
 // Applies to both device types (mobile regresses identically once updated).
 // Best-effort/SOFT: a value that does not resolve (already an id, or an unknown

--- a/internal/resources/device_group/groupref_acceptance_test.go
+++ b/internal/resources/device_group/groupref_acceptance_test.go
@@ -33,6 +33,11 @@ import (
 //  2. Re-applying the same config is an empty plan (no perpetual name-vs-id diff).
 //  3. Swapping the config to the equivalent numeric id is an empty plan (ModifyPlan
 //     recognises the name<->id representation swap as a no-op).
+//
+// The id-echo occurs only in the regressed window [11.29.0, 11.30.1) (PI-1394);
+// 11.30.1 restored the name round-trip (wire-probed), so on 11.30.1+ the write-side
+// workaround is off and this test degrades to a plain round-trip + swap-no-op check.
+// All four assertions hold on both sides of the fix, so no version branch is needed.
 func TestAccResource_DeviceGroup_JamfGroupMemberOf(t *testing.T) {
 	testhelpers.AccPreCheck(t)
 	// The "member of" / "not member of" directory-service-group operators are

--- a/internal/resources/pro/user_group/crud.go
+++ b/internal/resources/pro/user_group/crud.go
@@ -72,6 +72,28 @@ func fromCriterionModels(in []criteria.CriterionModel) []UserGroupCriterionModel
 	return out
 }
 
+// groupRefWorkaroundApplies reports whether the Jamf-group member-of name<->id
+// workaround should engage for this tenant. The classic /usergroups write is a pure
+// pass-through (the server accepts the group name and stores the id itself), so the
+// only workaround activity on the write path is building the id->name restore map
+// used by the post-create/update read-back; it is only needed inside the 11.29
+// regressed window [11.29.0, 11.30.1), where the server echoes the id back. 11.30.1+
+// restored the name round-trip (wire-probed live), so the map is skipped and the
+// authored name flows through untouched — no needless name->id lookups. Soft: an
+// unavailable/unparseable version keeps the workaround engaged (fail-open, matching
+// device_group). Version is read from the cached providerdata (no network after the
+// first lookup in a run); r.pd is nil only in unit tests that never set it.
+func (r *UserGroupResource) groupRefWorkaroundApplies(ctx context.Context) bool {
+	if r.pd == nil {
+		return true
+	}
+	v, err := r.pd.GetJamfProVersion(ctx)
+	if err != nil {
+		return true
+	}
+	return criteria.GroupRefWorkaroundApplies(v)
+}
+
 // ModifyPlan suppresses a no-op diff when a directory-service group criterion's
 // planned value is a different REPRESENTATION of the same group already in state
 // (a raw base64 value swapped for the equivalent group name, or vice versa).
@@ -162,11 +184,10 @@ func (r *UserGroupResource) Create(ctx context.Context, req resource.CreateReque
 		return
 	}
 	plan.Criteria = fromCriterionModels(resolved)
-	// Resolve Jamf-group "member of" criterion names to the ids the 11.29+ server
-	// will echo on read, so the post-write flatten can restore the authored name
-	// (reorder-safe; see RestoreAuthoredGroupRefCriteria). Built from the authored
-	// (pre-write) criteria; the write itself still sends the name (pass-through).
-	groupRefAuthored := criteria.ResolveAuthoredGroupRefMap(createCtx, r.groupRef, dsGroupObjectType, resolved)
+	var groupRefAuthored map[string]string
+	if r.groupRefWorkaroundApplies(createCtx) {
+		groupRefAuthored = criteria.ResolveAuthoredGroupRefMap(createCtx, r.groupRef, dsGroupObjectType, resolved)
+	}
 
 	input, inputDiags := buildUserGroupInput(createCtx, plan)
 	resp.Diagnostics.Append(inputDiags...)
@@ -324,7 +345,10 @@ func (r *UserGroupResource) Update(ctx context.Context, req resource.UpdateReque
 		return
 	}
 	plan.Criteria = fromCriterionModels(resolved)
-	groupRefAuthored := criteria.ResolveAuthoredGroupRefMap(updateCtx, r.groupRef, dsGroupObjectType, resolved)
+	var groupRefAuthored map[string]string
+	if r.groupRefWorkaroundApplies(updateCtx) {
+		groupRefAuthored = criteria.ResolveAuthoredGroupRefMap(updateCtx, r.groupRef, dsGroupObjectType, resolved)
+	}
 
 	input, inputDiags := buildUserGroupInput(updateCtx, plan)
 	resp.Diagnostics.Append(inputDiags...)

--- a/internal/resources/pro/user_group/groupref_acceptance_test.go
+++ b/internal/resources/pro/user_group/groupref_acceptance_test.go
@@ -27,6 +27,11 @@ import (
 // The "member of" target is a static fixture user group created via the classic
 // SDK (so its numeric id is known for the swap step) and referenced by name; it is
 // deleted on cleanup.
+//
+// The id-echo occurs only in the regressed window [11.29.0, 11.30.1) (PI-1394);
+// 11.30.1 restored the name round-trip (wire-probed), so on 11.30.1+ the write-side
+// workaround is off and this test degrades to a plain round-trip + swap-no-op check.
+// All assertions hold on both sides of the fix, so no version branch is needed.
 func TestAccResource_ProUserGroup_JamfGroupMemberOf(t *testing.T) {
 	testhelpers.AccPreCheck(t)
 	// The "member of" directory-service-group operator is rejected before Jamf

--- a/internal/resources/pro/user_group/resource.go
+++ b/internal/resources/pro/user_group/resource.go
@@ -45,6 +45,9 @@ type UserGroupResource struct {
 	// name and the numeric id Jamf Pro 11.29 echoes on read. Backed by the same
 	// classic client.
 	groupRef criteria.GroupResolver
+	// pd carries the cached Jamf Pro version, used to gate the Jamf-group member-of
+	// workaround to the 11.29 regressed window (criteria.GroupRefWorkaroundApplies).
+	pd *providerdata.Data
 }
 
 var _ resource.Resource = &UserGroupResource{}
@@ -173,6 +176,7 @@ func (r *UserGroupResource) Configure(ctx context.Context, req resource.Configur
 	r.groupRef = criteria.NewProGroupResolver(client)
 	if pd, ok := req.ProviderData.(*providerdata.Data); ok {
 		r.ldap = pro.New(pd.Client)
+		r.pd = pd
 	}
 }
 


### PR DESCRIPTION
## Problem

Jamf Pro 11.29 (nested-smart-group rework — **PI-1394 / PI-1471**; JPRO-20813 / JPRO-20814) echoed a Jamf-group **member of** / **not member of** criterion value back as the group's numeric **id** instead of the authored **name**, tripping "inconsistent result after apply" and a perpetual name-vs-id diff.

The provider carries a name↔id workaround, but it was gated only at a **lower bound** (`>= 11.29`). **11.30.1 fixes the regression** (the group name round-trips again on both classic `/usergroups` and the Platform `/device-groups` endpoint), so the workaround stayed needlessly engaged on 11.30.1+ — `device_group` kept resolving names→ids and sending ids on the wire, and `user_group` kept making redundant, privilege-requiring id lookups.

## Change

Turn the gate into a half-open **window `[11.29.0, 11.30.1)`**. Outside it, the authored group name is sent directly.

- `helpers.JamfProVersionInRange(actual, minIncl, maxExcl)` — fail-open version-window predicate (mirrors `AtLeastJamfProVersion`).
- `criteria.GroupRefWorkaroundApplies(version)` + consts `GroupRefRegressionVersion` (`11.29.0`) / `GroupRefFixedVersion` (`11.30.1`) — the shared engagement predicate.
- **device_group**: `groupRefWriteSendsID` delegates to the predicate → 11.30.1+ sends the name, not the id.
- **user_group**: new `pd` field + `groupRefWorkaroundApplies` gate the `ResolveAuthoredGroupRefMap` calls → 11.30.1+ skips the redundant restore map.
- **Read-path reverse-resolve + ModifyPlan name↔id-swap suppression stay version-agnostic** — soft no-ops when the server echoes the name; they still carry import/drift handling.

Fail-open default (unknown/unparseable version → workaround engaged) is safe across the whole supported range: the fixed endpoint accepts the numeric id and normalises it back to the name (wire-probed), whereas sending the name fails inside the window.

## Verification (wire-probed both regimes live)

| Tenant | Version | Workaround | device_group | user_group |
|---|---|---|---|---|
| us | `11.30.1` (fixed) | **off** | ✅ | ✅ (+ full `Smart_AllOperators` sweep ✅) |
| eu | `11.29.1` (regressed, control: `Computer Group` → id) | **on** | ✅ | ✅ |

- **"Assigned User" / "Assigned User Group"** (also listed in the PI) do **not** regress on the Platform device-groups surface even on 11.29.1 (probed; control `Computer Group` → id confirms the probe detects regression) — no provider handling needed.
- Acc tests unchanged (assertions hold in both regimes; on 11.30.1+ they degrade to a plain round-trip + swap-no-op check — noted in doc comments).
- New unit tests `TestJamfProVersionInRange` + `TestGroupRefWorkaroundApplies` pin the boundary: `11.29.0/.1/.2`, `11.30.0` → on; `11.30.1+` → off.
- `make fix fmt lint` clean (0 issues); unit tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)