### PR TITLE
feat(blueprints): support multi-step component_blocks; deprecate flat component attrs

### DIFF
--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -656,6 +656,20 @@ The tenant version is fetched **only when** a Pro construct with non-empty `minJ
 
 **Out of scope: Platform Services SDK packages** — `blueprints/`, `compliancebenchmarks/`, `devicegroups/`, `devices/`, `deviceactions/`, `ddmreport/`. These are continuously-deployed Jamf Platform microservices, not customer-versioned Jamf Pro endpoints. Always track the latest stable function in the SDK; no deprecation buffer, no quarterly audit, no annotation block required. When a Platform Services SDK function is updated (e.g., a new V2 added), migrate the corresponding resource opportunistically — typically as part of the SDK dependency bump that introduces it.
 
+#### Platform Services *Terraform schema* deprecation — 90-day window
+
+The endpoint-version policy above governs *SDK/endpoint* moves and does not cover **Terraform schema** changes. When a Platform Services resource (`blueprints/*`, `cbengine/*`, `device_group`, …) must reshape its Terraform surface in a backward-incompatible way (rename/retype/supersede an attribute), ship it **additively first**, then remove after a short window:
+
+1. **Add** the new attribute; keep the old one working.
+2. **Mark the old attribute `Deprecated`** with a user-facing `DeprecationMessage` that names the replacement **and the earliest removal date**.
+3. **Annotate it in code** with a greppable marker so removals can be batched later:
+   ```go
+   // PLATFORM-DEPRECATED remove-after=YYYY-MM-DD replaced-by=<new_attr> — <one-line reason>
+   ```
+4. **Window: 90 days** from the release that ships the deprecation (Platform microservices move fast and users track the latest — no Pro-style 12-month buffer). On or after `remove-after`, the field is eligible for **batch removal**: `grep -rn "PLATFORM-DEPRECATED remove-after=" internal/resources/`, drop every field whose date has passed, and land the removal with the schema `Version` bump + `UpgradeState` that migrates old state (see [[feedback-no-state-upgraders]] — published state exists, so removals are breaking and need an upgrader).
+
+This applies only to Platform Services resources. Jamf Pro schema deprecations follow the [rename PR / major-version](#jamf-pro-resource-naming) convention instead.
+
 **ProClassic is unversioned**: `jamfplatform/proclassic/` functions do not carry V1/V2 suffixes. Migration timing (below) does not apply to ProClassic-backed resources. Annotation block is still recommended for documenting which SDK function is in use, but `Status:` simply tracks "current" against the SDK release in use.
 
 #### SDK side-by-side dependency

--- a/docs/data-sources/blueprints_blueprint.md
+++ b/docs/data-sources/blueprints_blueprint.md
@@ -50,9 +50,10 @@ output "blueprint_example_all" {
 
 ### Read-Only
 
-- `activation_conditions` (String) Activation condition expression that further restricts which scoped devices the blueprint applies to. Empty when the blueprint applies to all devices in the targeted device groups.
+- `activation_conditions` (String, Deprecated) Activation condition expression that further restricts which scoped devices the blueprint applies to. Reflects the first component block only; read `component_blocks` for per-block conditions.
 - `blueprint_id` (String) Blueprint ID.
-- `component` (Attributes List) Blueprint components. (see [below for nested schema](#nestedatt--component))
+- `component` (Attributes List, Deprecated) Components of the first component block. Read `component_blocks` for the components of every block. (see [below for nested schema](#nestedatt--component))
+- `component_blocks` (Attributes List) Ordered component blocks of the blueprint. Each block has a name, an optional activation condition, and its own components. (see [below for nested schema](#nestedatt--component_blocks))
 - `created` (String) Created at (RFC3339).
 - `deployment_state` (String) Deployment state.
 - `description` (String) Description.
@@ -69,6 +70,24 @@ Optional:
 
 <a id="nestedatt--component"></a>
 ### Nested Schema for `component`
+
+Read-Only:
+
+- `configuration` (Map of String) Component configuration as a map of key-value pairs.
+- `identifier` (String) Component identifier.
+
+
+<a id="nestedatt--component_blocks"></a>
+### Nested Schema for `component_blocks`
+
+Read-Only:
+
+- `activation_conditions` (String) Activation condition applied to this block. Empty when the block applies to all devices in scope.
+- `component` (Attributes List) Components in this block. (see [below for nested schema](#nestedatt--component_blocks--component))
+- `name` (String) Component block name.
+
+<a id="nestedatt--component_blocks--component"></a>
+### Nested Schema for `component_blocks.component`
 
 Read-Only:
 

--- a/docs/resources/blueprints_blueprint.md
+++ b/docs/resources/blueprints_blueprint.md
@@ -40,7 +40,12 @@ The Jamf Platform API integration used by the provider must be granted the follo
 ## Example Usage
 
 ```terraform
-# Software Update Settings Blueprint
+# Blueprints are authored with `component_blocks` — an ordered list where each block appears as a
+# step in the Jamf Blueprints editor, with its own name, its own optional activation condition, and
+# its own components. Blocks are applied in the order listed, and a block may contain more than one
+# component.
+
+# Single block — Software Update Settings
 resource "jamfplatform_blueprints_blueprint" "software_update_settings" {
   name        = "Software Update Settings"
   description = "Managed by Terraform"
@@ -48,61 +53,97 @@ resource "jamfplatform_blueprints_blueprint" "software_update_settings" {
 
   device_groups = ["fce3d9a5-8660-42ff-a95e-625e7b53b48a"]
 
-  software_update_settings = {
-    allow_standard_user_os_updates           = true
-    automatic_download                       = "AlwaysOn"
-    automatic_install_os_updates             = "AlwaysOn"
-    automatic_install_security_updates       = "AlwaysOn"
-    beta_program_enrollment                  = "Allowed"
-    deferral_combined_period_days            = 7
-    deferral_major_period_days               = 30
-    deferral_minor_period_days               = 14
-    deferral_system_period_days              = 3
-    notifications_enabled                    = true
-    rapid_security_response_enabled          = true
-    rapid_security_response_rollback_enabled = false
-    recommended_cadence                      = "Newest"
+  component_blocks = [
+    {
+      name = "Software Update Settings"
+      software_update_settings = {
+        allow_standard_user_os_updates           = true
+        automatic_download                       = "AlwaysOn"
+        automatic_install_os_updates             = "AlwaysOn"
+        automatic_install_security_updates       = "AlwaysOn"
+        beta_program_enrollment                  = "Allowed"
+        deferral_combined_period_days            = 7
+        deferral_major_period_days               = 30
+        deferral_minor_period_days               = 14
+        deferral_system_period_days              = 3
+        notifications_enabled                    = true
+        rapid_security_response_enabled          = true
+        rapid_security_response_rollback_enabled = false
+        recommended_cadence                      = "Newest"
 
-    beta_offer_programs = [{
-      token       = "beta-token-1"
-      description = "iOS 18 Beta Program"
-      }, {
-      token       = "beta-token-2"
-      description = "macOS Sequoia Beta Program"
-    }]
-  }
+        beta_offer_programs = [{
+          token       = "beta-token-1"
+          description = "iOS 18 Beta Program"
+          }, {
+          token       = "beta-token-2"
+          description = "macOS Sequoia Beta Program"
+        }]
+      }
+    },
+  ]
 }
 
-# Latest OS version Software Updates Blueprint
-resource "jamfplatform_blueprints_blueprint" "automatic_software_updates" {
-  name        = "Latest OS version Software Updates"
+# Two components in a single block — a block may carry more than one component.
+resource "jamfplatform_blueprints_blueprint" "baseline_restrictions" {
+  name        = "Baseline Restrictions"
   description = "Managed by Terraform"
   deployed    = true
 
   device_groups = ["fce3d9a5-8660-42ff-a95e-625e7b53b48a"]
 
-  software_update = {
-    ignore_major_versions = true
-    deployment_time       = "02:00"
-    enforce_after_days    = 7
-  }
+  component_blocks = [
+    {
+      name = "Baseline Restrictions"
+      passcode_policy = {
+        require_passcode = true
+        minimum_length   = 6
+      }
+      math_settings = {
+        calculator_scientific_mode_enabled   = true
+        system_behavior_keyboard_suggestions = true
+        system_behavior_math_notes           = true
+      }
+    },
+  ]
 }
 
-# Specific OS version and time Software Updates Blueprint
-resource "jamfplatform_blueprints_blueprint" "manual_software_updates" {
-  name        = "Specific OS Version and time Software Updates"
+# Multiple blocks — each is a separate step, applied in order. The same component type may appear in
+# more than one block, and each block can carry its own activation condition.
+resource "jamfplatform_blueprints_blueprint" "multi_step" {
+  name        = "Multi-Step Components"
   description = "Managed by Terraform"
   deployed    = false
 
   device_groups = ["fce3d9a5-8660-42ff-a95e-625e7b53b48a"]
 
-  software_update = {
-    target_os_version      = "26.0.1"
-    target_local_date_time = "2025-10-10T12:00:00"
-  }
+  component_blocks = [
+    {
+      name = "Passcode Policy"
+      passcode_policy = {
+        require_passcode = true
+        minimum_length   = 6
+      }
+    },
+    {
+      name = "Latest OS Software Updates"
+      software_update = {
+        ignore_major_versions = true
+        deployment_time       = "02:00"
+        enforce_after_days    = 7
+      }
+    },
+    {
+      name = "Math Settings"
+      math_settings = {
+        calculator_scientific_mode_enabled   = true
+        system_behavior_keyboard_suggestions = true
+        system_behavior_math_notes           = true
+      }
+    },
+  ]
 }
 
-# Legacy Payloads Example Blueprint
+# Legacy configuration profile payloads inside a block.
 resource "jamfplatform_blueprints_blueprint" "legacy_payloads_example" {
   name        = "Restrictions for Safari"
   description = "Managed by Terraform"
@@ -110,18 +151,23 @@ resource "jamfplatform_blueprints_blueprint" "legacy_payloads_example" {
 
   device_groups = ["fce3d9a5-8660-42ff-a95e-625e7b53b48a"]
 
-  legacy_payloads = [
+  component_blocks = [
     {
-      payload_type = "com.apple.applicationaccess"
-      settings = {
-        allowSafariHistoryClearing = false
-        allowSafariPrivateBrowsing = false
-      }
-    }
+      name = "Safari Restrictions"
+      legacy_payloads = [
+        {
+          payload_type = "com.apple.applicationaccess"
+          settings = jsonencode({
+            allowSafariHistoryClearing = false
+            allowSafariPrivateBrowsing = false
+          })
+        }
+      ]
+    },
   ]
 }
 
-# Custom Declaration Example Blueprint
+# Custom declarations inside a block.
 resource "jamfplatform_blueprints_blueprint" "customdeclaration" {
   name        = "Custom Declarations"
   description = "Managed by Terraform"
@@ -129,45 +175,49 @@ resource "jamfplatform_blueprints_blueprint" "customdeclaration" {
 
   device_groups = ["fce3d9a5-8660-42ff-a95e-625e7b53b48a"]
 
-  custom_declarations = {
-
-    declaration = [{
-      channel = "SYSTEM"
-      kind    = "CONFIGURATION"
-      type    = "com.apple.configuration.softwareupdate.settings"
-      payload = jsonencode({
-        Beta = {
-          RequireProgram = {
-            Token       = "<beta-token-here>",
-            Description = "AppleSeed for IT"
-          },
-          ProgramEnrollment = "AlwaysOn"
-        }
-      })
-      }, {
-      channel = "USER"
-      kind    = "ASSET"
-      type    = "com.apple.asset.credential.userpassword"
-      payload = jsonencode({
-        Reference = {
-          DataURL     = "https://somewhere.com/something.plist",
-          ContentType = "application/plist"
-        }
-      })
-    }]
-  }
+  component_blocks = [
+    {
+      name = "Custom Declarations"
+      custom_declarations = {
+        declaration = [{
+          channel = "SYSTEM"
+          kind    = "CONFIGURATION"
+          type    = "com.apple.configuration.softwareupdate.settings"
+          payload = jsonencode({
+            Beta = {
+              RequireProgram = {
+                Token       = "<beta-token-here>",
+                Description = "AppleSeed for IT"
+              },
+              ProgramEnrollment = "AlwaysOn"
+            }
+          })
+          }, {
+          channel = "USER"
+          kind    = "ASSET"
+          type    = "com.apple.asset.credential.userpassword"
+          payload = jsonencode({
+            Reference = {
+              DataURL     = "https://somewhere.com/something.plist",
+              ContentType = "application/plist"
+            }
+          })
+        }]
+      }
+    },
+  ]
 }
 
-# Activation Conditions Blueprint
+# Per-block activation conditions.
 #
-# Activation conditions further restrict which scoped devices a blueprint applies
-# to. The expression is authored most easily in the Jamf UI ("Activation conditions"
-# editor -> Text view) and copied here verbatim. See the syntax reference:
+# An activation condition further restricts which scoped devices a block applies to. Author it in
+# the Jamf UI ("Activation conditions" editor -> Text view) and copy it here verbatim. See the
+# syntax reference:
 # https://learn.jamf.com/r/en-US/jamf-pro-blueprints-configuration-guide/Activation_Condition_Expression_Reference
 #
-# Device groups in the expression are referenced by their Platform UUID, so a
-# managed device group can be referenced by its `id` with ordinary Terraform
-# interpolation — keeping the condition in sync with the group it points at.
+# Device groups in the expression are referenced by their Platform UUID, so a managed device group
+# can be referenced by its `id` with ordinary Terraform interpolation — keeping the condition in
+# sync with the group it points at.
 resource "jamfplatform_device_group" "shared_ipads" {
   name        = "Shared iPads"
   group_type  = "smart"
@@ -189,15 +239,19 @@ resource "jamfplatform_blueprints_blueprint" "activation_conditions_example" {
 
   device_groups = [jamfplatform_device_group.shared_ipads.id]
 
-  # Only activate on supervised iPads that belong to the managed device group above.
-  # The group ID is interpolated from the resource, so the condition tracks the group.
-  activation_conditions = "ANY @property(jamf.device.groups) IN {'${jamfplatform_device_group.shared_ipads.id}'} AND @status(device.model.family) == 'iPad'"
-
-  software_update = {
-    ignore_major_versions = true
-    deployment_time       = "02:00"
-    enforce_after_days    = 7
-  }
+  component_blocks = [
+    {
+      name = "Shared iPad Software Updates"
+      # Only activate on supervised iPads that belong to the managed device group above.
+      # The group ID is interpolated from the resource, so the condition tracks the group.
+      activation_conditions = "ANY @property(jamf.device.groups) IN {'${jamfplatform_device_group.shared_ipads.id}'} AND @status(device.model.family) == 'iPad'"
+      software_update = {
+        ignore_major_versions = true
+        deployment_time       = "02:00"
+        enforce_after_days    = 7
+      }
+    },
+  ]
 }
 ```
 
@@ -212,22 +266,23 @@ resource "jamfplatform_blueprints_blueprint" "activation_conditions_example" {
 
 ### Optional
 
-- `activation_conditions` (String) Optional activation condition expression that further restricts which scoped devices the blueprint applies to. An expression combines a status item, an operator, and a value — using terms such as `@status(...)` and `@property(jamf.device.groups)` with operators like `==`, `!=`, `IN {…}`, `ANY`, `NONE`, `AND`, `OR`, and `NOT`. See the [Activation Condition Expression Reference](https://learn.jamf.com/r/en-US/jamf-pro-blueprints-configuration-guide/Activation_Condition_Expression_Reference) for the full syntax. The simplest way to author one is to build the rule in the **Activation conditions** editor in the Jamf UI, switch to the **Text** view, and copy the expression here. Device groups are referenced by their Platform UUID, so ordinary Terraform interpolation works — reference a managed `jamfplatform_device_group` by its `id` to keep conditions in sync, e.g. `"ANY @property(jamf.device.groups) IN {'${jamfplatform_device_group.example.id}'}"`. When omitted, the blueprint applies to all devices in the targeted device groups.
-- `audio_accessory_settings` (Attributes) Audio accessory settings component for managing temporary pairing and unpairing policies. (see [below for nested schema](#nestedatt--audio_accessory_settings))
-- `custom_declarations` (Attributes) Custom declarations component for managing custom DDM declarations with system or user channel types. (see [below for nested schema](#nestedatt--custom_declarations))
+- `activation_conditions` (String, Deprecated) Optional activation condition expression that further restricts which scoped devices the blueprint applies to. An expression combines a status item, an operator, and a value — using terms such as `@status(...)` and `@property(jamf.device.groups)` with operators like `==`, `!=`, `IN {…}`, `ANY`, `NONE`, `AND`, `OR`, and `NOT`. See the [Activation Condition Expression Reference](https://learn.jamf.com/r/en-US/jamf-pro-blueprints-configuration-guide/Activation_Condition_Expression_Reference) for the full syntax. The simplest way to author one is to build the rule in the **Activation conditions** editor in the Jamf UI, switch to the **Text** view, and copy the expression here. Device groups are referenced by their Platform UUID, so ordinary Terraform interpolation works — reference a managed `jamfplatform_device_group` by its `id` to keep conditions in sync, e.g. `"ANY @property(jamf.device.groups) IN {'${jamfplatform_device_group.example.id}'}"`. When omitted, the blueprint applies to all devices in the targeted device groups. When using `component_blocks`, set the condition on each block instead of here.
+- `audio_accessory_settings` (Attributes, Deprecated) Audio accessory settings component for managing temporary pairing and unpairing policies. (see [below for nested schema](#nestedatt--audio_accessory_settings))
+- `component_blocks` (Attributes List) Ordered list of component blocks. Each block appears as a step in the Jamf Blueprints editor, with its own name, its own activation condition, and its own set of components. Blocks are applied in the order listed. Use `component_blocks` instead of the deprecated top-level component attributes; the two cannot be combined. (see [below for nested schema](#nestedatt--component_blocks))
+- `custom_declarations` (Attributes, Deprecated) Custom declarations component for managing custom DDM declarations with system or user channel types. (see [below for nested schema](#nestedatt--custom_declarations))
 - `description` (String) Blueprint description.
-- `disk_management_settings` (Attributes) Disk management settings component for controlling external and network storage restrictions. (see [below for nested schema](#nestedatt--disk_management_settings))
-- `legacy_payloads` (Dynamic) Legacy configuration profile payloads as a list of objects. Each object must have a `payload_type` key (Apple reverse-domain identifier, e.g. `com.apple.applicationaccess`) and an optional `settings` object containing the payload key-value pairs. The payload identifier is auto-generated and the display name uses the blueprint name.
-- `math_settings` (Attributes) Math settings component for managing calculator modes and system behavior. (see [below for nested schema](#nestedatt--math_settings))
-- `passcode_policy` (Attributes) Passcode policy component for managing device passcode requirements and restrictions. (see [below for nested schema](#nestedatt--passcode_policy))
-- `raw_component` (Attributes Set) Raw component configuration using key-value pairs. (see [below for nested schema](#nestedatt--raw_component))
-- `safari_bookmarks` (Attributes) Safari bookmarks component for managing Safari managed bookmarks and bookmark groups. (see [below for nested schema](#nestedatt--safari_bookmarks))
-- `safari_extensions` (Attributes) Safari extensions component for managing Safari extension permissions and states. (see [below for nested schema](#nestedatt--safari_extensions))
-- `safari_settings` (Attributes) Safari settings component for managing Safari browser behavior and security settings. (see [below for nested schema](#nestedatt--safari_settings))
-- `service_background_tasks` (Attributes) Service background tasks component for managing background service tasks and launchd configurations. (see [below for nested schema](#nestedatt--service_background_tasks))
-- `service_configuration_files` (Attributes) Service configuration files component for managing configuration files for system services. (see [below for nested schema](#nestedatt--service_configuration_files))
-- `software_update` (Attributes) Software update component for enforcing OS updates on devices. (see [below for nested schema](#nestedatt--software_update))
-- `software_update_settings` (Attributes) Software update settings component for configuring system update behavior and policies. (see [below for nested schema](#nestedatt--software_update_settings))
+- `disk_management_settings` (Attributes, Deprecated) Disk management settings component for controlling external and network storage restrictions. (see [below for nested schema](#nestedatt--disk_management_settings))
+- `legacy_payloads` (Dynamic, Deprecated) Legacy configuration profile payloads as a list of objects. Each object must have a `payload_type` key (Apple reverse-domain identifier, e.g. `com.apple.applicationaccess`) and an optional `settings` object containing the payload key-value pairs. The payload identifier is auto-generated and the display name uses the blueprint name.
+- `math_settings` (Attributes, Deprecated) Math settings component for managing calculator modes and system behavior. (see [below for nested schema](#nestedatt--math_settings))
+- `passcode_policy` (Attributes, Deprecated) Passcode policy component for managing device passcode requirements and restrictions. (see [below for nested schema](#nestedatt--passcode_policy))
+- `raw_component` (Attributes Set, Deprecated) Raw component configuration using key-value pairs. (see [below for nested schema](#nestedatt--raw_component))
+- `safari_bookmarks` (Attributes, Deprecated) Safari bookmarks component for managing Safari managed bookmarks and bookmark groups. (see [below for nested schema](#nestedatt--safari_bookmarks))
+- `safari_extensions` (Attributes, Deprecated) Safari extensions component for managing Safari extension permissions and states. (see [below for nested schema](#nestedatt--safari_extensions))
+- `safari_settings` (Attributes, Deprecated) Safari settings component for managing Safari browser behavior and security settings. (see [below for nested schema](#nestedatt--safari_settings))
+- `service_background_tasks` (Attributes, Deprecated) Service background tasks component for managing background service tasks and launchd configurations. (see [below for nested schema](#nestedatt--service_background_tasks))
+- `service_configuration_files` (Attributes, Deprecated) Service configuration files component for managing configuration files for system services. (see [below for nested schema](#nestedatt--service_configuration_files))
+- `software_update` (Attributes, Deprecated) Software update component for enforcing OS updates on devices. (see [below for nested schema](#nestedatt--software_update))
+- `software_update_settings` (Attributes, Deprecated) Software update settings component for configuring system update behavior and policies. (see [below for nested schema](#nestedatt--software_update_settings))
 - `timeouts` (Attributes) (see [below for nested schema](#nestedatt--timeouts))
 
 ### Read-Only
@@ -248,6 +303,372 @@ Optional:
 
 - `unpairing_time_hour` (Number) The local time hour (24-hour clock) when the device automatically unpairs temporarily paired audio accessories. Required when policy is `Hour`. Range: `0`-`23`.
 - `unpairing_time_policy` (String) Device's unpairing policy. Valid values are `None`, `Hour`. When set to `Hour`, `unpairing_time_hour` must also be provided.
+
+
+<a id="nestedatt--component_blocks"></a>
+### Nested Schema for `component_blocks`
+
+Optional:
+
+- `activation_conditions` (String) Optional activation condition expression that further restricts which scoped devices this block applies to. An expression combines a status item, an operator, and a value — using terms such as `@status(...)` and `@property(jamf.device.groups)` with operators like `==`, `!=`, `IN {…}`, `ANY`, `NONE`, `AND`, `OR`, and `NOT`. See the [Activation Condition Expression Reference](https://learn.jamf.com/r/en-US/jamf-pro-blueprints-configuration-guide/Activation_Condition_Expression_Reference) for the full syntax. The simplest way to author one is to build the rule in the **Activation conditions** editor in the Jamf UI, switch to the **Text** view, and copy the expression here. Device groups are referenced by their Platform UUID, so ordinary Terraform interpolation works — reference a managed `jamfplatform_device_group` by its `id` to keep conditions in sync, e.g. `"ANY @property(jamf.device.groups) IN {'${jamfplatform_device_group.example.id}'}"`. When omitted, this block applies to all devices in the targeted device groups.
+- `audio_accessory_settings` (Attributes) Audio accessory settings component for managing temporary pairing and unpairing policies. (see [below for nested schema](#nestedatt--component_blocks--audio_accessory_settings))
+- `custom_declarations` (Attributes) Custom declarations component for managing custom DDM declarations with system or user channel types. (see [below for nested schema](#nestedatt--component_blocks--custom_declarations))
+- `disk_management_settings` (Attributes) Disk management settings component for controlling external and network storage restrictions. (see [below for nested schema](#nestedatt--component_blocks--disk_management_settings))
+- `legacy_payloads` (Attributes List) Legacy configuration profile payloads in this block. The payload identifier is auto-generated and the display name uses the blueprint name. (see [below for nested schema](#nestedatt--component_blocks--legacy_payloads))
+- `math_settings` (Attributes) Math settings component for managing calculator modes and system behavior. (see [below for nested schema](#nestedatt--component_blocks--math_settings))
+- `name` (String) Name shown for this component block in the Jamf Blueprints editor (e.g. `Passcode Policy`). When omitted, Jamf assigns a default name.
+- `passcode_policy` (Attributes) Passcode policy component for managing device passcode requirements and restrictions. (see [below for nested schema](#nestedatt--component_blocks--passcode_policy))
+- `raw_component` (Attributes Set) Raw component configuration using key-value pairs. (see [below for nested schema](#nestedatt--component_blocks--raw_component))
+- `safari_bookmarks` (Attributes) Safari bookmarks component for managing Safari managed bookmarks and bookmark groups. (see [below for nested schema](#nestedatt--component_blocks--safari_bookmarks))
+- `safari_extensions` (Attributes) Safari extensions component for managing Safari extension permissions and states. (see [below for nested schema](#nestedatt--component_blocks--safari_extensions))
+- `safari_settings` (Attributes) Safari settings component for managing Safari browser behavior and security settings. (see [below for nested schema](#nestedatt--component_blocks--safari_settings))
+- `service_background_tasks` (Attributes) Service background tasks component for managing background service tasks and launchd configurations. (see [below for nested schema](#nestedatt--component_blocks--service_background_tasks))
+- `service_configuration_files` (Attributes) Service configuration files component for managing configuration files for system services. (see [below for nested schema](#nestedatt--component_blocks--service_configuration_files))
+- `software_update` (Attributes) Software update component for enforcing OS updates on devices. (see [below for nested schema](#nestedatt--component_blocks--software_update))
+- `software_update_settings` (Attributes) Software update settings component for configuring system update behavior and policies. (see [below for nested schema](#nestedatt--component_blocks--software_update_settings))
+
+<a id="nestedatt--component_blocks--audio_accessory_settings"></a>
+### Nested Schema for `component_blocks.audio_accessory_settings`
+
+Required:
+
+- `temporary_pairing_disabled` (Boolean) If true, temporary pairing of audio accessories is disabled.
+
+Optional:
+
+- `unpairing_time_hour` (Number) The local time hour (24-hour clock) when the device automatically unpairs temporarily paired audio accessories. Required when policy is `Hour`. Range: `0`-`23`.
+- `unpairing_time_policy` (String) Device's unpairing policy. Valid values are `None`, `Hour`. When set to `Hour`, `unpairing_time_hour` must also be provided.
+
+
+<a id="nestedatt--component_blocks--custom_declarations"></a>
+### Nested Schema for `component_blocks.custom_declarations`
+
+Optional:
+
+- `declaration` (Attributes Set) Custom DDM declaration. (see [below for nested schema](#nestedatt--component_blocks--custom_declarations--declaration))
+
+<a id="nestedatt--component_blocks--custom_declarations--declaration"></a>
+### Nested Schema for `component_blocks.custom_declarations.declaration`
+
+Required:
+
+- `channel` (String) The channel type for the declaration. Valid values are `SYSTEM`, `USER`.
+- `kind` (String) The kind of declaration. Valid values are `CONFIGURATION`, `ASSET`.
+- `payload` (String) JSON-encoded payload object for the declaration.
+- `type` (String) The declaration type identifier (e.g., `com.apple.configuration.softwareupdate.settings`).
+
+
+
+<a id="nestedatt--component_blocks--disk_management_settings"></a>
+### Nested Schema for `component_blocks.disk_management_settings`
+
+Optional:
+
+- `external_storage` (String) Storage mode for external storage. Valid values are `Allowed`, `Disallowed`, `ReadOnly`.
+- `network_storage` (String) Storage mode for network storage. Valid values are `Allowed`, `Disallowed`, `ReadOnly`.
+
+
+<a id="nestedatt--component_blocks--legacy_payloads"></a>
+### Nested Schema for `component_blocks.legacy_payloads`
+
+Required:
+
+- `payload_type` (String) Apple reverse-domain payload identifier, e.g. `com.apple.applicationaccess`.
+
+Optional:
+
+- `settings` (String) Payload key-value settings as a JSON object string. Author with `jsonencode({ ... })`.
+
+
+<a id="nestedatt--component_blocks--math_settings"></a>
+### Nested Schema for `component_blocks.math_settings`
+
+Optional:
+
+- `calculator_basic_mode_add_square_root` (Boolean) Add the square root button to the basic calculator by replacing the +/- button.
+- `calculator_input_modes_rpn` (Boolean) Configures whether RPN input is enabled in Calculator. Also requires `calculator_input_modes_unit_conversion` to be set.
+- `calculator_input_modes_unit_conversion` (Boolean) Configures whether unit conversions are enabled in Calculator. Also requires `calculator_input_modes_rpn` to be set.
+- `calculator_math_notes_mode_enabled` (Boolean) Controls whether the Math Notes mode is enabled in Calculator.
+- `calculator_programmer_mode_enabled` (Boolean) Controls whether the programmer mode is enabled in Calculator.
+- `calculator_scientific_mode_enabled` (Boolean) Controls whether the scientific mode is enabled in Calculator.
+- `system_behavior_keyboard_suggestions` (Boolean) Controls whether keyboard suggestions include math solutions. Also requires `system_behavior_math_notes` to be set.
+- `system_behavior_math_notes` (Boolean) Controls whether Math Notes is allowed in other apps such as Notes. Also requires `system_behavior_keyboard_suggestions` to be set.
+
+
+<a id="nestedatt--component_blocks--passcode_policy"></a>
+### Nested Schema for `component_blocks.passcode_policy`
+
+Optional:
+
+- `change_at_next_auth` (Boolean) Change at next auth.
+- `custom_regex_description` (Map of String) Localized descriptions for the custom regex. Map of OS language ID to description string. Use the `default` key for languages not explicitly listed.
+- `custom_regex_pattern` (String) Custom regular expression for passcode validation. Maximum length: `2048`.
+- `failed_attempts_reset_in_minutes` (Number) Failed attempts reset in minutes. Minimum: `0`.
+- `maximum_failed_attempts` (Number) Maximum failed attempts. Range: `2`-`11`.
+- `maximum_grace_period_in_minutes` (Number) Maximum grace period in minutes. Minimum: `0`.
+- `maximum_inactivity_in_minutes` (Number) Maximum inactivity in minutes. Range: `0`-`15`.
+- `maximum_passcode_age_in_days` (Number) Maximum passcode age in days. Range: `0`-`730`.
+- `minimum_complex_characters` (Number) Minimum complex characters. Range: `0`-`4`.
+- `minimum_length` (Number) Minimum length. Range: `0`-`16`.
+- `passcode_reuse_limit` (Number) Passcode reuse limit. Range: `1`-`50`.
+- `require_alphanumeric_passcode` (Boolean) Require alphanumeric passcode.
+- `require_complex_passcode` (Boolean) Require complex passcode.
+- `require_passcode` (Boolean) Require passcode.
+
+
+<a id="nestedatt--component_blocks--raw_component"></a>
+### Nested Schema for `component_blocks.raw_component`
+
+Required:
+
+- `identifier` (String) Component identifier (e.g., `com.jamf.ddm.disk-management`).
+
+Optional:
+
+- `configuration` (Map of String) Component configuration as key-value pairs. Each component has its own unique configuration options.
+
+
+<a id="nestedatt--component_blocks--safari_bookmarks"></a>
+### Nested Schema for `component_blocks.safari_bookmarks`
+
+Optional:
+
+- `managed_bookmarks` (Attributes Set) Set of managed bookmark groups. (see [below for nested schema](#nestedatt--component_blocks--safari_bookmarks--managed_bookmarks))
+
+<a id="nestedatt--component_blocks--safari_bookmarks--managed_bookmarks"></a>
+### Nested Schema for `component_blocks.safari_bookmarks.managed_bookmarks`
+
+Required:
+
+- `bookmarks` (Attributes Set) Set of bookmarks in this group. (see [below for nested schema](#nestedatt--component_blocks--safari_bookmarks--managed_bookmarks--bookmarks))
+- `group_identifier` (String) Unique identifier for this group of managed bookmarks.
+- `title` (String) The name of the bookmarks folder.
+
+<a id="nestedatt--component_blocks--safari_bookmarks--managed_bookmarks--bookmarks"></a>
+### Nested Schema for `component_blocks.safari_bookmarks.managed_bookmarks.bookmarks`
+
+Required:
+
+- `title` (String) The title of the folder shown in Safari.
+
+Optional:
+
+- `folder` (Attributes Set) Bookmarks within this folder. (see [below for nested schema](#nestedatt--component_blocks--safari_bookmarks--managed_bookmarks--bookmarks--folder))
+- `type` (String) Type of bookmark. Valid values are `bookmark` (URL bookmark) or `folder` (bookmark folder).
+- `url` (String) The URL for direct bookmarks (not used for folders).
+
+<a id="nestedatt--component_blocks--safari_bookmarks--managed_bookmarks--bookmarks--folder"></a>
+### Nested Schema for `component_blocks.safari_bookmarks.managed_bookmarks.bookmarks.folder`
+
+Required:
+
+- `title` (String) The title of the bookmark shown in Safari.
+- `url` (String) The URL for the bookmark item.
+
+
+
+
+
+<a id="nestedatt--component_blocks--safari_extensions"></a>
+### Nested Schema for `component_blocks.safari_extensions`
+
+Optional:
+
+- `managed_extensions` (Attributes Set) Set of managed Safari extensions. (see [below for nested schema](#nestedatt--component_blocks--safari_extensions--managed_extensions))
+
+<a id="nestedatt--component_blocks--safari_extensions--managed_extensions"></a>
+### Nested Schema for `component_blocks.safari_extensions.managed_extensions`
+
+Required:
+
+- `extension_id` (String) The extension identifier (bundle ID).
+
+Optional:
+
+- `allowed_domains` (Attributes Set) Set of allowed domains for this extension. (see [below for nested schema](#nestedatt--component_blocks--safari_extensions--managed_extensions--allowed_domains))
+- `denied_domains` (Attributes Set) Set of denied domains for this extension. (see [below for nested schema](#nestedatt--component_blocks--safari_extensions--managed_extensions--denied_domains))
+- `private_browsing` (String) Private browsing state. Valid values are `Allowed`, `AlwaysOn`, `AlwaysOff`.
+- `state` (String) Extension state. Valid values are `Allowed`, `AlwaysOn`, `AlwaysOff`.
+
+<a id="nestedatt--component_blocks--safari_extensions--managed_extensions--allowed_domains"></a>
+### Nested Schema for `component_blocks.safari_extensions.managed_extensions.allowed_domains`
+
+Required:
+
+- `domain` (String) Domain name.
+
+
+<a id="nestedatt--component_blocks--safari_extensions--managed_extensions--denied_domains"></a>
+### Nested Schema for `component_blocks.safari_extensions.managed_extensions.denied_domains`
+
+Required:
+
+- `domain` (String) Domain name.
+
+
+
+
+<a id="nestedatt--component_blocks--safari_settings"></a>
+### Nested Schema for `component_blocks.safari_settings`
+
+Optional:
+
+- `accept_cookies` (String) The policy Safari uses for managing cookies. Valid values are `Never`, `CurrentWebsite`, `VisitedWebsites`, `Always`.
+- `allow_disabling_fraud_warning` (Boolean) If false, the system forces fraud warnings on in Safari.
+- `allow_history_clearing` (Boolean) If false, the system disables clearing history in Safari.
+- `allow_javascript` (Boolean) If false, the system disables JavaScript in Safari.
+- `allow_popups` (Boolean) If false, the system disables popups in Safari.
+- `allow_private_browsing` (Boolean) If false, the system disables private browsing in Safari.
+- `allow_summary` (Boolean) If false, the system disables summarization of content in Safari.
+- `new_tab_start_page_extension_id` (String) The composed identifier of the extension that provides the start page. Required when page type is `Extension`. Format: `com.example.extension (ABC1234567)`.
+- `new_tab_start_page_homepage_url` (String) The URL of the homepage which needs to start with `https://` or `http://`. Required when page type is `Home`.
+- `new_tab_start_page_type` (String) Sets the start page type in Safari. Valid values are `Start`, `Home`, `Extension`.
+
+
+<a id="nestedatt--component_blocks--service_background_tasks"></a>
+### Nested Schema for `component_blocks.service_background_tasks`
+
+Optional:
+
+- `background_tasks` (Attributes Set) Set of background tasks. (see [below for nested schema](#nestedatt--component_blocks--service_background_tasks--background_tasks))
+
+<a id="nestedatt--component_blocks--service_background_tasks--background_tasks"></a>
+### Nested Schema for `component_blocks.service_background_tasks.background_tasks`
+
+Required:
+
+- `task_type` (String) Task type identifier.
+
+Optional:
+
+- `executable_asset_reference` (Attributes) Reference to the executable asset. (see [below for nested schema](#nestedatt--component_blocks--service_background_tasks--background_tasks--executable_asset_reference))
+- `launchd_configurations` (Attributes Set) Launchd configuration items. (see [below for nested schema](#nestedatt--component_blocks--service_background_tasks--background_tasks--launchd_configurations))
+- `task_description` (String) Task description.
+
+<a id="nestedatt--component_blocks--service_background_tasks--background_tasks--executable_asset_reference"></a>
+### Nested Schema for `component_blocks.service_background_tasks.background_tasks.executable_asset_reference`
+
+Required:
+
+- `data_url` (String) URL that hosts the executable data.
+
+Optional:
+
+- `hash_sha_256` (String) SHA-256 hash of the data.
+
+Read-Only:
+
+- `content_type` (String) Media type of the data. Always `application/zip` for executable assets.
+
+
+<a id="nestedatt--component_blocks--service_background_tasks--background_tasks--launchd_configurations"></a>
+### Nested Schema for `component_blocks.service_background_tasks.background_tasks.launchd_configurations`
+
+Required:
+
+- `context` (String) Launchd context. Valid values are `daemon`, `agent`.
+- `file_asset_reference` (Attributes) Reference to the configuration file asset. (see [below for nested schema](#nestedatt--component_blocks--service_background_tasks--background_tasks--launchd_configurations--file_asset_reference))
+
+<a id="nestedatt--component_blocks--service_background_tasks--background_tasks--launchd_configurations--file_asset_reference"></a>
+### Nested Schema for `component_blocks.service_background_tasks.background_tasks.launchd_configurations.file_asset_reference`
+
+Required:
+
+- `data_url` (String) URL that hosts the configuration data.
+
+Optional:
+
+- `content_type` (String) Media type of the data.
+- `hash_sha_256` (String) SHA-256 hash of the data.
+
+
+
+
+
+<a id="nestedatt--component_blocks--service_configuration_files"></a>
+### Nested Schema for `component_blocks.service_configuration_files`
+
+Optional:
+
+- `service_config_files` (Attributes Set) Set of service configuration files. (see [below for nested schema](#nestedatt--component_blocks--service_configuration_files--service_config_files))
+
+<a id="nestedatt--component_blocks--service_configuration_files--service_config_files"></a>
+### Nested Schema for `component_blocks.service_configuration_files.service_config_files`
+
+Required:
+
+- `service_type` (String) The identifier of the system service with managed configuration files.
+
+Optional:
+
+- `data_asset_reference` (Attributes) Reference to the configuration data asset. (see [below for nested schema](#nestedatt--component_blocks--service_configuration_files--service_config_files--data_asset_reference))
+
+<a id="nestedatt--component_blocks--service_configuration_files--service_config_files--data_asset_reference"></a>
+### Nested Schema for `component_blocks.service_configuration_files.service_config_files.data_asset_reference`
+
+Required:
+
+- `data_url` (String) URL that hosts the configuration data.
+
+Optional:
+
+- `hash_sha_256` (String) SHA-256 hash of the data.
+
+Read-Only:
+
+- `content_type` (String) Media type of the data. Always `application/zip` for service configuration files.
+
+
+
+
+<a id="nestedatt--component_blocks--software_update"></a>
+### Nested Schema for `component_blocks.software_update`
+
+Optional:
+
+- `deployment_time` (String) For automatic enforcement. Local device time to install the update. Format: `HH:mm` (24-hour). Cannot be used with `target_os_version` or `target_local_date_time`.
+- `details_url_value` (String) URL of a web page with the details about the software update.
+- `enforce_after_days` (Number) For automatic enforcement. Days after release to enforce the update. Maximum is `30`. Cannot be used with `target_os_version` or `target_local_date_time`.
+- `ignore_major_versions` (Boolean) Whether to ignore major OS versions when enforcing updates. Only applicable for automatic enforcement. Cannot be used with `target_os_version` or `target_local_date_time`.
+- `target_local_date_time` (String) For manual enforcement. Local device date and time to enforce the software update. Format: RFC3339 date-time. Cannot be used with `deployment_time`, `enforce_after_days`, or `ignore_major_versions`.
+- `target_os_version` (String) For manual enforcement. Target OS version. Format: `major.minor[.patch]`. Cannot be used with `deployment_time`, `enforce_after_days`, or `ignore_major_versions`.
+
+Read-Only:
+
+- `enforcement_type` (String) Type of enforcement. Automatically set to `AUTOMATIC` when `deployment_time` or `enforce_after_days` is specified, or `MANUAL` when `target_os_version` or `target_local_date_time` is specified.
+
+
+<a id="nestedatt--component_blocks--software_update_settings"></a>
+### Nested Schema for `component_blocks.software_update_settings`
+
+Optional:
+
+- `allow_standard_user_os_updates` (Boolean) Allow standard users to install OS updates without administrator privileges.
+- `automatic_download` (String) Automatic download behavior for updates. Valid values: `Allowed`, `AlwaysOn`, `AlwaysOff`.
+- `automatic_install_os_updates` (String) Automatic installation behavior for OS updates. Valid values: `Allowed`, `AlwaysOn`, `AlwaysOff`.
+- `automatic_install_security_updates` (String) Automatic installation behavior for security updates. Valid values: `Allowed`, `AlwaysOn`, `AlwaysOff`.
+- `beta_offer_programs` (Attributes Set) Beta programs to offer (max 100). Each program must have a token and description (1-1000 characters each). (see [below for nested schema](#nestedatt--component_blocks--software_update_settings--beta_offer_programs))
+- `beta_program_enrollment` (String) Beta program enrollment setting. Valid values: `Allowed`, `AlwaysOn`, `AlwaysOff`.
+- `beta_require_program_description` (String) Required beta program description (1-1000 characters). Must be specified with `beta_require_program_token`.
+- `beta_require_program_token` (String) Required beta program token (1-1000 characters). Must be specified with `beta_require_program_description`.
+- `deferral_combined_period_days` (Number) Number of days to defer combined updates. Range: `1`-`90`.
+- `deferral_major_period_days` (Number) Number of days to defer major updates. Range: `1`-`90`.
+- `deferral_minor_period_days` (Number) Number of days to defer minor updates. Range: `1`-`90`.
+- `deferral_system_period_days` (Number) Number of days to defer system updates. Range: `1`-`90`.
+- `notifications_enabled` (Boolean) Enable update notifications to users.
+- `rapid_security_response_enabled` (Boolean) Enable Rapid Security Response updates.
+- `rapid_security_response_rollback_enabled` (Boolean) Enable rollback capability for Rapid Security Response updates.
+- `recommended_cadence` (String) Recommended update cadence policy. Valid values: `All`, `Oldest`, `Newest`.
+
+<a id="nestedatt--component_blocks--software_update_settings--beta_offer_programs"></a>
+### Nested Schema for `component_blocks.software_update_settings.beta_offer_programs`
+
+Required:
+
+- `description` (String) Beta program description (1-1000 characters).
+- `token` (String) Beta program token (1-1000 characters).
+
+
 
 
 <a id="nestedatt--custom_declarations"></a>

--- a/examples/resources/jamfplatform_blueprints_blueprint/resource.tf
+++ b/examples/resources/jamfplatform_blueprints_blueprint/resource.tf
@@ -1,4 +1,9 @@
-# Software Update Settings Blueprint
+# Blueprints are authored with `component_blocks` — an ordered list where each block appears as a
+# step in the Jamf Blueprints editor, with its own name, its own optional activation condition, and
+# its own components. Blocks are applied in the order listed, and a block may contain more than one
+# component.
+
+# Single block — Software Update Settings
 resource "jamfplatform_blueprints_blueprint" "software_update_settings" {
   name        = "Software Update Settings"
   description = "Managed by Terraform"
@@ -6,61 +11,97 @@ resource "jamfplatform_blueprints_blueprint" "software_update_settings" {
 
   device_groups = ["fce3d9a5-8660-42ff-a95e-625e7b53b48a"]
 
-  software_update_settings = {
-    allow_standard_user_os_updates           = true
-    automatic_download                       = "AlwaysOn"
-    automatic_install_os_updates             = "AlwaysOn"
-    automatic_install_security_updates       = "AlwaysOn"
-    beta_program_enrollment                  = "Allowed"
-    deferral_combined_period_days            = 7
-    deferral_major_period_days               = 30
-    deferral_minor_period_days               = 14
-    deferral_system_period_days              = 3
-    notifications_enabled                    = true
-    rapid_security_response_enabled          = true
-    rapid_security_response_rollback_enabled = false
-    recommended_cadence                      = "Newest"
+  component_blocks = [
+    {
+      name = "Software Update Settings"
+      software_update_settings = {
+        allow_standard_user_os_updates           = true
+        automatic_download                       = "AlwaysOn"
+        automatic_install_os_updates             = "AlwaysOn"
+        automatic_install_security_updates       = "AlwaysOn"
+        beta_program_enrollment                  = "Allowed"
+        deferral_combined_period_days            = 7
+        deferral_major_period_days               = 30
+        deferral_minor_period_days               = 14
+        deferral_system_period_days              = 3
+        notifications_enabled                    = true
+        rapid_security_response_enabled          = true
+        rapid_security_response_rollback_enabled = false
+        recommended_cadence                      = "Newest"
 
-    beta_offer_programs = [{
-      token       = "beta-token-1"
-      description = "iOS 18 Beta Program"
-      }, {
-      token       = "beta-token-2"
-      description = "macOS Sequoia Beta Program"
-    }]
-  }
+        beta_offer_programs = [{
+          token       = "beta-token-1"
+          description = "iOS 18 Beta Program"
+          }, {
+          token       = "beta-token-2"
+          description = "macOS Sequoia Beta Program"
+        }]
+      }
+    },
+  ]
 }
 
-# Latest OS version Software Updates Blueprint
-resource "jamfplatform_blueprints_blueprint" "automatic_software_updates" {
-  name        = "Latest OS version Software Updates"
+# Two components in a single block — a block may carry more than one component.
+resource "jamfplatform_blueprints_blueprint" "baseline_restrictions" {
+  name        = "Baseline Restrictions"
   description = "Managed by Terraform"
   deployed    = true
 
   device_groups = ["fce3d9a5-8660-42ff-a95e-625e7b53b48a"]
 
-  software_update = {
-    ignore_major_versions = true
-    deployment_time       = "02:00"
-    enforce_after_days    = 7
-  }
+  component_blocks = [
+    {
+      name = "Baseline Restrictions"
+      passcode_policy = {
+        require_passcode = true
+        minimum_length   = 6
+      }
+      math_settings = {
+        calculator_scientific_mode_enabled   = true
+        system_behavior_keyboard_suggestions = true
+        system_behavior_math_notes           = true
+      }
+    },
+  ]
 }
 
-# Specific OS version and time Software Updates Blueprint
-resource "jamfplatform_blueprints_blueprint" "manual_software_updates" {
-  name        = "Specific OS Version and time Software Updates"
+# Multiple blocks — each is a separate step, applied in order. The same component type may appear in
+# more than one block, and each block can carry its own activation condition.
+resource "jamfplatform_blueprints_blueprint" "multi_step" {
+  name        = "Multi-Step Components"
   description = "Managed by Terraform"
   deployed    = false
 
   device_groups = ["fce3d9a5-8660-42ff-a95e-625e7b53b48a"]
 
-  software_update = {
-    target_os_version      = "26.0.1"
-    target_local_date_time = "2025-10-10T12:00:00"
-  }
+  component_blocks = [
+    {
+      name = "Passcode Policy"
+      passcode_policy = {
+        require_passcode = true
+        minimum_length   = 6
+      }
+    },
+    {
+      name = "Latest OS Software Updates"
+      software_update = {
+        ignore_major_versions = true
+        deployment_time       = "02:00"
+        enforce_after_days    = 7
+      }
+    },
+    {
+      name = "Math Settings"
+      math_settings = {
+        calculator_scientific_mode_enabled   = true
+        system_behavior_keyboard_suggestions = true
+        system_behavior_math_notes           = true
+      }
+    },
+  ]
 }
 
-# Legacy Payloads Example Blueprint
+# Legacy configuration profile payloads inside a block.
 resource "jamfplatform_blueprints_blueprint" "legacy_payloads_example" {
   name        = "Restrictions for Safari"
   description = "Managed by Terraform"
@@ -68,18 +109,23 @@ resource "jamfplatform_blueprints_blueprint" "legacy_payloads_example" {
 
   device_groups = ["fce3d9a5-8660-42ff-a95e-625e7b53b48a"]
 
-  legacy_payloads = [
+  component_blocks = [
     {
-      payload_type = "com.apple.applicationaccess"
-      settings = {
-        allowSafariHistoryClearing = false
-        allowSafariPrivateBrowsing = false
-      }
-    }
+      name = "Safari Restrictions"
+      legacy_payloads = [
+        {
+          payload_type = "com.apple.applicationaccess"
+          settings = jsonencode({
+            allowSafariHistoryClearing = false
+            allowSafariPrivateBrowsing = false
+          })
+        }
+      ]
+    },
   ]
 }
 
-# Custom Declaration Example Blueprint
+# Custom declarations inside a block.
 resource "jamfplatform_blueprints_blueprint" "customdeclaration" {
   name        = "Custom Declarations"
   description = "Managed by Terraform"
@@ -87,45 +133,49 @@ resource "jamfplatform_blueprints_blueprint" "customdeclaration" {
 
   device_groups = ["fce3d9a5-8660-42ff-a95e-625e7b53b48a"]
 
-  custom_declarations = {
-
-    declaration = [{
-      channel = "SYSTEM"
-      kind    = "CONFIGURATION"
-      type    = "com.apple.configuration.softwareupdate.settings"
-      payload = jsonencode({
-        Beta = {
-          RequireProgram = {
-            Token       = "<beta-token-here>",
-            Description = "AppleSeed for IT"
-          },
-          ProgramEnrollment = "AlwaysOn"
-        }
-      })
-      }, {
-      channel = "USER"
-      kind    = "ASSET"
-      type    = "com.apple.asset.credential.userpassword"
-      payload = jsonencode({
-        Reference = {
-          DataURL     = "https://somewhere.com/something.plist",
-          ContentType = "application/plist"
-        }
-      })
-    }]
-  }
+  component_blocks = [
+    {
+      name = "Custom Declarations"
+      custom_declarations = {
+        declaration = [{
+          channel = "SYSTEM"
+          kind    = "CONFIGURATION"
+          type    = "com.apple.configuration.softwareupdate.settings"
+          payload = jsonencode({
+            Beta = {
+              RequireProgram = {
+                Token       = "<beta-token-here>",
+                Description = "AppleSeed for IT"
+              },
+              ProgramEnrollment = "AlwaysOn"
+            }
+          })
+          }, {
+          channel = "USER"
+          kind    = "ASSET"
+          type    = "com.apple.asset.credential.userpassword"
+          payload = jsonencode({
+            Reference = {
+              DataURL     = "https://somewhere.com/something.plist",
+              ContentType = "application/plist"
+            }
+          })
+        }]
+      }
+    },
+  ]
 }
 
-# Activation Conditions Blueprint
+# Per-block activation conditions.
 #
-# Activation conditions further restrict which scoped devices a blueprint applies
-# to. The expression is authored most easily in the Jamf UI ("Activation conditions"
-# editor -> Text view) and copied here verbatim. See the syntax reference:
+# An activation condition further restricts which scoped devices a block applies to. Author it in
+# the Jamf UI ("Activation conditions" editor -> Text view) and copy it here verbatim. See the
+# syntax reference:
 # https://learn.jamf.com/r/en-US/jamf-pro-blueprints-configuration-guide/Activation_Condition_Expression_Reference
 #
-# Device groups in the expression are referenced by their Platform UUID, so a
-# managed device group can be referenced by its `id` with ordinary Terraform
-# interpolation — keeping the condition in sync with the group it points at.
+# Device groups in the expression are referenced by their Platform UUID, so a managed device group
+# can be referenced by its `id` with ordinary Terraform interpolation — keeping the condition in
+# sync with the group it points at.
 resource "jamfplatform_device_group" "shared_ipads" {
   name        = "Shared iPads"
   group_type  = "smart"
@@ -147,13 +197,17 @@ resource "jamfplatform_blueprints_blueprint" "activation_conditions_example" {
 
   device_groups = [jamfplatform_device_group.shared_ipads.id]
 
-  # Only activate on supervised iPads that belong to the managed device group above.
-  # The group ID is interpolated from the resource, so the condition tracks the group.
-  activation_conditions = "ANY @property(jamf.device.groups) IN {'${jamfplatform_device_group.shared_ipads.id}'} AND @status(device.model.family) == 'iPad'"
-
-  software_update = {
-    ignore_major_versions = true
-    deployment_time       = "02:00"
-    enforce_after_days    = 7
-  }
+  component_blocks = [
+    {
+      name = "Shared iPad Software Updates"
+      # Only activate on supervised iPads that belong to the managed device group above.
+      # The group ID is interpolated from the resource, so the condition tracks the group.
+      activation_conditions = "ANY @property(jamf.device.groups) IN {'${jamfplatform_device_group.shared_ipads.id}'} AND @status(device.model.family) == 'iPad'"
+      software_update = {
+        ignore_major_versions = true
+        deployment_time       = "02:00"
+        enforce_after_days    = 7
+      }
+    },
+  ]
 }

--- a/internal/resources/blueprints/blueprint/component_blocks_acceptance_test.go
+++ b/internal/resources/blueprints/blueprint/component_blocks_acceptance_test.go
@@ -1,0 +1,191 @@
+// Copyright Jamf Software LLC 2026
+// SPDX-License-Identifier: MPL-2.0
+
+//go:build acceptance
+
+package blueprint_test
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/testhelpers"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
+)
+
+// TestAccResource_Blueprint_ComponentBlocks exercises the ordered component_blocks authoring style:
+// multiple named blocks, a per-block activation condition, plan stability on read-back, appending a
+// block (including audio_accessory_settings — the appended-list-element path), and the same
+// component type (passcode_policy) repeated across two blocks.
+func TestAccResource_Blueprint_ComponentBlocks(t *testing.T) {
+	testhelpers.AccPreCheck(t)
+	suffix := testhelpers.RunSuffix()
+	name := "tf-acc-bp-blocks-" + suffix
+	res := "jamfplatform_blueprints_blueprint.blocks"
+
+	threeBlocks := testBlueprintConfig(smartGroupHCL("blocks"), fmt.Sprintf(`
+		resource "jamfplatform_blueprints_blueprint" "blocks" {
+			name          = %q
+			description   = "Acceptance test — safe to delete"
+			deployed      = false
+			device_groups = [jamfplatform_device_group.scope.id]
+
+			component_blocks = [
+				{
+					name = "Passcode Policy"
+					passcode_policy = {
+						require_passcode = true
+						minimum_length   = 6
+					}
+				},
+				{
+					name = "Software Update Settings"
+					software_update_settings = {
+						allow_standard_user_os_updates     = true
+						automatic_download                 = "AlwaysOn"
+						automatic_install_os_updates       = "AlwaysOn"
+						automatic_install_security_updates = "AlwaysOn"
+						recommended_cadence                = "Newest"
+					}
+				},
+				{
+					name                  = "Math Settings"
+					activation_conditions = "ANY @property(jamf.device.groups) IN {'${jamfplatform_device_group.scope.id}'}"
+					math_settings = {
+						calculator_scientific_mode_enabled   = true
+						system_behavior_keyboard_suggestions = true
+						system_behavior_math_notes           = true
+					}
+				},
+			]
+		}
+	`, name))
+
+	fourBlocks := testBlueprintConfig(smartGroupHCL("blocks"), fmt.Sprintf(`
+		resource "jamfplatform_blueprints_blueprint" "blocks" {
+			name          = %q
+			description   = "Acceptance test — safe to delete"
+			deployed      = false
+			device_groups = [jamfplatform_device_group.scope.id]
+
+			component_blocks = [
+				{
+					name = "Passcode Policy"
+					passcode_policy = {
+						require_passcode = true
+						minimum_length   = 8
+					}
+				},
+				{
+					name = "Software Update Settings"
+					software_update_settings = {
+						allow_standard_user_os_updates     = true
+						automatic_download                 = "AlwaysOn"
+						automatic_install_os_updates       = "AlwaysOn"
+						automatic_install_security_updates = "AlwaysOn"
+						recommended_cadence                = "Newest"
+					}
+				},
+				{
+					name = "Audio"
+					audio_accessory_settings = {
+						temporary_pairing_disabled = true
+					}
+				},
+				{
+					name = "Stricter Passcode"
+					passcode_policy = {
+						require_passcode = true
+						minimum_length   = 10
+					}
+				},
+			]
+		}
+	`, name))
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testhelpers.AccTestProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckBlueprintResourcesDestroy(t),
+		Steps: []resource.TestStep{
+			{
+				Config: threeBlocks,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet(res, "id"),
+					resource.TestCheckResourceAttr(res, "component_blocks.#", "3"),
+					resource.TestCheckResourceAttr(res, "component_blocks.0.name", "Passcode Policy"),
+					resource.TestCheckResourceAttr(res, "component_blocks.0.passcode_policy.minimum_length", "6"),
+					resource.TestCheckResourceAttr(res, "component_blocks.1.name", "Software Update Settings"),
+					resource.TestCheckResourceAttr(res, "component_blocks.2.name", "Math Settings"),
+					resource.TestCheckResourceAttrSet(res, "component_blocks.2.activation_conditions"),
+					// Flat attributes stay null in block mode.
+					resource.TestCheckNoResourceAttr(res, "passcode_policy.%"),
+				),
+			},
+			{
+				// Read-back of the three blocks must produce no diff.
+				Config: threeBlocks,
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{plancheck.ExpectEmptyPlan()},
+				},
+			},
+			{
+				// Reorder-in-place edit + append an audio block (appended list element) and a
+				// second passcode block (same component type in two blocks).
+				Config: fourBlocks,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(res, "component_blocks.#", "4"),
+					resource.TestCheckResourceAttr(res, "component_blocks.0.passcode_policy.minimum_length", "8"),
+					resource.TestCheckResourceAttr(res, "component_blocks.2.name", "Audio"),
+					resource.TestCheckResourceAttr(res, "component_blocks.2.audio_accessory_settings.temporary_pairing_disabled", "true"),
+					resource.TestCheckResourceAttr(res, "component_blocks.3.name", "Stricter Passcode"),
+					resource.TestCheckResourceAttr(res, "component_blocks.3.passcode_policy.minimum_length", "10"),
+				),
+			},
+			{
+				// Read-back of the four blocks (including the defaulted audio fields) must be stable.
+				Config: fourBlocks,
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{plancheck.ExpectEmptyPlan()},
+				},
+			},
+		},
+	})
+}
+
+// TestAccResource_Blueprint_ComponentBlocks_ConflictsWithFlat proves the two authoring styles are
+// mutually exclusive: declaring a flat component attribute alongside component_blocks fails at plan.
+func TestAccResource_Blueprint_ComponentBlocks_ConflictsWithFlat(t *testing.T) {
+	testhelpers.AccPreCheck(t)
+	suffix := testhelpers.RunSuffix()
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testhelpers.AccTestProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testBlueprintConfig(smartGroupHCL("conflict"), fmt.Sprintf(`
+					resource "jamfplatform_blueprints_blueprint" "conflict" {
+						name          = "tf-acc-bp-conflict-%s"
+						deployed      = false
+						device_groups = [jamfplatform_device_group.scope.id]
+
+						passcode_policy = {
+							require_passcode = true
+						}
+
+						component_blocks = [
+							{
+								name = "X"
+								math_settings = {
+									system_behavior_math_notes = true
+								}
+							},
+						]
+					}
+				`, suffix)),
+				ExpectError: regexp.MustCompile(`Invalid Attribute Combination`),
+			},
+		},
+	})
+}

--- a/internal/resources/blueprints/blueprint/component_blocks_test.go
+++ b/internal/resources/blueprints/blueprint/component_blocks_test.go
@@ -1,0 +1,291 @@
+// Copyright Jamf Software LLC 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package blueprint
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/Jamf-Concepts/jamfplatform-go-sdk/jamfplatform/blueprints"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	resourceschema "github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func strptr(s string) *string { return &s }
+
+// --- Schema ---
+
+func TestBlueprintResource_SchemaComponentBlocks(t *testing.T) {
+	r := NewBlueprintResource()
+	var resp resource.SchemaResponse
+	r.(*BlueprintResource).Schema(context.Background(), resource.SchemaRequest{}, &resp)
+
+	attr, ok := resp.Schema.Attributes["component_blocks"]
+	if !ok {
+		t.Fatal("missing component_blocks attribute")
+	}
+	if !attr.IsOptional() {
+		t.Error("component_blocks should be optional")
+	}
+
+	list, ok := attr.(resourceschema.ListNestedAttribute)
+	if !ok {
+		t.Fatalf("component_blocks should be a ListNestedAttribute, got %T", attr)
+	}
+
+	nested := list.NestedObject.Attributes
+	for _, name := range []string{"name", "activation_conditions", "raw_component", "passcode_policy", "software_update_settings", "legacy_payloads"} {
+		if _, ok := nested[name]; !ok {
+			t.Errorf("component_blocks block missing attribute %q", name)
+		}
+	}
+
+	if nested["passcode_policy"].GetDeprecationMessage() != "" {
+		t.Error("component attributes inside component_blocks must not be deprecated")
+	}
+}
+
+func TestBlueprintResource_FlatComponentAttrsDeprecated(t *testing.T) {
+	r := NewBlueprintResource()
+	var resp resource.SchemaResponse
+	r.(*BlueprintResource).Schema(context.Background(), resource.SchemaRequest{}, &resp)
+
+	deprecated := []string{
+		"activation_conditions",
+		"legacy_payloads",
+		"raw_component",
+		"audio_accessory_settings",
+		"custom_declarations",
+		"disk_management_settings",
+		"math_settings",
+		"passcode_policy",
+		"safari_bookmarks",
+		"safari_extensions",
+		"safari_settings",
+		"service_background_tasks",
+		"service_configuration_files",
+		"software_update",
+		"software_update_settings",
+	}
+	for _, name := range deprecated {
+		attr, ok := resp.Schema.Attributes[name]
+		if !ok {
+			t.Errorf("missing flat attribute %q", name)
+			continue
+		}
+		if attr.GetDeprecationMessage() == "" {
+			t.Errorf("flat attribute %q should carry a DeprecationMessage", name)
+		}
+	}
+
+	// Blueprint-level attributes must NOT be deprecated.
+	for _, name := range []string{"name", "description", "deployed", "device_groups"} {
+		if resp.Schema.Attributes[name].GetDeprecationMessage() != "" {
+			t.Errorf("blueprint-level attribute %q must not be deprecated", name)
+		}
+	}
+}
+
+func TestBlueprintDataSource_SchemaComponentBlocks(t *testing.T) {
+	d := NewBlueprintDataSource()
+	var resp datasource.SchemaResponse
+	d.(*BlueprintDataSource).Schema(context.Background(), datasource.SchemaRequest{}, &resp)
+
+	attr, ok := resp.Schema.Attributes["component_blocks"]
+	if !ok {
+		t.Fatal("data source missing component_blocks attribute")
+	}
+	if !attr.IsComputed() {
+		t.Error("data source component_blocks should be computed")
+	}
+}
+
+// --- buildSteps (input) ---
+
+func TestBuildSteps_BlockMode(t *testing.T) {
+	r := &BlueprintResource{}
+	data := &BlueprintResourceModel{
+		Name: types.StringValue("BP"),
+		ComponentBlocks: []ComponentBlockModel{
+			{
+				Name:                 types.StringValue("Block A"),
+				ActivationConditions: types.StringValue("ANY @property(jamf.device.groups)"),
+				Components: []ComponentModel{
+					{Identifier: types.StringValue("com.jamf.ddm.passcode-settings"), Configuration: types.MapNull(types.StringType)},
+				},
+			},
+			{
+				Name: types.StringValue("Block B"),
+				Components: []ComponentModel{
+					{Identifier: types.StringValue("com.jamf.ddm.passcode-settings"), Configuration: types.MapNull(types.StringType)},
+				},
+			},
+		},
+	}
+
+	steps, diags := r.buildSteps(context.Background(), data)
+	if diags.HasError() {
+		t.Fatalf("unexpected diagnostics: %v", diags)
+	}
+	if len(steps) != 2 {
+		t.Fatalf("expected 2 steps, got %d", len(steps))
+	}
+
+	if steps[0].Name == nil || *steps[0].Name != "Block A" {
+		t.Errorf("expected step 0 name 'Block A', got %v", steps[0].Name)
+	}
+	if steps[0].ActivationPredicate == nil || *steps[0].ActivationPredicate != "ANY @property(jamf.device.groups)" {
+		t.Errorf("expected step 0 activation predicate, got %v", steps[0].ActivationPredicate)
+	}
+	if steps[1].Name == nil || *steps[1].Name != "Block B" {
+		t.Errorf("expected step 1 name 'Block B', got %v", steps[1].Name)
+	}
+	if steps[1].ActivationPredicate != nil {
+		t.Errorf("expected step 1 activation predicate nil, got %v", *steps[1].ActivationPredicate)
+	}
+
+	// Same identifier appears in both blocks — the wire allows it and buildSteps must not merge.
+	if len(steps[0].Components) != 1 || steps[0].Components[0].Identifier != "com.jamf.ddm.passcode-settings" {
+		t.Errorf("expected step 0 to carry the passcode component, got %+v", steps[0].Components)
+	}
+	if len(steps[1].Components) != 1 || steps[1].Components[0].Identifier != "com.jamf.ddm.passcode-settings" {
+		t.Errorf("expected step 1 to carry the passcode component, got %+v", steps[1].Components)
+	}
+}
+
+func TestBuildSteps_FlatMode(t *testing.T) {
+	r := &BlueprintResource{}
+	data := &BlueprintResourceModel{
+		Name:                 types.StringValue("BP"),
+		ActivationConditions: types.StringValue("ANY x"),
+		Components: []ComponentModel{
+			{Identifier: types.StringValue("com.jamf.ddm.disk-management"), Configuration: types.MapNull(types.StringType)},
+		},
+	}
+
+	steps, diags := r.buildSteps(context.Background(), data)
+	if diags.HasError() {
+		t.Fatalf("unexpected diagnostics: %v", diags)
+	}
+	if len(steps) != 1 {
+		t.Fatalf("expected 1 flat step, got %d", len(steps))
+	}
+	if steps[0].Name == nil || *steps[0].Name != flatStepName {
+		t.Errorf("expected flat step name %q, got %v", flatStepName, steps[0].Name)
+	}
+	if steps[0].ActivationPredicate == nil || *steps[0].ActivationPredicate != "ANY x" {
+		t.Errorf("expected flat step activation predicate 'ANY x', got %v", steps[0].ActivationPredicate)
+	}
+}
+
+// --- Dual-mode read (state) ---
+
+func TestUpdateModelFromAPIResponse_BlockMode(t *testing.T) {
+	ctx := context.Background()
+	model := &BlueprintResourceModel{} // empty prior → block mode
+	blueprint := &blueprints.BlueprintDetail{
+		DeploymentState: &blueprints.DeploymentState{State: "DEPLOYED"},
+		Steps: []blueprints.BlueprintStep{
+			{
+				Name:       strptr("Step 1"),
+				Components: []blueprints.Component{{Identifier: "com.jamf.custom.thing", Configuration: json.RawMessage(`{"a":"1"}`)}},
+			},
+			{
+				Name:                strptr("Step 2"),
+				ActivationPredicate: strptr("ANY @status(x) == 'y'"),
+				Components:          []blueprints.Component{{Identifier: "com.jamf.custom.thing", Configuration: json.RawMessage(`{"a":"2"}`)}},
+			},
+		},
+	}
+
+	diags := updateModelFromAPIResponse(ctx, model, blueprint)
+	if diags.HasError() {
+		t.Fatalf("unexpected diagnostics: %v", diags)
+	}
+	if len(model.ComponentBlocks) != 2 {
+		t.Fatalf("expected 2 component blocks, got %d", len(model.ComponentBlocks))
+	}
+	if model.ComponentBlocks[0].Name.ValueString() != "Step 1" {
+		t.Errorf("expected block 0 name 'Step 1', got %q", model.ComponentBlocks[0].Name.ValueString())
+	}
+	if !model.ComponentBlocks[0].ActivationConditions.IsNull() {
+		t.Errorf("expected block 0 activation null, got %q", model.ComponentBlocks[0].ActivationConditions.ValueString())
+	}
+	if model.ComponentBlocks[1].ActivationConditions.ValueString() != "ANY @status(x) == 'y'" {
+		t.Errorf("expected block 1 activation predicate, got %q", model.ComponentBlocks[1].ActivationConditions.ValueString())
+	}
+	// Same non-typed identifier lands in each block's raw_component independently.
+	for i, block := range model.ComponentBlocks {
+		if len(block.Components) != 1 || block.Components[0].Identifier.ValueString() != "com.jamf.custom.thing" {
+			t.Errorf("expected block %d raw component 'com.jamf.custom.thing', got %+v", i, block.Components)
+		}
+	}
+
+	// Flat attributes must be cleared in block mode.
+	if model.Components != nil {
+		t.Error("expected flat raw_component nil in block mode")
+	}
+	if !model.ActivationConditions.IsNull() {
+		t.Error("expected flat activation_conditions null in block mode")
+	}
+}
+
+func TestUpdateModelFromAPIResponse_FlatModeMultiStepWarns(t *testing.T) {
+	ctx := context.Background()
+	model := &BlueprintResourceModel{
+		Components: []ComponentModel{
+			{Identifier: types.StringValue("com.jamf.ddm.disk-management"), Configuration: types.MapNull(types.StringType)},
+		},
+	}
+	blueprint := &blueprints.BlueprintDetail{
+		DeploymentState: &blueprints.DeploymentState{State: "DEPLOYED"},
+		Steps: []blueprints.BlueprintStep{
+			{Components: []blueprints.Component{{Identifier: "com.jamf.ddm.disk-management", Configuration: json.RawMessage(`{"externalStorage":"deny"}`)}}},
+			{Components: []blueprints.Component{{Identifier: "com.jamf.ddm.math-settings", Configuration: json.RawMessage(`{}`)}}},
+		},
+	}
+
+	diags := updateModelFromAPIResponse(ctx, model, blueprint)
+	if diags.HasError() {
+		t.Fatalf("unexpected error diagnostics: %v", diags)
+	}
+	if diags.WarningsCount() == 0 {
+		t.Fatal("expected a migration warning for a multi-step blueprint in flat mode")
+	}
+	found := false
+	for _, d := range diags.Warnings() {
+		if d.Summary() == "Blueprint has multiple component blocks" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected 'Blueprint has multiple component blocks' warning, got %v", diags)
+	}
+	if model.ComponentBlocks != nil {
+		t.Error("flat mode must not populate component_blocks")
+	}
+}
+
+func TestUpdateModelFromAPIResponse_EmptyPriorUsesBlockMode(t *testing.T) {
+	ctx := context.Background()
+	model := &BlueprintResourceModel{}
+	blueprint := &blueprints.BlueprintDetail{
+		DeploymentState: &blueprints.DeploymentState{State: "NOT_DEPLOYED"},
+		Steps: []blueprints.BlueprintStep{
+			{Name: strptr("Only Block"), Components: []blueprints.Component{{Identifier: "com.jamf.custom.x", Configuration: json.RawMessage(`{"k":"v"}`)}}},
+		},
+	}
+
+	updateModelFromAPIResponse(ctx, model, blueprint)
+
+	if len(model.ComponentBlocks) != 1 {
+		t.Fatalf("expected empty prior to read as one block, got %d blocks", len(model.ComponentBlocks))
+	}
+	if model.Components != nil {
+		t.Error("expected flat raw_component nil when reading in block mode")
+	}
+}

--- a/internal/resources/blueprints/blueprint/crud.go
+++ b/internal/resources/blueprints/blueprint/crud.go
@@ -36,19 +36,10 @@ func (r *BlueprintResource) Create(ctx context.Context, req resource.CreateReque
 		return
 	}
 
-	allComponents, diags := r.collectAllComponents(ctx, &data)
+	steps, diags := r.buildSteps(ctx, &data)
 	if diags.HasError() {
 		resp.Diagnostics.Append(diags...)
 		return
-	}
-
-	stepName := "Declaration group"
-	steps := []blueprints.BlueprintStep{
-		{
-			Name:                &stepName,
-			Components:          allComponents,
-			ActivationPredicate: data.ActivationConditions.ValueStringPointer(),
-		},
 	}
 
 	reqBody := &blueprints.CreateBlueprintRequest{
@@ -87,7 +78,7 @@ func (r *BlueprintResource) Create(ctx context.Context, req resource.CreateReque
 		}
 	}
 
-	updateModelFromAPIResponse(ctx, &data, blueprint)
+	resp.Diagnostics.Append(updateModelFromAPIResponse(ctx, &data, blueprint)...)
 
 	resp.Diagnostics.Append(helpers.SetIdentity(ctx, resp.Identity, blueprintIdentityModel{ID: data.ID})...)
 	if resp.Diagnostics.HasError() {
@@ -165,7 +156,7 @@ func (r *BlueprintResource) Read(ctx context.Context, req resource.ReadRequest, 
 		return
 	}
 
-	updateModelFromAPIResponse(ctx, &data, blueprint)
+	resp.Diagnostics.Append(updateModelFromAPIResponse(ctx, &data, blueprint)...)
 
 	resp.Diagnostics.Append(helpers.SetIdentity(ctx, resp.Identity, blueprintIdentityModel{ID: data.ID})...)
 	if resp.Diagnostics.HasError() {
@@ -199,19 +190,10 @@ func (r *BlueprintResource) Update(ctx context.Context, req resource.UpdateReque
 		return
 	}
 
-	allComponents, diags := r.collectAllComponents(ctx, &data)
+	steps, diags := r.buildSteps(ctx, &data)
 	if diags.HasError() {
 		resp.Diagnostics.Append(diags...)
 		return
-	}
-
-	stepName := "Declaration group"
-	steps := []blueprints.BlueprintStep{
-		{
-			Name:                &stepName,
-			Components:          allComponents,
-			ActivationPredicate: data.ActivationConditions.ValueStringPointer(),
-		},
 	}
 
 	updateReq := &blueprints.UpdateBlueprintRequest{
@@ -249,7 +231,7 @@ func (r *BlueprintResource) Update(ctx context.Context, req resource.UpdateReque
 		}
 	}
 
-	updateModelFromAPIResponse(ctx, &data, blueprint)
+	resp.Diagnostics.Append(updateModelFromAPIResponse(ctx, &data, blueprint)...)
 
 	resp.Diagnostics.Append(helpers.SetIdentity(ctx, resp.Identity, blueprintIdentityModel{ID: data.ID})...)
 	if resp.Diagnostics.HasError() {

--- a/internal/resources/blueprints/blueprint/data_source.go
+++ b/internal/resources/blueprints/blueprint/data_source.go
@@ -78,12 +78,14 @@ func (d *BlueprintDataSource) Schema(ctx context.Context, req datasource.SchemaR
 				Computed:            true,
 			},
 			"activation_conditions": schema.StringAttribute{
-				MarkdownDescription: "Activation condition expression that further restricts which scoped devices the blueprint applies to. Empty when the blueprint applies to all devices in the targeted device groups.",
+				MarkdownDescription: "Activation condition expression that further restricts which scoped devices the blueprint applies to. Reflects the first component block only; read `component_blocks` for per-block conditions.",
 				Computed:            true,
+				DeprecationMessage:  componentAttrDeprecation,
 			},
 			"component": schema.ListNestedAttribute{
-				MarkdownDescription: "Blueprint components.",
+				MarkdownDescription: "Components of the first component block. Read `component_blocks` for the components of every block.",
 				Computed:            true,
+				DeprecationMessage:  componentAttrDeprecation,
 				NestedObject: schema.NestedAttributeObject{
 					Attributes: map[string]schema.Attribute{
 						"identifier": schema.StringAttribute{
@@ -94,6 +96,39 @@ func (d *BlueprintDataSource) Schema(ctx context.Context, req datasource.SchemaR
 							MarkdownDescription: "Component configuration as a map of key-value pairs.",
 							ElementType:         types.StringType,
 							Computed:            true,
+						},
+					},
+				},
+			},
+			"component_blocks": schema.ListNestedAttribute{
+				MarkdownDescription: "Ordered component blocks of the blueprint. Each block has a name, an optional activation condition, and its own components.",
+				Computed:            true,
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"name": schema.StringAttribute{
+							MarkdownDescription: "Component block name.",
+							Computed:            true,
+						},
+						"activation_conditions": schema.StringAttribute{
+							MarkdownDescription: "Activation condition applied to this block. Empty when the block applies to all devices in scope.",
+							Computed:            true,
+						},
+						"component": schema.ListNestedAttribute{
+							MarkdownDescription: "Components in this block.",
+							Computed:            true,
+							NestedObject: schema.NestedAttributeObject{
+								Attributes: map[string]schema.Attribute{
+									"identifier": schema.StringAttribute{
+										MarkdownDescription: "Component identifier.",
+										Computed:            true,
+									},
+									"configuration": schema.MapAttribute{
+										MarkdownDescription: "Component configuration as a map of key-value pairs.",
+										ElementType:         types.StringType,
+										Computed:            true,
+									},
+								},
+							},
 						},
 					},
 				},
@@ -181,23 +216,16 @@ func (d *BlueprintDataSource) Read(ctx context.Context, req datasource.ReadReque
 
 	var components []ComponentModel
 	if len(bp.Steps) > 0 {
-		step := bp.Steps[0]
-		components = make([]ComponentModel, len(step.Components))
-		for i, comp := range step.Components {
-			configMap := make(map[string]string)
-			if comp.Configuration != nil {
-				var jsonObj map[string]any
-				if err := json.Unmarshal(comp.Configuration, &jsonObj); err == nil {
-					flattenJSON(jsonObj, "", configMap)
-				}
-			}
+		components = flattenStepComponents(bp.Steps[0])
+	}
 
-			configMapValue, _ := types.MapValueFrom(context.Background(), types.StringType, configMap)
-			components[i] = ComponentModel{
-				Identifier:    types.StringValue(comp.Identifier),
-				Configuration: configMapValue,
-			}
-		}
+	componentBlocks := make([]ComponentBlockDataSourceModel, 0, len(bp.Steps))
+	for _, step := range bp.Steps {
+		componentBlocks = append(componentBlocks, ComponentBlockDataSourceModel{
+			Name:                 types.StringValue(helpers.DerefString(step.Name)),
+			ActivationConditions: types.StringValue(helpers.DerefString(step.ActivationPredicate)),
+			Components:           flattenStepComponents(step),
+		})
 	}
 
 	deployState := ""
@@ -217,10 +245,33 @@ func (d *BlueprintDataSource) Read(ctx context.Context, req datasource.ReadReque
 		DeviceGroups:         deviceGroupsList,
 		ActivationConditions: activationConditions,
 		Components:           components,
+		ComponentBlocks:      componentBlocks,
 		Timeouts:             timeoutsValue,
 	}
 
 	tflog.Trace(ctx, "read a data source")
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+// flattenStepComponents converts a wire step's components into the data source's read-only
+// component list (identifier + flattened key/value configuration map).
+func flattenStepComponents(step blueprints.BlueprintStep) []ComponentModel {
+	components := make([]ComponentModel, len(step.Components))
+	for i, comp := range step.Components {
+		configMap := make(map[string]string)
+		if comp.Configuration != nil {
+			var jsonObj map[string]any
+			if err := json.Unmarshal(comp.Configuration, &jsonObj); err == nil {
+				flattenJSON(jsonObj, "", configMap)
+			}
+		}
+
+		configMapValue, _ := types.MapValueFrom(context.Background(), types.StringType, configMap)
+		components[i] = ComponentModel{
+			Identifier:    types.StringValue(comp.Identifier),
+			Configuration: configMapValue,
+		}
+	}
+	return components
 }

--- a/internal/resources/blueprints/blueprint/input_builders.go
+++ b/internal/resources/blueprints/blueprint/input_builders.go
@@ -15,12 +15,62 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
-// collectAllComponents gathers components from both raw and strongly-typed sources.
-func (r *BlueprintResource) collectAllComponents(ctx context.Context, data *BlueprintResourceModel) ([]blueprints.Component, diag.Diagnostics) {
+// flatStepName is the single step name used when a blueprint is authored with the deprecated flat
+// top-level component attributes (no component_blocks).
+const flatStepName = "Declaration group"
+
+// buildSteps converts the model into the ordered SDK steps for a create/update request. In block
+// mode (component_blocks set) it emits one step per block, preserving order, per-block name, and
+// per-block activation condition. In the deprecated flat mode it emits the single "Declaration
+// group" step carrying every top-level component and the top-level activation condition.
+func (r *BlueprintResource) buildSteps(ctx context.Context, data *BlueprintResourceModel) ([]blueprints.BlueprintStep, diag.Diagnostics) {
+	var diags diag.Diagnostics
+	blueprintName := data.Name.ValueString()
+
+	if len(data.ComponentBlocks) > 0 {
+		steps := make([]blueprints.BlueprintStep, 0, len(data.ComponentBlocks))
+		for _, block := range data.ComponentBlocks {
+			components, blockDiags := r.collectBlockComponents(ctx, block)
+			r.collectBlockLegacyPayloads(&components, &blockDiags, block.LegacyPayloads, blueprintName)
+			diags.Append(blockDiags...)
+			if blockDiags.HasError() {
+				continue
+			}
+			steps = append(steps, blueprints.BlueprintStep{
+				Name:                block.Name.ValueStringPointer(),
+				ActivationPredicate: block.ActivationConditions.ValueStringPointer(),
+				Components:          components,
+			})
+		}
+		return steps, diags
+	}
+
+	components, flatDiags := r.collectBlockComponents(ctx, data.flatComponentsAsBlock())
+	if !data.LegacyPayloads.IsNull() && !data.LegacyPayloads.IsUnknown() {
+		r.collectLegacyPayloads(&components, &flatDiags, data.LegacyPayloads, blueprintName)
+	}
+	diags.Append(flatDiags...)
+
+	stepName := flatStepName
+	steps := []blueprints.BlueprintStep{
+		{
+			Name:                &stepName,
+			Components:          components,
+			ActivationPredicate: data.ActivationConditions.ValueStringPointer(),
+		},
+	}
+	return steps, diags
+}
+
+// collectBlockComponents gathers the raw and strongly-typed components of one block into SDK
+// component values. Legacy payloads are collected separately by the caller because the flat
+// (dynamic) and block (JSON-string) shapes differ. The flat top-level authoring style reuses this
+// by passing data.flatComponentsAsBlock(); each entry in component_blocks passes its own carrier.
+func (r *BlueprintResource) collectBlockComponents(ctx context.Context, block ComponentBlockModel) ([]blueprints.Component, diag.Diagnostics) {
 	var allComponents []blueprints.Component
 	var diags diag.Diagnostics
 
-	for _, comp := range data.Components {
+	for _, comp := range block.Components {
 		component := blueprints.Component{
 			Identifier: comp.Identifier.ValueString(),
 		}
@@ -52,63 +102,59 @@ func (r *BlueprintResource) collectAllComponents(ctx context.Context, data *Blue
 		allComponents = append(allComponents, component)
 	}
 
-	r.collectStronglyTypedComponents(&allComponents, &diags, data)
+	r.collectStronglyTypedComponents(&allComponents, &diags, block)
 
 	return allComponents, diags
 }
 
-// collectStronglyTypedComponents processes all strongly-typed components using a scalable approach.
-func (r *BlueprintResource) collectStronglyTypedComponents(allComponents *[]blueprints.Component, diags *diag.Diagnostics, data *BlueprintResourceModel) {
-	if data.AudioAccessorySettings != nil {
-		r.collectSingleComponent(allComponents, diags, data.AudioAccessorySettings, "audio accessory settings")
+// collectStronglyTypedComponents processes all strongly-typed components of a block.
+func (r *BlueprintResource) collectStronglyTypedComponents(allComponents *[]blueprints.Component, diags *diag.Diagnostics, block ComponentBlockModel) {
+	if block.AudioAccessorySettings != nil {
+		r.collectSingleComponent(allComponents, diags, block.AudioAccessorySettings, "audio accessory settings")
 	}
 
-	if data.CustomDeclarations != nil {
-		r.collectSingleComponent(allComponents, diags, data.CustomDeclarations, "custom declarations")
+	if block.CustomDeclarations != nil {
+		r.collectSingleComponent(allComponents, diags, block.CustomDeclarations, "custom declarations")
 	}
 
-	if data.DiskManagementSettings != nil {
-		r.collectSingleComponent(allComponents, diags, data.DiskManagementSettings, "disk management settings")
+	if block.DiskManagementSettings != nil {
+		r.collectSingleComponent(allComponents, diags, block.DiskManagementSettings, "disk management settings")
 	}
 
-	if data.MathSettings != nil {
-		r.collectSingleComponent(allComponents, diags, data.MathSettings, "math settings")
+	if block.MathSettings != nil {
+		r.collectSingleComponent(allComponents, diags, block.MathSettings, "math settings")
 	}
 
-	if data.PasscodePolicy != nil {
-		r.collectSingleComponent(allComponents, diags, data.PasscodePolicy, "passcode policy")
+	if block.PasscodePolicy != nil {
+		r.collectSingleComponent(allComponents, diags, block.PasscodePolicy, "passcode policy")
 	}
 
-	if data.SafariBookmarks != nil {
-		r.collectSingleComponent(allComponents, diags, data.SafariBookmarks, "safari bookmarks")
+	if block.SafariBookmarks != nil {
+		r.collectSingleComponent(allComponents, diags, block.SafariBookmarks, "safari bookmarks")
 	}
 
-	if data.SafariExtensions != nil {
-		r.collectSingleComponent(allComponents, diags, data.SafariExtensions, "safari extensions")
+	if block.SafariExtensions != nil {
+		r.collectSingleComponent(allComponents, diags, block.SafariExtensions, "safari extensions")
 	}
 
-	if data.SafariSettings != nil {
-		r.collectSingleComponent(allComponents, diags, data.SafariSettings, "safari settings")
+	if block.SafariSettings != nil {
+		r.collectSingleComponent(allComponents, diags, block.SafariSettings, "safari settings")
 	}
 
-	if data.ServiceBackgroundTasks != nil {
-		r.collectSingleComponent(allComponents, diags, data.ServiceBackgroundTasks, "service background tasks")
+	if block.ServiceBackgroundTasks != nil {
+		r.collectSingleComponent(allComponents, diags, block.ServiceBackgroundTasks, "service background tasks")
 	}
 
-	if data.ServiceConfigurationFiles != nil {
-		r.collectSingleComponent(allComponents, diags, data.ServiceConfigurationFiles, "service configuration files")
+	if block.ServiceConfigurationFiles != nil {
+		r.collectSingleComponent(allComponents, diags, block.ServiceConfigurationFiles, "service configuration files")
 	}
 
-	if data.SoftwareUpdate != nil {
-		r.collectSingleComponent(allComponents, diags, data.SoftwareUpdate, "software update")
+	if block.SoftwareUpdate != nil {
+		r.collectSingleComponent(allComponents, diags, block.SoftwareUpdate, "software update")
 	}
 
-	if data.SoftwareUpdateSettings != nil {
-		r.collectSingleComponent(allComponents, diags, data.SoftwareUpdateSettings, "software update settings")
-	}
-
-	if !data.LegacyPayloads.IsNull() && !data.LegacyPayloads.IsUnknown() {
-		r.collectLegacyPayloads(allComponents, diags, data.LegacyPayloads, data.Name.ValueString())
+	if block.SoftwareUpdateSettings != nil {
+		r.collectSingleComponent(allComponents, diags, block.SoftwareUpdateSettings, "software update settings")
 	}
 }
 
@@ -122,7 +168,15 @@ func (r *BlueprintResource) collectSingleComponent(allComponents *[]blueprints.C
 	*allComponents = append(*allComponents, *clientComp)
 }
 
-// collectLegacyPayloads builds the API component from a dynamic legacy payloads value.
+// legacyPayloadEntry is one legacy payload flattened to its payload type and settings map, the
+// common shape both the flat (dynamic) and block (JSON-string) legacy collectors reduce to.
+type legacyPayloadEntry struct {
+	PayloadType string
+	Settings    map[string]any
+}
+
+// collectLegacyPayloads builds the legacy configuration profile component from the deprecated
+// dynamic top-level legacy_payloads value.
 func (r *BlueprintResource) collectLegacyPayloads(allComponents *[]blueprints.Component, diags *diag.Diagnostics, legacyPayloads types.Dynamic, blueprintName string) {
 	raw, err := helpers.TerraformDynamicToJSON(legacyPayloads)
 	if err != nil {
@@ -136,8 +190,7 @@ func (r *BlueprintResource) collectLegacyPayloads(allComponents *[]blueprints.Co
 		return
 	}
 
-	seenPayloadTypes := make(map[string]bool, len(items))
-	payloadArray := make([]map[string]any, 0, len(items))
+	entries := make([]legacyPayloadEntry, 0, len(items))
 	for _, item := range items {
 		obj, ok := item.(map[string]any)
 		if !ok {
@@ -146,32 +199,72 @@ func (r *BlueprintResource) collectLegacyPayloads(allComponents *[]blueprints.Co
 		}
 
 		payloadType, _ := obj["payload_type"].(string)
-		if payloadType == "" {
+		entry := legacyPayloadEntry{PayloadType: payloadType}
+		if settings, exists := obj["settings"]; exists {
+			if settingsMap, ok := settings.(map[string]any); ok {
+				entry.Settings = settingsMap
+			}
+		}
+		entries = append(entries, entry)
+	}
+
+	r.appendLegacyConfigProfile(allComponents, diags, entries, blueprintName)
+}
+
+// collectBlockLegacyPayloads builds the legacy configuration profile component from a block's
+// legacy_payloads list, whose settings arrive as JSON object strings.
+func (r *BlueprintResource) collectBlockLegacyPayloads(allComponents *[]blueprints.Component, diags *diag.Diagnostics, payloads []BlockLegacyPayloadModel, blueprintName string) {
+	if len(payloads) == 0 {
+		return
+	}
+
+	entries := make([]legacyPayloadEntry, 0, len(payloads))
+	for _, payload := range payloads {
+		entry := legacyPayloadEntry{PayloadType: payload.PayloadType.ValueString()}
+		if helpers.IsConfiguredValue(payload.Settings) && payload.Settings.ValueString() != "" {
+			var settingsMap map[string]any
+			if err := json.Unmarshal([]byte(payload.Settings.ValueString()), &settingsMap); err != nil {
+				diags.AddError(
+					"Invalid legacy payload settings",
+					"settings for payload_type "+entry.PayloadType+" must be a JSON object string (use jsonencode): "+err.Error(),
+				)
+				return
+			}
+			entry.Settings = settingsMap
+		}
+		entries = append(entries, entry)
+	}
+
+	r.appendLegacyConfigProfile(allComponents, diags, entries, blueprintName)
+}
+
+// appendLegacyConfigProfile assembles the shared com.jamf.ddm-configuration-profile component from
+// the flattened legacy payload entries and appends it. It rejects a missing payload type or a
+// duplicate payload type.
+func (r *BlueprintResource) appendLegacyConfigProfile(allComponents *[]blueprints.Component, diags *diag.Diagnostics, entries []legacyPayloadEntry, blueprintName string) {
+	seenPayloadTypes := make(map[string]bool, len(entries))
+	payloadArray := make([]map[string]any, 0, len(entries))
+	for _, entry := range entries {
+		if entry.PayloadType == "" {
 			diags.AddError("Missing payload_type", "Each legacy payload must include a payload_type key.")
 			return
 		}
 
-		if seenPayloadTypes[payloadType] {
+		if seenPayloadTypes[entry.PayloadType] {
 			diags.AddError(
 				"Duplicate payload_type",
-				"Legacy payloads must not contain duplicate payload types. Found duplicate: "+payloadType,
+				"Legacy payloads must not contain duplicate payload types. Found duplicate: "+entry.PayloadType,
 			)
 			return
 		}
-		seenPayloadTypes[payloadType] = true
+		seenPayloadTypes[entry.PayloadType] = true
 
-		entry := map[string]any{
-			"payloadType":       payloadType,
-			"payloadIdentifier": generatePayloadIdentifier(payloadType),
+		payload := map[string]any{
+			"payloadType":       entry.PayloadType,
+			"payloadIdentifier": generatePayloadIdentifier(entry.PayloadType),
 		}
-
-		if settings, exists := obj["settings"]; exists {
-			if settingsMap, ok := settings.(map[string]any); ok {
-				maps.Copy(entry, settingsMap)
-			}
-		}
-
-		payloadArray = append(payloadArray, entry)
+		maps.Copy(payload, entry.Settings)
+		payloadArray = append(payloadArray, payload)
 	}
 
 	config := map[string]any{

--- a/internal/resources/blueprints/blueprint/list_resource.go
+++ b/internal/resources/blueprints/blueprint/list_resource.go
@@ -143,7 +143,7 @@ func (r *BlueprintListResource) List(ctx context.Context, req list.ListRequest, 
 			}
 
 			var state BlueprintResourceModel
-			updateModelFromAPIResponse(ctx, &state, detail)
+			result.Diagnostics.Append(updateModelFromAPIResponse(ctx, &state, detail)...)
 			result.Diagnostics.Append(result.Resource.Set(ctx, &state)...)
 		}
 

--- a/internal/resources/blueprints/blueprint/model_types.go
+++ b/internal/resources/blueprints/blueprint/model_types.go
@@ -18,6 +18,7 @@ type BlueprintResourceModel struct {
 	Deployed                  types.Bool                                     `tfsdk:"deployed"`
 	DeviceGroups              types.Set                                      `tfsdk:"device_groups"`
 	ActivationConditions      types.String                                   `tfsdk:"activation_conditions"`
+	ComponentBlocks           []ComponentBlockModel                          `tfsdk:"component_blocks"`
 	Components                []ComponentModel                               `tfsdk:"raw_component"`
 	AudioAccessorySettings    *components.AudioAccessorySettingsComponent    `tfsdk:"audio_accessory_settings"`
 	CustomDeclarations        *components.CustomDeclarationsComponent        `tfsdk:"custom_declarations"`
@@ -40,23 +41,122 @@ type BlueprintResourceModel struct {
 
 // BlueprintDataSourceModel defines the data structure for the blueprint data source.
 type BlueprintDataSourceModel struct {
-	ID                   types.String             `tfsdk:"id"`
-	Name                 types.String             `tfsdk:"name"`
-	BlueprintID          types.String             `tfsdk:"blueprint_id"`
-	Description          types.String             `tfsdk:"description"`
-	Created              types.String             `tfsdk:"created"`
-	Updated              types.String             `tfsdk:"updated"`
-	DeploymentState      types.String             `tfsdk:"deployment_state"`
-	DeviceGroups         types.List               `tfsdk:"device_groups"`
-	ActivationConditions types.String             `tfsdk:"activation_conditions"`
-	Components           []ComponentModel         `tfsdk:"component"`
-	Timeouts             datasourceTimeouts.Value `tfsdk:"timeouts"`
+	ID                   types.String                    `tfsdk:"id"`
+	Name                 types.String                    `tfsdk:"name"`
+	BlueprintID          types.String                    `tfsdk:"blueprint_id"`
+	Description          types.String                    `tfsdk:"description"`
+	Created              types.String                    `tfsdk:"created"`
+	Updated              types.String                    `tfsdk:"updated"`
+	DeploymentState      types.String                    `tfsdk:"deployment_state"`
+	DeviceGroups         types.List                      `tfsdk:"device_groups"`
+	ActivationConditions types.String                    `tfsdk:"activation_conditions"`
+	Components           []ComponentModel                `tfsdk:"component"`
+	ComponentBlocks      []ComponentBlockDataSourceModel `tfsdk:"component_blocks"`
+	Timeouts             datasourceTimeouts.Value        `tfsdk:"timeouts"`
+}
+
+// ComponentBlockDataSourceModel is one ordered component block in the data source read model.
+type ComponentBlockDataSourceModel struct {
+	Name                 types.String     `tfsdk:"name"`
+	ActivationConditions types.String     `tfsdk:"activation_conditions"`
+	Components           []ComponentModel `tfsdk:"component"`
 }
 
 // ComponentModel defines the data structure for a blueprint component.
 type ComponentModel struct {
 	Identifier    types.String `tfsdk:"identifier"`
 	Configuration types.Map    `tfsdk:"configuration"`
+}
+
+// ComponentBlockModel represents one ordered component block ("Step N" in the Jamf UI): a named
+// group with its own activation condition and its own set of components. It doubles as the
+// framework-free carrier the input collector and state mapper read/write for both block mode and
+// the deprecated flat mode (flat mode leaves Name and ActivationConditions unset).
+type ComponentBlockModel struct {
+	Name                      types.String                                   `tfsdk:"name"`
+	ActivationConditions      types.String                                   `tfsdk:"activation_conditions"`
+	Components                []ComponentModel                               `tfsdk:"raw_component"`
+	AudioAccessorySettings    *components.AudioAccessorySettingsComponent    `tfsdk:"audio_accessory_settings"`
+	CustomDeclarations        *components.CustomDeclarationsComponent        `tfsdk:"custom_declarations"`
+	DiskManagementSettings    *components.DiskManagementPolicyComponent      `tfsdk:"disk_management_settings"`
+	MathSettings              *components.MathSettingsComponent              `tfsdk:"math_settings"`
+	PasscodePolicy            *components.PasscodePolicyComponent            `tfsdk:"passcode_policy"`
+	SafariBookmarks           *components.SafariBookmarksComponent           `tfsdk:"safari_bookmarks"`
+	SafariExtensions          *components.SafariExtensionsComponent          `tfsdk:"safari_extensions"`
+	SafariSettings            *components.SafariSettingsComponent            `tfsdk:"safari_settings"`
+	ServiceBackgroundTasks    *components.ServiceBackgroundTasksComponent    `tfsdk:"service_background_tasks"`
+	ServiceConfigurationFiles *components.ServiceConfigurationFilesComponent `tfsdk:"service_configuration_files"`
+	SoftwareUpdate            *components.SoftwareUpdateComponent            `tfsdk:"software_update"`
+	SoftwareUpdateSettings    *components.SoftwareUpdateSettingsComponent    `tfsdk:"software_update_settings"`
+	LegacyPayloads            []BlockLegacyPayloadModel                      `tfsdk:"legacy_payloads"`
+}
+
+// BlockLegacyPayloadModel is one legacy configuration profile payload inside a component block.
+// The framework forbids a dynamic type inside a collection, so a block carries settings as a
+// JSON-encoded string (author with `jsonencode(...)`) rather than the dynamic shape used by the
+// deprecated top-level legacy_payloads attribute.
+type BlockLegacyPayloadModel struct {
+	PayloadType types.String `tfsdk:"payload_type"`
+	Settings    types.String `tfsdk:"settings"`
+}
+
+// flatComponentsAsBlock gathers the deprecated flat top-level component attributes into a
+// ComponentBlockModel carrier so the shared collector can build the single implicit step. Legacy
+// payloads are not carried here — the flat (dynamic) and block (JSON-string) shapes differ, so each
+// path handles legacy payloads separately.
+func (m *BlueprintResourceModel) flatComponentsAsBlock() ComponentBlockModel {
+	return ComponentBlockModel{
+		Components:                m.Components,
+		AudioAccessorySettings:    m.AudioAccessorySettings,
+		CustomDeclarations:        m.CustomDeclarations,
+		DiskManagementSettings:    m.DiskManagementSettings,
+		MathSettings:              m.MathSettings,
+		PasscodePolicy:            m.PasscodePolicy,
+		SafariBookmarks:           m.SafariBookmarks,
+		SafariExtensions:          m.SafariExtensions,
+		SafariSettings:            m.SafariSettings,
+		ServiceBackgroundTasks:    m.ServiceBackgroundTasks,
+		ServiceConfigurationFiles: m.ServiceConfigurationFiles,
+		SoftwareUpdate:            m.SoftwareUpdate,
+		SoftwareUpdateSettings:    m.SoftwareUpdateSettings,
+	}
+}
+
+// applyFlatComponentsFromBlock scatters a mapped ComponentBlockModel's component fields back into
+// the deprecated flat top-level attributes (flat-mode read path).
+func (m *BlueprintResourceModel) applyFlatComponentsFromBlock(b ComponentBlockModel) {
+	m.Components = b.Components
+	m.AudioAccessorySettings = b.AudioAccessorySettings
+	m.CustomDeclarations = b.CustomDeclarations
+	m.DiskManagementSettings = b.DiskManagementSettings
+	m.MathSettings = b.MathSettings
+	m.PasscodePolicy = b.PasscodePolicy
+	m.SafariBookmarks = b.SafariBookmarks
+	m.SafariExtensions = b.SafariExtensions
+	m.SafariSettings = b.SafariSettings
+	m.ServiceBackgroundTasks = b.ServiceBackgroundTasks
+	m.ServiceConfigurationFiles = b.ServiceConfigurationFiles
+	m.SoftwareUpdate = b.SoftwareUpdate
+	m.SoftwareUpdateSettings = b.SoftwareUpdateSettings
+}
+
+// hasFlatComponents reports whether any deprecated flat top-level component attribute is set.
+// It selects flat-mode vs block-mode on read (see updateModelFromAPIResponse).
+func (m *BlueprintResourceModel) hasFlatComponents() bool {
+	return len(m.Components) > 0 ||
+		m.AudioAccessorySettings != nil ||
+		m.CustomDeclarations != nil ||
+		m.DiskManagementSettings != nil ||
+		m.MathSettings != nil ||
+		m.PasscodePolicy != nil ||
+		m.SafariBookmarks != nil ||
+		m.SafariExtensions != nil ||
+		m.SafariSettings != nil ||
+		m.ServiceBackgroundTasks != nil ||
+		m.ServiceConfigurationFiles != nil ||
+		m.SoftwareUpdate != nil ||
+		m.SoftwareUpdateSettings != nil ||
+		(!m.LegacyPayloads.IsNull() && !m.LegacyPayloads.IsUnknown())
 }
 
 // blueprintIdentityModel defines the resource identity shared with list results.

--- a/internal/resources/blueprints/blueprint/resource.go
+++ b/internal/resources/blueprints/blueprint/resource.go
@@ -13,6 +13,7 @@ import (
 	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/providerdata"
 	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/resources/blueprints/blueprint/components"
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
+	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/setvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -46,6 +47,13 @@ const (
 // uuidRegex matches UUID strings used to validate device group IDs.
 var uuidRegex = regexp.MustCompile(`^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$`)
 
+// PLATFORM-DEPRECATED remove-after=2026-10-22 replaced-by=component_blocks — the flat top-level
+// component attributes (and the top-level activation_conditions) are superseded by named, ordered
+// component_blocks. On or after the date, batch-remove every attribute carrying
+// componentAttrDeprecation plus this const, and land the schema Version bump + UpgradeState. See
+// STYLE_GUIDE "Platform Services Terraform schema deprecation — 90-day window".
+const componentAttrDeprecation = "Deprecated: use `component_blocks` instead. Superseded by named, ordered component blocks; may be removed on or after 2026-10-22."
+
 // NewBlueprintResource returns a new instance of BlueprintResource.
 func NewBlueprintResource() resource.Resource {
 	return &BlueprintResource{}
@@ -58,156 +66,274 @@ func (r *BlueprintResource) Metadata(ctx context.Context, req resource.MetadataR
 
 // Schema returns the Terraform schema for the blueprint resource.
 func (r *BlueprintResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
-	resp.Schema = schema.Schema{
-		Version:             3,
-		MarkdownDescription: "Resource schema for creating and managing Jamf Blueprints. Requires **Blueprints API** access." + resourcePrivileges,
-		Attributes: map[string]schema.Attribute{
-			"id": schema.StringAttribute{
-				MarkdownDescription: "The unique identifier for the blueprint.",
-				Computed:            true,
-				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.UseStateForUnknown(),
-				},
+	attributes := map[string]schema.Attribute{
+		"id": schema.StringAttribute{
+			MarkdownDescription: "The unique identifier for the blueprint.",
+			Computed:            true,
+			PlanModifiers: []planmodifier.String{
+				stringplanmodifier.UseStateForUnknown(),
 			},
-			"name": schema.StringAttribute{
-				MarkdownDescription: "Blueprint name.",
-				Required:            true,
+		},
+		"name": schema.StringAttribute{
+			MarkdownDescription: "Blueprint name.",
+			Required:            true,
+		},
+		"description": schema.StringAttribute{
+			MarkdownDescription: "Blueprint description.",
+			Optional:            true,
+		},
+		"deployed": schema.BoolAttribute{
+			MarkdownDescription: "Whether the blueprint should be deployed. If set to `true`, the provider will deploy the blueprint (and redeploy if it becomes `OUT_OF_DATE`). If set to `false`, the provider will undeploy the blueprint.",
+			Required:            true,
+		},
+		"device_groups": schema.SetAttribute{
+			MarkdownDescription: "Set of device group Platform IDs to target. Specified as a set of strings in UUID format.",
+			Required:            true,
+			ElementType:         types.StringType,
+			Validators: []validator.Set{
+				setvalidator.SizeAtLeast(1),
+				setvalidator.ValueStringsAre(stringvalidator.RegexMatches(
+					uuidRegex,
+					"Each device group ID must be a valid UUID",
+				)),
 			},
-			"description": schema.StringAttribute{
-				MarkdownDescription: "Blueprint description.",
-				Optional:            true,
+		},
+		"activation_conditions": schema.StringAttribute{
+			MarkdownDescription: activationConditionsDescription("the blueprint") +
+				" When using `component_blocks`, set the condition on each block instead of here.",
+			Optional:           true,
+			DeprecationMessage: componentAttrDeprecation,
+			Validators: []validator.String{
+				stringvalidator.LengthAtMost(10000),
 			},
-			"deployed": schema.BoolAttribute{
-				MarkdownDescription: "Whether the blueprint should be deployed. If set to `true`, the provider will deploy the blueprint (and redeploy if it becomes `OUT_OF_DATE`). If set to `false`, the provider will undeploy the blueprint.",
-				Required:            true,
+		},
+		"created": schema.StringAttribute{
+			MarkdownDescription: "Creation timestamp.",
+			Computed:            true,
+		},
+		"updated": schema.StringAttribute{
+			MarkdownDescription: "Last updated timestamp.",
+			Computed:            true,
+		},
+		"deployment_state": schema.StringAttribute{
+			MarkdownDescription: "Current deployment state.",
+			Computed:            true,
+		},
+		"timeouts": timeouts.Attributes(ctx, timeouts.Opts{
+			Create: true,
+			Read:   true,
+			Update: true,
+			Delete: true,
+		}),
+		"legacy_payloads": schema.DynamicAttribute{
+			MarkdownDescription: "Legacy configuration profile payloads as a list of objects. Each object must have a `payload_type` key (Apple reverse-domain identifier, e.g. `com.apple.applicationaccess`) and an optional `settings` object containing the payload key-value pairs. The payload identifier is auto-generated and the display name uses the blueprint name.",
+			Optional:            true,
+			DeprecationMessage:  componentAttrDeprecation,
+		},
+		"component_blocks": schema.ListNestedAttribute{
+			MarkdownDescription: "Ordered list of component blocks. Each block appears as a step in the Jamf Blueprints editor, with its own name, " +
+				"its own activation condition, and its own set of components. Blocks are applied in the order listed. " +
+				"Use `component_blocks` instead of the deprecated top-level component attributes; the two cannot be combined.",
+			Optional: true,
+			Validators: []validator.List{
+				listvalidator.ConflictsWith(flatComponentAttributePaths()...),
 			},
-			"device_groups": schema.SetAttribute{
-				MarkdownDescription: "Set of device group Platform IDs to target. Specified as a set of strings in UUID format.",
-				Required:            true,
-				ElementType:         types.StringType,
-				Validators: []validator.Set{
-					setvalidator.SizeAtLeast(1),
-					setvalidator.ValueStringsAre(stringvalidator.RegexMatches(
-						uuidRegex,
-						"Each device group ID must be a valid UUID",
-					)),
-				},
-			},
-			"activation_conditions": schema.StringAttribute{
-				MarkdownDescription: "Optional activation condition expression that further restricts which scoped devices the blueprint applies to. " +
-					"An expression combines a status item, an operator, and a value — using terms such as `@status(...)` and `@property(jamf.device.groups)` " +
-					"with operators like `==`, `!=`, `IN {…}`, `ANY`, `NONE`, `AND`, `OR`, and `NOT`. " +
-					"See the [Activation Condition Expression Reference](https://learn.jamf.com/r/en-US/jamf-pro-blueprints-configuration-guide/Activation_Condition_Expression_Reference) for the full syntax. " +
-					"The simplest way to author one is to build the rule in the **Activation conditions** editor in the Jamf UI, switch to the **Text** view, and copy the expression here. " +
-					"Device groups are referenced by their Platform UUID, so ordinary Terraform interpolation works — reference a managed `jamfplatform_device_group` by its `id` " +
-					"to keep conditions in sync, e.g. `\"ANY @property(jamf.device.groups) IN {'${jamfplatform_device_group.example.id}'}\"`. " +
-					"When omitted, the blueprint applies to all devices in the targeted device groups.",
-				Optional: true,
-				Validators: []validator.String{
-					stringvalidator.LengthAtMost(10000),
-				},
-			},
-			"created": schema.StringAttribute{
-				MarkdownDescription: "Creation timestamp.",
-				Computed:            true,
-			},
-			"updated": schema.StringAttribute{
-				MarkdownDescription: "Last updated timestamp.",
-				Computed:            true,
-			},
-			"deployment_state": schema.StringAttribute{
-				MarkdownDescription: "Current deployment state.",
-				Computed:            true,
-			},
-			"legacy_payloads": schema.DynamicAttribute{
-				MarkdownDescription: "Legacy configuration profile payloads as a list of objects. Each object must have a `payload_type` key (Apple reverse-domain identifier, e.g. `com.apple.applicationaccess`) and an optional `settings` object containing the payload key-value pairs. The payload identifier is auto-generated and the display name uses the blueprint name.",
-				Optional:            true,
-			},
-			"timeouts": timeouts.Attributes(ctx, timeouts.Opts{
-				Create: true,
-				Read:   true,
-				Update: true,
-				Delete: true,
-			}),
-			"raw_component": schema.SetNestedAttribute{
-				MarkdownDescription: "Raw component configuration using key-value pairs.",
-				Optional:            true,
-				NestedObject: schema.NestedAttributeObject{
-					Attributes: map[string]schema.Attribute{
-						"identifier": schema.StringAttribute{
-							MarkdownDescription: "Component identifier (e.g., `com.jamf.ddm.disk-management`).",
-							Required:            true,
-						},
-						"configuration": schema.MapAttribute{
-							MarkdownDescription: "Component configuration as key-value pairs. Each component has its own unique configuration options.",
-							Optional:            true,
-							ElementType:         types.StringType,
-						},
-					},
-				},
-			},
-			"audio_accessory_settings": schema.SingleNestedAttribute{
-				MarkdownDescription: "Audio accessory settings component for managing temporary pairing and unpairing policies.",
-				Optional:            true,
-				Attributes:          components.AudioAccessorySettingsComponentSchema(),
-			},
-			"custom_declarations": schema.SingleNestedAttribute{
-				MarkdownDescription: "Custom declarations component for managing custom DDM declarations with system or user channel types.",
-				Optional:            true,
-				Attributes:          components.CustomDeclarationsComponentSchema(),
-			},
-			"disk_management_settings": schema.SingleNestedAttribute{
-				MarkdownDescription: "Disk management settings component for controlling external and network storage restrictions.",
-				Optional:            true,
-				Attributes:          components.DiskManagementPolicyComponentSchema(),
-			},
-			"math_settings": schema.SingleNestedAttribute{
-				MarkdownDescription: "Math settings component for managing calculator modes and system behavior.",
-				Optional:            true,
-				Attributes:          components.MathSettingsComponentSchema(),
-			},
-			"passcode_policy": schema.SingleNestedAttribute{
-				MarkdownDescription: "Passcode policy component for managing device passcode requirements and restrictions.",
-				Optional:            true,
-				Attributes:          components.PasscodePolicyComponentSchema(),
-			},
-			"safari_bookmarks": schema.SingleNestedAttribute{
-				MarkdownDescription: "Safari bookmarks component for managing Safari managed bookmarks and bookmark groups.",
-				Optional:            true,
-				Attributes:          components.SafariBookmarksComponentSchema(),
-			},
-			"safari_extensions": schema.SingleNestedAttribute{
-				MarkdownDescription: "Safari extensions component for managing Safari extension permissions and states.",
-				Optional:            true,
-				Attributes:          components.SafariExtensionsComponentSchema(),
-			},
-			"safari_settings": schema.SingleNestedAttribute{
-				MarkdownDescription: "Safari settings component for managing Safari browser behavior and security settings.",
-				Optional:            true,
-				Attributes:          components.SafariSettingsComponentSchema(),
-			},
-			"service_background_tasks": schema.SingleNestedAttribute{
-				MarkdownDescription: "Service background tasks component for managing background service tasks and launchd configurations.",
-				Optional:            true,
-				Attributes:          components.ServiceBackgroundTasksComponentSchema(),
-			},
-			"service_configuration_files": schema.SingleNestedAttribute{
-				MarkdownDescription: "Service configuration files component for managing configuration files for system services.",
-				Optional:            true,
-				Attributes:          components.ServiceConfigurationFilesComponentSchema(),
-			},
-			"software_update": schema.SingleNestedAttribute{
-				MarkdownDescription: "Software update component for enforcing OS updates on devices.",
-				Optional:            true,
-				Attributes:          components.SoftwareUpdateComponentSchema(),
-			},
-			"software_update_settings": schema.SingleNestedAttribute{
-				MarkdownDescription: "Software update settings component for configuring system update behavior and policies.",
-				Optional:            true,
-				Attributes:          components.SoftwareUpdateSettingsComponentSchema(),
+			NestedObject: schema.NestedAttributeObject{
+				Attributes: componentBlockAttributes(),
 			},
 		},
 	}
+
+	for name, attr := range sharedComponentAttributes(componentAttrDeprecation) {
+		attributes[name] = attr
+	}
+
+	resp.Schema = schema.Schema{
+		Version:             3,
+		MarkdownDescription: "Resource schema for creating and managing Jamf Blueprints. Requires **Blueprints API** access." + resourcePrivileges,
+		Attributes:          attributes,
+	}
+}
+
+// activationConditionsDescription returns the shared MarkdownDescription for an activation-condition
+// field, parameterised by what the condition applies to ("the blueprint" or "this block").
+func activationConditionsDescription(appliesTo string) string {
+	return "Optional activation condition expression that further restricts which scoped devices " + appliesTo + " applies to. " +
+		"An expression combines a status item, an operator, and a value — using terms such as `@status(...)` and `@property(jamf.device.groups)` " +
+		"with operators like `==`, `!=`, `IN {…}`, `ANY`, `NONE`, `AND`, `OR`, and `NOT`. " +
+		"See the [Activation Condition Expression Reference](https://learn.jamf.com/r/en-US/jamf-pro-blueprints-configuration-guide/Activation_Condition_Expression_Reference) for the full syntax. " +
+		"The simplest way to author one is to build the rule in the **Activation conditions** editor in the Jamf UI, switch to the **Text** view, and copy the expression here. " +
+		"Device groups are referenced by their Platform UUID, so ordinary Terraform interpolation works — reference a managed `jamfplatform_device_group` by its `id` " +
+		"to keep conditions in sync, e.g. `\"ANY @property(jamf.device.groups) IN {'${jamfplatform_device_group.example.id}'}\"`. " +
+		"When omitted, " + appliesTo + " applies to all devices in the targeted device groups."
+}
+
+// sharedComponentAttributes returns the component attribute set shared by the deprecated flat
+// top-level schema and each component block — the strongly-typed components plus raw_component, all
+// of which the framework allows inside a collection. legacy_payloads is NOT included: it is a
+// dynamic type at the top level (illegal inside a collection), so each caller supplies its own
+// legacy_payloads shape. Passing a non-empty deprecation string marks every entry Deprecated (the
+// flat top-level use); the block passes "" so the same attributes are current there.
+func sharedComponentAttributes(deprecation string) map[string]schema.Attribute {
+	return map[string]schema.Attribute{
+		"raw_component": schema.SetNestedAttribute{
+			MarkdownDescription: "Raw component configuration using key-value pairs.",
+			Optional:            true,
+			DeprecationMessage:  deprecation,
+			NestedObject: schema.NestedAttributeObject{
+				Attributes: map[string]schema.Attribute{
+					"identifier": schema.StringAttribute{
+						MarkdownDescription: "Component identifier (e.g., `com.jamf.ddm.disk-management`).",
+						Required:            true,
+					},
+					"configuration": schema.MapAttribute{
+						MarkdownDescription: "Component configuration as key-value pairs. Each component has its own unique configuration options.",
+						Optional:            true,
+						ElementType:         types.StringType,
+					},
+				},
+			},
+		},
+		"audio_accessory_settings": schema.SingleNestedAttribute{
+			MarkdownDescription: "Audio accessory settings component for managing temporary pairing and unpairing policies.",
+			Optional:            true,
+			DeprecationMessage:  deprecation,
+			Attributes:          components.AudioAccessorySettingsComponentSchema(),
+		},
+		"custom_declarations": schema.SingleNestedAttribute{
+			MarkdownDescription: "Custom declarations component for managing custom DDM declarations with system or user channel types.",
+			Optional:            true,
+			DeprecationMessage:  deprecation,
+			Attributes:          components.CustomDeclarationsComponentSchema(),
+		},
+		"disk_management_settings": schema.SingleNestedAttribute{
+			MarkdownDescription: "Disk management settings component for controlling external and network storage restrictions.",
+			Optional:            true,
+			DeprecationMessage:  deprecation,
+			Attributes:          components.DiskManagementPolicyComponentSchema(),
+		},
+		"math_settings": schema.SingleNestedAttribute{
+			MarkdownDescription: "Math settings component for managing calculator modes and system behavior.",
+			Optional:            true,
+			DeprecationMessage:  deprecation,
+			Attributes:          components.MathSettingsComponentSchema(),
+		},
+		"passcode_policy": schema.SingleNestedAttribute{
+			MarkdownDescription: "Passcode policy component for managing device passcode requirements and restrictions.",
+			Optional:            true,
+			DeprecationMessage:  deprecation,
+			Attributes:          components.PasscodePolicyComponentSchema(),
+		},
+		"safari_bookmarks": schema.SingleNestedAttribute{
+			MarkdownDescription: "Safari bookmarks component for managing Safari managed bookmarks and bookmark groups.",
+			Optional:            true,
+			DeprecationMessage:  deprecation,
+			Attributes:          components.SafariBookmarksComponentSchema(),
+		},
+		"safari_extensions": schema.SingleNestedAttribute{
+			MarkdownDescription: "Safari extensions component for managing Safari extension permissions and states.",
+			Optional:            true,
+			DeprecationMessage:  deprecation,
+			Attributes:          components.SafariExtensionsComponentSchema(),
+		},
+		"safari_settings": schema.SingleNestedAttribute{
+			MarkdownDescription: "Safari settings component for managing Safari browser behavior and security settings.",
+			Optional:            true,
+			DeprecationMessage:  deprecation,
+			Attributes:          components.SafariSettingsComponentSchema(),
+		},
+		"service_background_tasks": schema.SingleNestedAttribute{
+			MarkdownDescription: "Service background tasks component for managing background service tasks and launchd configurations.",
+			Optional:            true,
+			DeprecationMessage:  deprecation,
+			Attributes:          components.ServiceBackgroundTasksComponentSchema(),
+		},
+		"service_configuration_files": schema.SingleNestedAttribute{
+			MarkdownDescription: "Service configuration files component for managing configuration files for system services.",
+			Optional:            true,
+			DeprecationMessage:  deprecation,
+			Attributes:          components.ServiceConfigurationFilesComponentSchema(),
+		},
+		"software_update": schema.SingleNestedAttribute{
+			MarkdownDescription: "Software update component for enforcing OS updates on devices.",
+			Optional:            true,
+			DeprecationMessage:  deprecation,
+			Attributes:          components.SoftwareUpdateComponentSchema(),
+		},
+		"software_update_settings": schema.SingleNestedAttribute{
+			MarkdownDescription: "Software update settings component for configuring system update behavior and policies.",
+			Optional:            true,
+			DeprecationMessage:  deprecation,
+			Attributes:          components.SoftwareUpdateSettingsComponentSchema(),
+		},
+	}
+}
+
+// componentBlockAttributes returns the schema attributes for one component block: block metadata
+// (name, per-block activation condition) plus the shared, non-deprecated component set.
+func componentBlockAttributes() map[string]schema.Attribute {
+	attributes := map[string]schema.Attribute{
+		"name": schema.StringAttribute{
+			MarkdownDescription: "Name shown for this component block in the Jamf Blueprints editor (e.g. `Passcode Policy`). When omitted, Jamf assigns a default name.",
+			Optional:            true,
+		},
+		"activation_conditions": schema.StringAttribute{
+			MarkdownDescription: activationConditionsDescription("this block"),
+			Optional:            true,
+			Validators: []validator.String{
+				stringvalidator.LengthAtMost(10000),
+			},
+		},
+		"legacy_payloads": schema.ListNestedAttribute{
+			MarkdownDescription: "Legacy configuration profile payloads in this block. The payload identifier is auto-generated and the display name uses the blueprint name.",
+			Optional:            true,
+			NestedObject: schema.NestedAttributeObject{
+				Attributes: map[string]schema.Attribute{
+					"payload_type": schema.StringAttribute{
+						MarkdownDescription: "Apple reverse-domain payload identifier, e.g. `com.apple.applicationaccess`.",
+						Required:            true,
+					},
+					"settings": schema.StringAttribute{
+						MarkdownDescription: "Payload key-value settings as a JSON object string. Author with `jsonencode({ ... })`.",
+						Optional:            true,
+					},
+				},
+			},
+		},
+	}
+
+	for name, attr := range sharedComponentAttributes("") {
+		attributes[name] = attr
+	}
+
+	return attributes
+}
+
+// flatComponentAttributePaths lists the root paths of the deprecated flat component attributes,
+// used to make `component_blocks` mutually exclusive with the flat top-level authoring style.
+func flatComponentAttributePaths() []path.Expression {
+	names := []string{
+		"activation_conditions",
+		"legacy_payloads",
+		"raw_component",
+		"audio_accessory_settings",
+		"custom_declarations",
+		"disk_management_settings",
+		"math_settings",
+		"passcode_policy",
+		"safari_bookmarks",
+		"safari_extensions",
+		"safari_settings",
+		"service_background_tasks",
+		"service_configuration_files",
+		"software_update",
+		"software_update_settings",
+	}
+	paths := make([]path.Expression, 0, len(names))
+	for _, name := range names {
+		paths = append(paths, path.MatchRoot(name))
+	}
+	return paths
 }
 
 // IdentitySchema defines the blueprint identity used across CRUD and list.

--- a/internal/resources/blueprints/blueprint/resource_acceptance_test.go
+++ b/internal/resources/blueprints/blueprint/resource_acceptance_test.go
@@ -99,16 +99,24 @@ func TestAccResource_Blueprint_CreateAndUpdate(t *testing.T) {
 						deployed      = false
 						device_groups = [jamfplatform_device_group.scope.id]
 
-						passcode_policy = {
-							require_passcode = true
-							minimum_length   = 6
-						}
+						component_blocks = [
+							{
+								name = "Passcode Policy"
+								passcode_policy = {
+									require_passcode = true
+									minimum_length   = 6
+								}
+							},
+						]
 					}
 				`, name)),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet("jamfplatform_blueprints_blueprint.test_update", "id"),
 					resource.TestCheckResourceAttr("jamfplatform_blueprints_blueprint.test_update", "name", name),
 					resource.TestCheckResourceAttr("jamfplatform_blueprints_blueprint.test_update", "deployed", "false"),
+					resource.TestCheckResourceAttr("jamfplatform_blueprints_blueprint.test_update", "component_blocks.#", "1"),
+					resource.TestCheckResourceAttr("jamfplatform_blueprints_blueprint.test_update", "component_blocks.0.name", "Passcode Policy"),
+					resource.TestCheckResourceAttr("jamfplatform_blueprints_blueprint.test_update", "component_blocks.0.passcode_policy.minimum_length", "6"),
 				),
 			},
 			{
@@ -119,25 +127,30 @@ func TestAccResource_Blueprint_CreateAndUpdate(t *testing.T) {
 						deployed      = false
 						device_groups = [jamfplatform_device_group.scope.id]
 
-						passcode_policy = {
-							require_passcode = true
-							minimum_length   = 8
-						}
+						component_blocks = [
+							{
+								name = "Passcode Policy"
+								passcode_policy = {
+									require_passcode = true
+									minimum_length   = 8
+								}
+							},
+						]
 					}
 				`, nameRenamed)),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("jamfplatform_blueprints_blueprint.test_update", "name", nameRenamed),
 					resource.TestCheckResourceAttr("jamfplatform_blueprints_blueprint.test_update", "description", "Updated description"),
+					resource.TestCheckResourceAttr("jamfplatform_blueprints_blueprint.test_update", "component_blocks.0.passcode_policy.minimum_length", "8"),
 				),
 			},
 		},
 	})
 }
 
-// checkActivationConditionsContainGroupID verifies the blueprint's
-// activation_conditions expression embeds the managed device group's ID verbatim,
-// proving Terraform interpolation of a device-group reference round-trips through
-// the API.
+// checkActivationConditionsContainGroupID verifies the first block's activation_conditions
+// expression embeds the managed device group's ID verbatim, proving Terraform interpolation of a
+// device-group reference round-trips through the API.
 func checkActivationConditionsContainGroupID(blueprintRes, groupRes string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		group, ok := s.RootModule().Resources[groupRes]
@@ -149,9 +162,9 @@ func checkActivationConditionsContainGroupID(blueprintRes, groupRes string) reso
 			return fmt.Errorf("blueprint resource %q not found in state", blueprintRes)
 		}
 		groupID := group.Primary.ID
-		conditions := blueprint.Primary.Attributes["activation_conditions"]
+		conditions := blueprint.Primary.Attributes["component_blocks.0.activation_conditions"]
 		if !strings.Contains(conditions, groupID) {
-			return fmt.Errorf("activation_conditions %q does not contain device group id %q", conditions, groupID)
+			return fmt.Errorf("component_blocks.0.activation_conditions %q does not contain device group id %q", conditions, groupID)
 		}
 		return nil
 	}
@@ -161,14 +174,15 @@ func TestAccResource_Blueprint_ActivationConditions(t *testing.T) {
 	testhelpers.AccPreCheck(t)
 	suffix := testhelpers.RunSuffix()
 	name := "tf-acc-activation-conditions-" + suffix
+	res := "jamfplatform_blueprints_blueprint.test_activation"
 
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testhelpers.AccTestProtoV6ProviderFactories,
 		CheckDestroy:             testAccCheckBlueprintResourcesDestroy(t),
 		Steps: []resource.TestStep{
-			// Step 1: activation_conditions references the managed device group by id via
-			// Terraform interpolation; the resolved expression must round-trip with the
-			// group's UUID embedded verbatim.
+			// Step 1: a block's activation_conditions references the managed device group by id via
+			// Terraform interpolation; the resolved expression must round-trip with the group's UUID
+			// embedded verbatim.
 			{
 				Config: testBlueprintConfig(smartGroupHCL("activation"), fmt.Sprintf(`
 					resource "jamfplatform_blueprints_blueprint" "test_activation" {
@@ -177,30 +191,31 @@ func TestAccResource_Blueprint_ActivationConditions(t *testing.T) {
 						deployed      = false
 						device_groups = [jamfplatform_device_group.scope.id]
 
-						activation_conditions = "ANY @property(jamf.device.groups) IN {'${jamfplatform_device_group.scope.id}'} AND @status(device.model.family) == 'iPad'"
-
-						software_update = {
-							ignore_major_versions = true
-							deployment_time       = "02:00"
-							enforce_after_days    = 7
-						}
+						component_blocks = [
+							{
+								name                  = "Shared iPad Software Updates"
+								activation_conditions = "ANY @property(jamf.device.groups) IN {'${jamfplatform_device_group.scope.id}'} AND @status(device.model.family) == 'iPad'"
+								software_update = {
+									ignore_major_versions = true
+									deployment_time       = "02:00"
+									enforce_after_days    = 7
+								}
+							},
+						]
 					}
 				`, name)),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttrSet("jamfplatform_blueprints_blueprint.test_activation", "id"),
+					resource.TestCheckResourceAttrSet(res, "id"),
 					resource.TestMatchResourceAttr(
-						"jamfplatform_blueprints_blueprint.test_activation",
-						"activation_conditions",
+						res,
+						"component_blocks.0.activation_conditions",
 						regexp.MustCompile(`^ANY @property\(jamf\.device\.groups\) IN \{'[0-9a-fA-F-]{36}'\} AND @status\(device\.model\.family\) == 'iPad'$`),
 					),
-					checkActivationConditionsContainGroupID(
-						"jamfplatform_blueprints_blueprint.test_activation",
-						"jamfplatform_device_group.scope",
-					),
+					checkActivationConditionsContainGroupID(res, "jamfplatform_device_group.scope"),
 				),
 			},
-			// Step 2: replace with a static expression; verifies the update path round-trips
-			// the value byte-for-byte (no server-side normalization).
+			// Step 2: replace with a static expression; verifies the update path round-trips the
+			// value byte-for-byte (no server-side normalization).
 			{
 				Config: testBlueprintConfig(smartGroupHCL("activation"), fmt.Sprintf(`
 					resource "jamfplatform_blueprints_blueprint" "test_activation" {
@@ -209,24 +224,24 @@ func TestAccResource_Blueprint_ActivationConditions(t *testing.T) {
 						deployed      = false
 						device_groups = [jamfplatform_device_group.scope.id]
 
-						activation_conditions = "@status(device.model.family) == 'iPad'"
-
-						software_update = {
-							ignore_major_versions = true
-							deployment_time       = "02:00"
-							enforce_after_days    = 7
-						}
+						component_blocks = [
+							{
+								name                  = "Shared iPad Software Updates"
+								activation_conditions = "@status(device.model.family) == 'iPad'"
+								software_update = {
+									ignore_major_versions = true
+									deployment_time       = "02:00"
+									enforce_after_days    = 7
+								}
+							},
+						]
 					}
 				`, name)),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr(
-						"jamfplatform_blueprints_blueprint.test_activation",
-						"activation_conditions",
-						"@status(device.model.family) == 'iPad'",
-					),
+					resource.TestCheckResourceAttr(res, "component_blocks.0.activation_conditions", "@status(device.model.family) == 'iPad'"),
 				),
 			},
-			// Step 3: drop activation_conditions entirely; it must clear back to null.
+			// Step 3: drop the block's activation_conditions entirely; it must clear back to null.
 			{
 				Config: testBlueprintConfig(smartGroupHCL("activation"), fmt.Sprintf(`
 					resource "jamfplatform_blueprints_blueprint" "test_activation" {
@@ -235,18 +250,20 @@ func TestAccResource_Blueprint_ActivationConditions(t *testing.T) {
 						deployed      = false
 						device_groups = [jamfplatform_device_group.scope.id]
 
-						software_update = {
-							ignore_major_versions = true
-							deployment_time       = "02:00"
-							enforce_after_days    = 7
-						}
+						component_blocks = [
+							{
+								name = "Shared iPad Software Updates"
+								software_update = {
+									ignore_major_versions = true
+									deployment_time       = "02:00"
+									enforce_after_days    = 7
+								}
+							},
+						]
 					}
 				`, name)),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckNoResourceAttr(
-						"jamfplatform_blueprints_blueprint.test_activation",
-						"activation_conditions",
-					),
+					resource.TestCheckNoResourceAttr(res, "component_blocks.0.activation_conditions"),
 				),
 			},
 		},
@@ -270,17 +287,23 @@ func TestAccResource_Blueprint_PasscodePolicy(t *testing.T) {
 						deployed      = false
 						device_groups = [jamfplatform_device_group.scope.id]
 
-						passcode_policy = {
-							require_passcode     = true
-							minimum_length       = 8
-							maximum_failed_attempts = 5
-							maximum_inactivity_in_minutes = 10
-						}
+						component_blocks = [
+							{
+								name = "Passcode Policy"
+								passcode_policy = {
+									require_passcode              = true
+									minimum_length                = 8
+									maximum_failed_attempts       = 5
+									maximum_inactivity_in_minutes = 10
+								}
+							},
+						]
 					}
 				`, name)),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet("jamfplatform_blueprints_blueprint.test_passcode", "id"),
 					resource.TestCheckResourceAttr("jamfplatform_blueprints_blueprint.test_passcode", "name", name),
+					resource.TestCheckResourceAttr("jamfplatform_blueprints_blueprint.test_passcode", "component_blocks.0.passcode_policy.minimum_length", "8"),
 				),
 			},
 		},
@@ -304,21 +327,27 @@ func TestAccResource_Blueprint_MathSettings(t *testing.T) {
 						deployed      = false
 						device_groups = [jamfplatform_device_group.scope.id]
 
-						math_settings = {
-							calculator_basic_mode_add_square_root = true
-							calculator_scientific_mode_enabled    = true
-							calculator_programmer_mode_enabled    = false
-							calculator_math_notes_mode_enabled    = true
-							calculator_input_modes_unit_conversion = true
-							calculator_input_modes_rpn             = false
-							system_behavior_keyboard_suggestions   = true
-							system_behavior_math_notes             = true
-						}
+						component_blocks = [
+							{
+								name = "Math Settings"
+								math_settings = {
+									calculator_basic_mode_add_square_root  = true
+									calculator_scientific_mode_enabled     = true
+									calculator_programmer_mode_enabled     = false
+									calculator_math_notes_mode_enabled     = true
+									calculator_input_modes_unit_conversion = true
+									calculator_input_modes_rpn             = false
+									system_behavior_keyboard_suggestions   = true
+									system_behavior_math_notes             = true
+								}
+							},
+						]
 					}
 				`, name)),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet("jamfplatform_blueprints_blueprint.test_math", "id"),
 					resource.TestCheckResourceAttr("jamfplatform_blueprints_blueprint.test_math", "name", name),
+					resource.TestCheckResourceAttr("jamfplatform_blueprints_blueprint.test_math", "component_blocks.0.math_settings.calculator_scientific_mode_enabled", "true"),
 				),
 			},
 		},
@@ -342,16 +371,22 @@ func TestAccResource_Blueprint_AudioAccessorySettings(t *testing.T) {
 						deployed      = false
 						device_groups = [jamfplatform_device_group.scope.id]
 
-						audio_accessory_settings = {
-							temporary_pairing_disabled = true
-							unpairing_time_policy      = "Hour"
-							unpairing_time_hour        = 14
-						}
+						component_blocks = [
+							{
+								name = "Audio Accessory Settings"
+								audio_accessory_settings = {
+									temporary_pairing_disabled = true
+									unpairing_time_policy      = "Hour"
+									unpairing_time_hour        = 14
+								}
+							},
+						]
 					}
 				`, name)),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet("jamfplatform_blueprints_blueprint.test_audio", "id"),
 					resource.TestCheckResourceAttr("jamfplatform_blueprints_blueprint.test_audio", "name", name),
+					resource.TestCheckResourceAttr("jamfplatform_blueprints_blueprint.test_audio", "component_blocks.0.audio_accessory_settings.unpairing_time_hour", "14"),
 				),
 			},
 		},
@@ -375,10 +410,15 @@ func TestAccResource_Blueprint_DiskManagement(t *testing.T) {
 						deployed      = false
 						device_groups = [jamfplatform_device_group.scope.id]
 
-						disk_management_settings = {
-							external_storage = "ReadOnly"
-							network_storage  = "Disallowed"
-						}
+						component_blocks = [
+							{
+								name = "Disk Management"
+								disk_management_settings = {
+									external_storage = "ReadOnly"
+									network_storage  = "Disallowed"
+								}
+							},
+						]
 					}
 				`, name)),
 				Check: resource.ComposeAggregateTestCheckFunc(
@@ -407,13 +447,18 @@ func TestAccResource_Blueprint_SafariSettings(t *testing.T) {
 						deployed      = false
 						device_groups = [jamfplatform_device_group.scope.id]
 
-						safari_settings = {
-							accept_cookies       = "VisitedWebsites"
-							allow_private_browsing = false
-							allow_javascript       = true
-							allow_popups           = false
-							allow_history_clearing = false
-						}
+						component_blocks = [
+							{
+								name = "Safari Settings"
+								safari_settings = {
+									accept_cookies         = "VisitedWebsites"
+									allow_private_browsing = false
+									allow_javascript       = true
+									allow_popups           = false
+									allow_history_clearing = false
+								}
+							},
+						]
 					}
 				`, name)),
 				Check: resource.ComposeAggregateTestCheckFunc(
@@ -442,20 +487,25 @@ func TestAccResource_Blueprint_SoftwareUpdateSettings(t *testing.T) {
 						deployed      = false
 						device_groups = [jamfplatform_device_group.scope.id]
 
-						software_update_settings = {
-							allow_standard_user_os_updates           = true
-							automatic_download                       = "AlwaysOn"
-							automatic_install_os_updates             = "AlwaysOn"
-							automatic_install_security_updates       = "AlwaysOn"
-							deferral_combined_period_days            = 7
-							deferral_major_period_days               = 30
-							deferral_minor_period_days               = 14
-							deferral_system_period_days              = 3
-							notifications_enabled                    = true
-							rapid_security_response_enabled          = true
-							rapid_security_response_rollback_enabled = false
-							recommended_cadence                      = "Newest"
-						}
+						component_blocks = [
+							{
+								name = "Software Update Settings"
+								software_update_settings = {
+									allow_standard_user_os_updates           = true
+									automatic_download                       = "AlwaysOn"
+									automatic_install_os_updates             = "AlwaysOn"
+									automatic_install_security_updates       = "AlwaysOn"
+									deferral_combined_period_days            = 7
+									deferral_major_period_days               = 30
+									deferral_minor_period_days               = 14
+									deferral_system_period_days              = 3
+									notifications_enabled                    = true
+									rapid_security_response_enabled          = true
+									rapid_security_response_rollback_enabled = false
+									recommended_cadence                      = "Newest"
+								}
+							},
+						]
 					}
 				`, name)),
 				Check: resource.ComposeAggregateTestCheckFunc(
@@ -484,11 +534,16 @@ func TestAccResource_Blueprint_SoftwareUpdate_Automatic(t *testing.T) {
 						deployed      = false
 						device_groups = [jamfplatform_device_group.scope.id]
 
-						software_update = {
-							ignore_major_versions = true
-							deployment_time       = "02:00"
-							enforce_after_days    = 7
-						}
+						component_blocks = [
+							{
+								name = "Latest OS Software Updates"
+								software_update = {
+									ignore_major_versions = true
+									deployment_time       = "02:00"
+									enforce_after_days    = 7
+								}
+							},
+						]
 					}
 				`, name)),
 				Check: resource.ComposeAggregateTestCheckFunc(
@@ -517,14 +572,19 @@ func TestAccResource_Blueprint_LegacyPayloads(t *testing.T) {
 						deployed      = false
 						device_groups = [jamfplatform_device_group.scope.id]
 
-						legacy_payloads = [
+						component_blocks = [
 							{
-								payload_type = "com.apple.applicationaccess"
-								settings = {
-									allowSafariHistoryClearing = false
-									allowSafariPrivateBrowsing = false
-								}
-							}
+								name = "Safari Restrictions"
+								legacy_payloads = [
+									{
+										payload_type = "com.apple.applicationaccess"
+										settings = jsonencode({
+											allowSafariHistoryClearing = false
+											allowSafariPrivateBrowsing = false
+										})
+									}
+								]
+							},
 						]
 					}
 				`, name)),
@@ -537,18 +597,16 @@ func TestAccResource_Blueprint_LegacyPayloads(t *testing.T) {
 	})
 }
 
-// TestAccResource_Blueprint_LegacyPayloads_NullFields_PlanStability is a
-// regression test for issue #282. A legacy payload whose settings contain
-// explicit nulls (here com.apple.notificationsettings) previously produced a
-// perpetual in-place update, and applying that update failed with "Provider
-// produced inconsistent result after apply" on the server-stamped `updated`
-// attribute. Step 1 creates the blueprint; step 2 re-applies the identical
-// config and asserts an empty plan (the dynamic null-typing reconcile); step 3
-// makes a genuine metadata change (description) that forces an in-place update
-// and must apply without an inconsistent-result error (ModifyPlan marks
-// `updated` unknown); step 4 confirms plan stability after that update; step 5
-// makes a genuine change to the payload itself, proving the reconcile surfaces
-// real payload edits rather than masking them; step 6 confirms stability again.
+// TestAccResource_Blueprint_LegacyPayloads_NullFields_PlanStability is a regression test for issue
+// #282, adapted to component_blocks. A legacy payload whose settings contain explicit nulls (here
+// com.apple.notificationsettings) previously produced a perpetual in-place update, and applying that
+// update failed with "Provider produced inconsistent result after apply" on the server-stamped
+// `updated` attribute. Step 1 creates the blueprint; step 2 re-applies the identical config and
+// asserts an empty plan (the dynamic null-typing reconcile); step 3 makes a genuine metadata change
+// (description) that forces an in-place update and must apply without an inconsistent-result error
+// (ModifyPlan marks `updated` unknown); step 4 confirms plan stability after that update; step 5
+// makes a genuine change to the payload itself, proving the reconcile surfaces real payload edits
+// rather than masking them; step 6 confirms stability again.
 func TestAccResource_Blueprint_LegacyPayloads_NullFields_PlanStability(t *testing.T) {
 	testhelpers.AccPreCheck(t)
 	suffix := testhelpers.RunSuffix()
@@ -563,39 +621,44 @@ func TestAccResource_Blueprint_LegacyPayloads_NullFields_PlanStability(t *testin
 				deployed      = false
 				device_groups = [jamfplatform_device_group.scope.id]
 
-				legacy_payloads = [
+				component_blocks = [
 					{
-						payload_type = "com.apple.notificationsettings"
-						settings = {
-							NotificationSettings = [
-								{
-									AlertType                = 0
-									PreviewType              = null
-									GroupingType             = null
-									BadgesEnabled            = null
-									ShowInCarPlay            = null
-									SoundsEnabled            = null
-									BundleIdentifier         = "_SYSTEM_CENTER_:com.apple.followup.alert"
-									ShowInLockScreen         = false
-									CriticalAlertEnabled     = null
-									NotificationsEnabled     = %t
-									ShowInNotificationCenter = false
-								},
-								{
-									AlertType                = 2
-									PreviewType              = null
-									GroupingType             = null
-									BadgesEnabled            = true
-									ShowInCarPlay            = null
-									SoundsEnabled            = true
-									BundleIdentifier         = "au.bartreardon.dialog"
-									ShowInLockScreen         = false
-									CriticalAlertEnabled     = true
-									NotificationsEnabled     = true
-									ShowInNotificationCenter = true
-								},
-							]
-						}
+						name = "Notification Settings"
+						legacy_payloads = [
+							{
+								payload_type = "com.apple.notificationsettings"
+								settings = jsonencode({
+									NotificationSettings = [
+										{
+											AlertType                = 0
+											PreviewType              = null
+											GroupingType             = null
+											BadgesEnabled            = null
+											ShowInCarPlay            = null
+											SoundsEnabled            = null
+											BundleIdentifier         = "_SYSTEM_CENTER_:com.apple.followup.alert"
+											ShowInLockScreen         = false
+											CriticalAlertEnabled     = null
+											NotificationsEnabled     = %t
+											ShowInNotificationCenter = false
+										},
+										{
+											AlertType                = 2
+											PreviewType              = null
+											GroupingType             = null
+											BadgesEnabled            = true
+											ShowInCarPlay            = null
+											SoundsEnabled            = true
+											BundleIdentifier         = "au.bartreardon.dialog"
+											ShowInLockScreen         = false
+											CriticalAlertEnabled     = true
+											NotificationsEnabled     = true
+											ShowInNotificationCenter = true
+										},
+									]
+								})
+							},
+						]
 					},
 				]
 			}
@@ -665,18 +728,23 @@ func TestAccResource_Blueprint_CustomDeclarations(t *testing.T) {
 						deployed      = false
 						device_groups = [jamfplatform_device_group.scope.id]
 
-						custom_declarations = {
-							declaration = [{
-								channel = "SYSTEM"
-								kind    = "CONFIGURATION"
-								type    = "com.apple.configuration.softwareupdate.settings"
-								payload = jsonencode({
-									Beta = {
-										ProgramEnrollment = "AlwaysOff"
-									}
-								})
-							}]
-						}
+						component_blocks = [
+							{
+								name = "Custom Declarations"
+								custom_declarations = {
+									declaration = [{
+										channel = "SYSTEM"
+										kind    = "CONFIGURATION"
+										type    = "com.apple.configuration.softwareupdate.settings"
+										payload = jsonencode({
+											Beta = {
+												ProgramEnrollment = "AlwaysOff"
+											}
+										})
+									}]
+								}
+							},
+						]
 					}
 				`, name)),
 				Check: resource.ComposeAggregateTestCheckFunc(
@@ -705,17 +773,22 @@ func TestAccResource_Blueprint_SafariBookmarks(t *testing.T) {
 						deployed      = false
 						device_groups = [jamfplatform_device_group.scope.id]
 
-						safari_bookmarks = {
-							managed_bookmarks = [{
-								group_identifier = "tf-acc-group-1"
-								title            = "Test Bookmarks"
-								bookmarks = [{
-									type  = "bookmark"
-									title = "Jamf"
-									url   = "https://www.jamf.com"
-								}]
-							}]
-						}
+						component_blocks = [
+							{
+								name = "Safari Bookmarks"
+								safari_bookmarks = {
+									managed_bookmarks = [{
+										group_identifier = "tf-acc-group-1"
+										title            = "Test Bookmarks"
+										bookmarks = [{
+											type  = "bookmark"
+											title = "Jamf"
+											url   = "https://www.jamf.com"
+										}]
+									}]
+								}
+							},
+						]
 					}
 				`, name)),
 				Check: resource.ComposeAggregateTestCheckFunc(
@@ -744,19 +817,70 @@ func TestAccResource_Blueprint_SafariExtensions(t *testing.T) {
 						deployed      = false
 						device_groups = [jamfplatform_device_group.scope.id]
 
-						safari_extensions = {
-							managed_extensions = [{
-								extension_id    = "com.example.test.extension (ABC1234567)"
-								state           = "Allowed"
-								private_browsing = "AlwaysOff"
-							}]
-						}
+						component_blocks = [
+							{
+								name = "Safari Extensions"
+								safari_extensions = {
+									managed_extensions = [{
+										extension_id     = "com.example.test.extension (ABC1234567)"
+										state            = "Allowed"
+										private_browsing = "AlwaysOff"
+									}]
+								}
+							},
+						]
 					}
 				`, name)),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet("jamfplatform_blueprints_blueprint.test_extensions", "id"),
 					resource.TestCheckResourceAttr("jamfplatform_blueprints_blueprint.test_extensions", "name", name),
 				),
+			},
+		},
+	})
+}
+
+// TestAccResource_Blueprint_DeprecatedFlatMode keeps a thin regression on the deprecated top-level
+// authoring style, which continues to function during its removal window (see the
+// PLATFORM-DEPRECATED marker in resource.go). It proves a flat single-component blueprint still
+// applies and reads back cleanly, and that a re-apply is a no-op.
+func TestAccResource_Blueprint_DeprecatedFlatMode(t *testing.T) {
+	testhelpers.AccPreCheck(t)
+	suffix := testhelpers.RunSuffix()
+	name := "tf-acc-flat-deprecated-" + suffix
+	addr := "jamfplatform_blueprints_blueprint.test_flat"
+
+	config := testBlueprintConfig(smartGroupHCL("flat"), fmt.Sprintf(`
+		resource "jamfplatform_blueprints_blueprint" "test_flat" {
+			name          = %q
+			description   = "Acceptance test — safe to delete"
+			deployed      = false
+			device_groups = [jamfplatform_device_group.scope.id]
+
+			passcode_policy = {
+				require_passcode = true
+				minimum_length   = 6
+			}
+		}
+	`, name))
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testhelpers.AccTestProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckBlueprintResourcesDestroy(t),
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet(addr, "id"),
+					resource.TestCheckResourceAttr(addr, "passcode_policy.minimum_length", "6"),
+					resource.TestCheckNoResourceAttr(addr, "component_blocks.#"),
+				),
+			},
+			{
+				Config: config,
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{plancheck.ExpectEmptyPlan()},
+				},
 			},
 		},
 	})
@@ -779,10 +903,15 @@ func TestAccDataSource_Blueprint(t *testing.T) {
 						deployed      = false
 						device_groups = [jamfplatform_device_group.scope.id]
 
-						passcode_policy = {
-							require_passcode = true
-							minimum_length   = 6
-						}
+						component_blocks = [
+							{
+								name = "Passcode Policy"
+								passcode_policy = {
+									require_passcode = true
+									minimum_length   = 6
+								}
+							},
+						]
 					}
 
 					data "jamfplatform_blueprints_blueprint" "test" {
@@ -792,6 +921,9 @@ func TestAccDataSource_Blueprint(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("data.jamfplatform_blueprints_blueprint.test", "name", name),
 					resource.TestCheckResourceAttrSet("data.jamfplatform_blueprints_blueprint.test", "blueprint_id"),
+					resource.TestCheckResourceAttr("data.jamfplatform_blueprints_blueprint.test", "component_blocks.#", "1"),
+					resource.TestCheckResourceAttr("data.jamfplatform_blueprints_blueprint.test", "component_blocks.0.name", "Passcode Policy"),
+					resource.TestCheckResourceAttrSet("data.jamfplatform_blueprints_blueprint.test", "component_blocks.0.component.#"),
 				),
 			},
 		},

--- a/internal/resources/blueprints/blueprint/state_builders.go
+++ b/internal/resources/blueprints/blueprint/state_builders.go
@@ -13,25 +13,21 @@ import (
 	"github.com/Jamf-Concepts/jamfplatform-go-sdk/jamfplatform/blueprints"
 	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/common/helpers"
 	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/resources/blueprints/blueprint/components"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
 
-// updateModelFromAPIResponse updates the Terraform model with data from the API response.
-func updateModelFromAPIResponse(ctx context.Context, model *BlueprintResourceModel, blueprint *blueprints.BlueprintDetail) {
-	stateRawIdentifiers := make(map[string]struct{}, len(model.Components))
-	for _, comp := range model.Components {
-		identifier := comp.Identifier.ValueString()
-		if identifier != "" {
-			stateRawIdentifiers[identifier] = struct{}{}
-		}
-	}
+// updateModelFromAPIResponse updates the Terraform model with data from the API response. It
+// selects between the deprecated flat top-level attributes and ordered component_blocks based on
+// which the prior model used (a fresh/empty model — import, list resource — defaults to blocks).
+func updateModelFromAPIResponse(ctx context.Context, model *BlueprintResourceModel, blueprint *blueprints.BlueprintDetail) diag.Diagnostics {
+	var diags diag.Diagnostics
+
+	blockMode := len(model.ComponentBlocks) > 0 || !model.hasFlatComponents()
 
 	model.ID = types.StringValue(blueprint.ID)
 	model.Name = types.StringValue(blueprint.Name)
-
 	model.Description = helpers.ReconcileOptionalStringPointer(blueprint.Description, model.Description)
-
 	model.Created = types.StringValue(blueprint.Created.Format(time.RFC3339))
 	model.Updated = types.StringValue(blueprint.Updated.Format(time.RFC3339))
 	if blueprint.DeploymentState != nil {
@@ -45,103 +41,184 @@ func updateModelFromAPIResponse(ctx context.Context, model *BlueprintResourceMod
 	deviceGroupsSet, _ := types.SetValueFrom(context.Background(), types.StringType, scopeDeviceGroups(blueprint.Scope))
 	model.DeviceGroups = deviceGroupsSet
 
-	var activationPredicate *string
-	if len(blueprint.Steps) > 0 {
-		activationPredicate = blueprint.Steps[0].ActivationPredicate
+	if blockMode {
+		updateComponentBlocksFromAPI(ctx, model, blueprint)
+	} else {
+		diags.Append(updateFlatComponentsFromAPI(ctx, model, blueprint)...)
 	}
-	model.ActivationConditions = helpers.ReconcileOptionalStringPointer(activationPredicate, model.ActivationConditions)
+
+	model.Timeouts = helpers.EnsureResourceTimeouts(model.Timeouts, blueprintTimeoutAttributeTypes)
+	return diags
+}
+
+// updateComponentBlocksFromAPI populates model.ComponentBlocks from every wire step (block mode)
+// and clears the deprecated flat attributes so state carries a single representation.
+func updateComponentBlocksFromAPI(ctx context.Context, model *BlueprintResourceModel, blueprint *blueprints.BlueprintDetail) {
+	prior := model.ComponentBlocks
+	blocks := make([]ComponentBlockModel, 0, len(blueprint.Steps))
+
+	for i, step := range blueprint.Steps {
+		var priorRaw map[string]struct{}
+		var priorLegacy []BlockLegacyPayloadModel
+		priorName := types.StringNull()
+		priorActivation := types.StringNull()
+		if i < len(prior) {
+			priorRaw = rawIdentifierSet(prior[i].Components)
+			priorLegacy = prior[i].LegacyPayloads
+			priorName = prior[i].Name
+			priorActivation = prior[i].ActivationConditions
+		}
+
+		block, apiComponentsByID := mapStepComponents(ctx, step, priorRaw)
+		block.Name = helpers.ReconcileOptionalStringPointer(step.Name, priorName)
+		block.ActivationConditions = helpers.ReconcileOptionalStringPointer(step.ActivationPredicate, priorActivation)
+		block.LegacyPayloads = flattenBlockLegacyPayloads(priorLegacy, apiComponentsByID, priorRaw)
+		blocks = append(blocks, block)
+	}
+
+	if len(blocks) > 0 {
+		model.ComponentBlocks = blocks
+	} else {
+		model.ComponentBlocks = nil
+	}
+
+	model.applyFlatComponentsFromBlock(ComponentBlockModel{})
+	model.LegacyPayloads = types.DynamicNull()
+	model.ActivationConditions = types.StringNull()
+}
+
+// updateFlatComponentsFromAPI populates the deprecated flat top-level attributes from the first
+// step (flat mode). When the blueprint has more than one step it also emits a migration warning:
+// the flat attributes cannot represent the extra blocks, so applying would collapse them.
+func updateFlatComponentsFromAPI(ctx context.Context, model *BlueprintResourceModel, blueprint *blueprints.BlueprintDetail) diag.Diagnostics {
+	var diags diag.Diagnostics
+
+	priorRaw := rawIdentifierSet(model.Components)
+
+	var step blueprints.BlueprintStep
+	if len(blueprint.Steps) > 0 {
+		step = blueprint.Steps[0]
+	}
+
+	block, apiComponentsByID := mapStepComponents(ctx, step, priorRaw)
+	model.applyFlatComponentsFromBlock(block)
+	model.LegacyPayloads = flattenFlatLegacyPayloads(model.LegacyPayloads, apiComponentsByID, priorRaw)
+	model.ActivationConditions = helpers.ReconcileOptionalStringPointer(step.ActivationPredicate, model.ActivationConditions)
+
+	if len(blueprint.Steps) > 1 {
+		diags.AddWarning(
+			"Blueprint has multiple component blocks",
+			"This blueprint has multiple component blocks, but the configuration uses the deprecated top-level component attributes, which can only represent the first block. "+
+				"Only the first block is reflected in state, and applying this configuration would remove the others. Migrate to `component_blocks` to manage every block.",
+		)
+	}
+
+	return diags
+}
+
+// rawIdentifierSet collects the raw_component identifiers a prior model authored, so components
+// that also have a strongly-typed representation stay in raw_component when the user chose it.
+func rawIdentifierSet(components []ComponentModel) map[string]struct{} {
+	identifiers := make(map[string]struct{}, len(components))
+	for _, comp := range components {
+		if identifier := comp.Identifier.ValueString(); identifier != "" {
+			identifiers[identifier] = struct{}{}
+		}
+	}
+	return identifiers
+}
+
+// mapStepComponents converts one wire step's raw and strongly-typed components into a
+// ComponentBlockModel carrier, and returns the step's components keyed by identifier so the caller
+// can flatten legacy payloads. It leaves Name, ActivationConditions, and LegacyPayloads unset — the
+// caller reconciles those.
+func mapStepComponents(ctx context.Context, step blueprints.BlueprintStep, priorRawIdentifiers map[string]struct{}) (ComponentBlockModel, map[string]blueprints.Component) {
+	var block ComponentBlockModel
 
 	apiComponentsByID := make(map[string]blueprints.Component)
 	var rawComponents []ComponentModel
 
-	if len(blueprint.Steps) > 0 {
-		step := blueprint.Steps[0]
-		rawComponents = make([]ComponentModel, 0, len(step.Components))
+	for _, comp := range step.Components {
+		apiComponentsByID[comp.Identifier] = comp
 
-		for _, comp := range step.Components {
-			apiComponentsByID[comp.Identifier] = comp
-
-			_, handledAsRaw := stateRawIdentifiers[comp.Identifier]
-			if _, isTyped := stronglyTypedComponentIdentifiers[comp.Identifier]; isTyped && !handledAsRaw {
-				continue
-			}
-
-			configMap := make(map[string]string)
-			if comp.Configuration != nil {
-				var jsonObj map[string]any
-				if err := json.Unmarshal(comp.Configuration, &jsonObj); err == nil {
-					flattenJSON(jsonObj, "", configMap)
-				}
-			}
-			configMapValue, _ := types.MapValueFrom(context.Background(), types.StringType, configMap)
-
-			rawComponents = append(rawComponents, ComponentModel{
-				Identifier:    types.StringValue(comp.Identifier),
-				Configuration: configMapValue,
-			})
+		_, handledAsRaw := priorRawIdentifiers[comp.Identifier]
+		if _, isTyped := stronglyTypedComponentIdentifiers[comp.Identifier]; isTyped && !handledAsRaw {
+			continue
 		}
+
+		configMap := make(map[string]string)
+		if comp.Configuration != nil {
+			var jsonObj map[string]any
+			if err := json.Unmarshal(comp.Configuration, &jsonObj); err == nil {
+				flattenJSON(jsonObj, "", configMap)
+			}
+		}
+		configMapValue, _ := types.MapValueFrom(ctx, types.StringType, configMap)
+
+		rawComponents = append(rawComponents, ComponentModel{
+			Identifier:    types.StringValue(comp.Identifier),
+			Configuration: configMapValue,
+		})
 	}
 
 	if len(rawComponents) > 0 {
-		model.Components = rawComponents
-	} else {
-		model.Components = nil
+		block.Components = rawComponents
 	}
-	updateStronglyTypedComponentsFromAPI(ctx, model, apiComponentsByID, stateRawIdentifiers)
-	model.Timeouts = helpers.EnsureResourceTimeouts(model.Timeouts, blueprintTimeoutAttributeTypes)
+
+	updateStronglyTypedComponentsFromAPI(&block, apiComponentsByID, priorRawIdentifiers)
+	return block, apiComponentsByID
 }
 
-// updateStronglyTypedComponentsFromAPI updates all strongly-typed components from API response.
-func updateStronglyTypedComponentsFromAPI(ctx context.Context, model *BlueprintResourceModel, apiComponentsByID map[string]blueprints.Component, rawIdentifiers map[string]struct{}) {
-	model.AudioAccessorySettings = buildTypedComponent[components.AudioAccessorySettingsComponent](apiComponentsByID, rawIdentifiers, "com.jamf.ddm.audio-accessory-settings", func(raw json.RawMessage, target *components.AudioAccessorySettingsComponent) error {
+// updateStronglyTypedComponentsFromAPI updates all strongly-typed components of a block from the
+// API response.
+func updateStronglyTypedComponentsFromAPI(block *ComponentBlockModel, apiComponentsByID map[string]blueprints.Component, rawIdentifiers map[string]struct{}) {
+	block.AudioAccessorySettings = buildTypedComponent[components.AudioAccessorySettingsComponent](apiComponentsByID, rawIdentifiers, "com.jamf.ddm.audio-accessory-settings", func(raw json.RawMessage, target *components.AudioAccessorySettingsComponent) error {
 		return target.FromRawConfiguration(raw)
 	})
 
-	model.CustomDeclarations = buildTypedComponent[components.CustomDeclarationsComponent](apiComponentsByID, rawIdentifiers, "com.jamf.ddm.custom-declarations", func(raw json.RawMessage, target *components.CustomDeclarationsComponent) error {
+	block.CustomDeclarations = buildTypedComponent[components.CustomDeclarationsComponent](apiComponentsByID, rawIdentifiers, "com.jamf.ddm.custom-declarations", func(raw json.RawMessage, target *components.CustomDeclarationsComponent) error {
 		return target.FromRawConfiguration(raw)
 	})
 
-	model.DiskManagementSettings = buildTypedComponent[components.DiskManagementPolicyComponent](apiComponentsByID, rawIdentifiers, "com.jamf.ddm.disk-management", func(raw json.RawMessage, target *components.DiskManagementPolicyComponent) error {
+	block.DiskManagementSettings = buildTypedComponent[components.DiskManagementPolicyComponent](apiComponentsByID, rawIdentifiers, "com.jamf.ddm.disk-management", func(raw json.RawMessage, target *components.DiskManagementPolicyComponent) error {
 		return target.FromRawConfiguration(raw)
 	})
 
-	model.MathSettings = buildTypedComponent[components.MathSettingsComponent](apiComponentsByID, rawIdentifiers, "com.jamf.ddm.math-settings", func(raw json.RawMessage, target *components.MathSettingsComponent) error {
+	block.MathSettings = buildTypedComponent[components.MathSettingsComponent](apiComponentsByID, rawIdentifiers, "com.jamf.ddm.math-settings", func(raw json.RawMessage, target *components.MathSettingsComponent) error {
 		return target.FromRawConfiguration(raw)
 	})
 
-	model.PasscodePolicy = buildTypedComponent[components.PasscodePolicyComponent](apiComponentsByID, rawIdentifiers, "com.jamf.ddm.passcode-settings", func(raw json.RawMessage, target *components.PasscodePolicyComponent) error {
+	block.PasscodePolicy = buildTypedComponent[components.PasscodePolicyComponent](apiComponentsByID, rawIdentifiers, "com.jamf.ddm.passcode-settings", func(raw json.RawMessage, target *components.PasscodePolicyComponent) error {
 		return target.FromRawConfiguration(raw)
 	})
 
-	model.SafariBookmarks = buildTypedComponent[components.SafariBookmarksComponent](apiComponentsByID, rawIdentifiers, "com.jamf.ddm.safari-bookmarks", func(raw json.RawMessage, target *components.SafariBookmarksComponent) error {
+	block.SafariBookmarks = buildTypedComponent[components.SafariBookmarksComponent](apiComponentsByID, rawIdentifiers, "com.jamf.ddm.safari-bookmarks", func(raw json.RawMessage, target *components.SafariBookmarksComponent) error {
 		return target.FromRawConfiguration(raw)
 	})
 
-	model.SafariExtensions = buildTypedComponent[components.SafariExtensionsComponent](apiComponentsByID, rawIdentifiers, "com.jamf.ddm.safari-extensions", func(raw json.RawMessage, target *components.SafariExtensionsComponent) error {
+	block.SafariExtensions = buildTypedComponent[components.SafariExtensionsComponent](apiComponentsByID, rawIdentifiers, "com.jamf.ddm.safari-extensions", func(raw json.RawMessage, target *components.SafariExtensionsComponent) error {
 		return target.FromRawConfiguration(raw)
 	})
 
-	model.SafariSettings = buildTypedComponent[components.SafariSettingsComponent](apiComponentsByID, rawIdentifiers, "com.jamf.ddm.safari-settings", func(raw json.RawMessage, target *components.SafariSettingsComponent) error {
+	block.SafariSettings = buildTypedComponent[components.SafariSettingsComponent](apiComponentsByID, rawIdentifiers, "com.jamf.ddm.safari-settings", func(raw json.RawMessage, target *components.SafariSettingsComponent) error {
 		return target.FromRawConfiguration(raw)
 	})
 
-	model.ServiceBackgroundTasks = buildTypedComponent[components.ServiceBackgroundTasksComponent](apiComponentsByID, rawIdentifiers, "com.jamf.ddm.service-background-tasks", func(raw json.RawMessage, target *components.ServiceBackgroundTasksComponent) error {
+	block.ServiceBackgroundTasks = buildTypedComponent[components.ServiceBackgroundTasksComponent](apiComponentsByID, rawIdentifiers, "com.jamf.ddm.service-background-tasks", func(raw json.RawMessage, target *components.ServiceBackgroundTasksComponent) error {
 		return target.FromRawConfiguration(raw)
 	})
 
-	model.ServiceConfigurationFiles = buildTypedComponent[components.ServiceConfigurationFilesComponent](apiComponentsByID, rawIdentifiers, "com.jamf.ddm.service-configuration-files", func(raw json.RawMessage, target *components.ServiceConfigurationFilesComponent) error {
+	block.ServiceConfigurationFiles = buildTypedComponent[components.ServiceConfigurationFilesComponent](apiComponentsByID, rawIdentifiers, "com.jamf.ddm.service-configuration-files", func(raw json.RawMessage, target *components.ServiceConfigurationFilesComponent) error {
 		return target.FromRawConfiguration(raw)
 	})
 
-	model.SoftwareUpdate = buildTypedComponent[components.SoftwareUpdateComponent](apiComponentsByID, rawIdentifiers, "com.jamf.ddm.sw-updates", func(raw json.RawMessage, target *components.SoftwareUpdateComponent) error {
+	block.SoftwareUpdate = buildTypedComponent[components.SoftwareUpdateComponent](apiComponentsByID, rawIdentifiers, "com.jamf.ddm.sw-updates", func(raw json.RawMessage, target *components.SoftwareUpdateComponent) error {
 		return target.FromRawConfiguration(raw)
 	})
 
-	model.SoftwareUpdateSettings = buildTypedComponent[components.SoftwareUpdateSettingsComponent](apiComponentsByID, rawIdentifiers, "com.jamf.ddm.software-update-settings", func(raw json.RawMessage, target *components.SoftwareUpdateSettingsComponent) error {
+	block.SoftwareUpdateSettings = buildTypedComponent[components.SoftwareUpdateSettingsComponent](apiComponentsByID, rawIdentifiers, "com.jamf.ddm.software-update-settings", func(raw json.RawMessage, target *components.SoftwareUpdateSettingsComponent) error {
 		return target.FromRawConfiguration(raw)
 	})
-
-	updateLegacyPayloadsFromAPI(ctx, model, apiComponentsByID, rawIdentifiers)
 }
 
 // buildTypedComponent is a generic helper to build a strongly-typed singleton component pointer.
@@ -172,42 +249,26 @@ func parseComponentConfiguration(apiComponentsByID map[string]blueprints.Compone
 	return apiComp.Configuration, true
 }
 
-// updateLegacyPayloadsFromAPI handles the special case of legacy payloads component.
-// Legacy payloads round-trip through a dynamic attribute, where a JSON null from
-// the server is typed as a string while the same null in configuration is untyped;
-// that mismatch alone would cause a perpetual diff. When the server response is
-// semantically identical to the incoming plan/state value it therefore preserves
-// that configuration-shaped value rather than overwriting it (see dynamicPayloadsMatchJSON).
-func updateLegacyPayloadsFromAPI(ctx context.Context, model *BlueprintResourceModel, apiComponentsByID map[string]blueprints.Component, rawIdentifiers map[string]struct{}) {
-	if _, handledAsRaw := rawIdentifiers["com.jamf.ddm-configuration-profile"]; handledAsRaw {
-		return
-	}
-
+// legacyPayloadItems extracts the legacy configuration profile's payloads from the wire as a list
+// of `{payload_type, settings}` maps (settings present only when non-empty), or nil when the
+// component is absent or malformed. The caller decides how to render them (dynamic or JSON string).
+func legacyPayloadItems(apiComponentsByID map[string]blueprints.Component) []any {
 	rawJSON, ok := parseComponentConfiguration(apiComponentsByID, "com.jamf.ddm-configuration-profile")
 	if !ok {
-		model.LegacyPayloads = types.DynamicNull()
-		return
+		return nil
 	}
 
 	var config map[string]any
 	if err := json.Unmarshal(rawJSON, &config); err != nil {
-		model.LegacyPayloads = types.DynamicNull()
-		return
+		return nil
 	}
 
-	payloadContent, exists := config["payloadContent"]
-	if !exists {
-		model.LegacyPayloads = types.DynamicNull()
-		return
-	}
-
-	payloadArray, ok := payloadContent.([]any)
+	payloadArray, ok := config["payloadContent"].([]any)
 	if !ok {
-		model.LegacyPayloads = types.DynamicNull()
-		return
+		return nil
 	}
 
-	var resultItems []any
+	var items []any
 	for _, item := range payloadArray {
 		payloadMap, ok := item.(map[string]any)
 		if !ok {
@@ -224,34 +285,114 @@ func updateLegacyPayloadsFromAPI(ctx context.Context, model *BlueprintResourceMo
 			settingsMap[k] = v
 		}
 
-		entry := map[string]any{
-			"payload_type": payloadType,
-		}
+		entry := map[string]any{"payload_type": payloadType}
 		if len(settingsMap) > 0 {
 			entry["settings"] = settingsMap
 		}
-
-		resultItems = append(resultItems, entry)
+		items = append(items, entry)
 	}
 
-	if len(resultItems) == 0 {
-		model.LegacyPayloads = types.DynamicNull()
-		return
+	if len(items) == 0 {
+		return nil
+	}
+	return items
+}
+
+// flattenFlatLegacyPayloads renders the wire legacy payloads into the deprecated top-level dynamic
+// value. When the user manages the configuration profile as a raw_component it is left untouched;
+// when the server value is semantically identical to the prior value that prior value is preserved
+// (the dynamic null-typing reconcile — see dynamicPayloadsMatchJSON).
+func flattenFlatLegacyPayloads(prior types.Dynamic, apiComponentsByID map[string]blueprints.Component, rawIdentifiers map[string]struct{}) types.Dynamic {
+	if _, handledAsRaw := rawIdentifiers["com.jamf.ddm-configuration-profile"]; handledAsRaw {
+		return prior
 	}
 
-	if dynamicPayloadsMatchJSON(model.LegacyPayloads, resultItems) {
-		return
+	items := legacyPayloadItems(apiComponentsByID)
+	if len(items) == 0 {
+		return types.DynamicNull()
 	}
 
-	dynVal, err := helpers.JSONToTerraformDynamic(resultItems)
+	if dynamicPayloadsMatchJSON(prior, items) {
+		return prior
+	}
+
+	dynVal, err := helpers.JSONToTerraformDynamic(items)
 	if err != nil {
-		tflog.Warn(ctx, "Failed to convert legacy payloads to dynamic", map[string]any{
-			"error": err.Error(),
-		})
-		model.LegacyPayloads = types.DynamicNull()
-		return
+		return types.DynamicNull()
 	}
-	model.LegacyPayloads = dynVal
+	return dynVal
+}
+
+// flattenBlockLegacyPayloads renders the wire legacy payloads into a block's typed list, with each
+// payload's settings as a canonical JSON string. When the user manages the configuration profile as
+// a raw_component the prior value is left untouched. For each payload, the prior settings string is
+// preserved when it is semantically identical to the server value, keeping diffs stable.
+func flattenBlockLegacyPayloads(prior []BlockLegacyPayloadModel, apiComponentsByID map[string]blueprints.Component, rawIdentifiers map[string]struct{}) []BlockLegacyPayloadModel {
+	if _, handledAsRaw := rawIdentifiers["com.jamf.ddm-configuration-profile"]; handledAsRaw {
+		return prior
+	}
+
+	items := legacyPayloadItems(apiComponentsByID)
+	if len(items) == 0 {
+		return nil
+	}
+
+	priorByType := make(map[string]types.String, len(prior))
+	for _, entry := range prior {
+		priorByType[entry.PayloadType.ValueString()] = entry.Settings
+	}
+
+	result := make([]BlockLegacyPayloadModel, 0, len(items))
+	for _, item := range items {
+		obj, ok := item.(map[string]any)
+		if !ok {
+			continue
+		}
+		payloadType, _ := obj["payload_type"].(string)
+		entry := BlockLegacyPayloadModel{PayloadType: types.StringValue(payloadType)}
+
+		settings, hasSettings := obj["settings"].(map[string]any)
+		switch {
+		case !hasSettings:
+			entry.Settings = types.StringNull()
+		case settingsStringMatchesJSON(priorByType[payloadType], settings):
+			entry.Settings = priorByType[payloadType]
+		default:
+			if encoded, err := json.Marshal(settings); err == nil {
+				entry.Settings = types.StringValue(string(encoded))
+			} else {
+				entry.Settings = types.StringNull()
+			}
+		}
+		result = append(result, entry)
+	}
+	return result
+}
+
+// settingsStringMatchesJSON reports whether a prior settings JSON string is semantically identical
+// to a server-derived settings map, comparing canonical JSON encodings (sorted keys, float64
+// numbers). It keeps a block's settings string stable when the server echoes an equivalent value.
+func settingsStringMatchesJSON(prior types.String, settings map[string]any) bool {
+	if prior.IsNull() || prior.IsUnknown() {
+		return false
+	}
+
+	var priorObj any
+	if err := json.Unmarshal([]byte(prior.ValueString()), &priorObj); err != nil {
+		return false
+	}
+
+	priorBytes, err := json.Marshal(priorObj)
+	if err != nil {
+		return false
+	}
+
+	settingsBytes, err := json.Marshal(settings)
+	if err != nil {
+		return false
+	}
+
+	return bytes.Equal(priorBytes, settingsBytes)
 }
 
 // dynamicPayloadsMatchJSON reports whether the prior dynamic value is

--- a/internal/resources/blueprints/blueprint/state_builders_test.go
+++ b/internal/resources/blueprints/blueprint/state_builders_test.go
@@ -74,24 +74,21 @@ func TestParseComponentConfiguration_InvalidJSON(t *testing.T) {
 	}
 }
 
-func TestUpdateLegacyPayloadsFromAPI_WithPayloads(t *testing.T) {
-	ctx := t.Context()
+func TestFlattenFlatLegacyPayloads_WithPayloads(t *testing.T) {
 	apiComponents := map[string]blueprints.Component{
 		"com.jamf.ddm-configuration-profile": {
 			Identifier:    "com.jamf.ddm-configuration-profile",
 			Configuration: json.RawMessage(`{"payloadDisplayName":"Test","payloadContent":[{"payloadType":"com.apple.wifi.managed","payloadIdentifier":"test-uuid","SSID_STR":"TestNetwork"}]}`),
 		},
 	}
-	rawIdentifiers := map[string]struct{}{}
 
-	model := &BlueprintResourceModel{}
-	updateLegacyPayloadsFromAPI(ctx, model, apiComponents, rawIdentifiers)
+	got := flattenFlatLegacyPayloads(types.DynamicNull(), apiComponents, map[string]struct{}{})
 
-	if model.LegacyPayloads.IsNull() {
+	if got.IsNull() {
 		t.Fatal("expected non-null legacy payloads")
 	}
 
-	raw, err := helpers.TerraformDynamicToJSON(model.LegacyPayloads)
+	raw, err := helpers.TerraformDynamicToJSON(got)
 	if err != nil {
 		t.Fatalf("failed to convert dynamic to JSON: %v", err)
 	}
@@ -123,24 +120,16 @@ func TestUpdateLegacyPayloadsFromAPI_WithPayloads(t *testing.T) {
 	}
 }
 
-func TestUpdateLegacyPayloadsFromAPI_NoComponent(t *testing.T) {
-	ctx := t.Context()
-	apiComponents := map[string]blueprints.Component{}
-	rawIdentifiers := map[string]struct{}{}
-
+func TestFlattenFlatLegacyPayloads_NoComponent(t *testing.T) {
 	existingDyn, _ := helpers.JSONToTerraformDynamic([]any{map[string]any{"payload_type": "should be cleared"}})
-	model := &BlueprintResourceModel{
-		LegacyPayloads: existingDyn,
-	}
-	updateLegacyPayloadsFromAPI(ctx, model, apiComponents, rawIdentifiers)
+	got := flattenFlatLegacyPayloads(existingDyn, map[string]blueprints.Component{}, map[string]struct{}{})
 
-	if !model.LegacyPayloads.IsNull() {
+	if !got.IsNull() {
 		t.Error("expected null legacy payloads when component is absent")
 	}
 }
 
-func TestUpdateLegacyPayloadsFromAPI_HandledAsRaw(t *testing.T) {
-	ctx := t.Context()
+func TestFlattenFlatLegacyPayloads_HandledAsRaw(t *testing.T) {
 	apiComponents := map[string]blueprints.Component{
 		"com.jamf.ddm-configuration-profile": {
 			Identifier:    "com.jamf.ddm-configuration-profile",
@@ -152,10 +141,9 @@ func TestUpdateLegacyPayloadsFromAPI_HandledAsRaw(t *testing.T) {
 	}
 
 	existingDyn, _ := helpers.JSONToTerraformDynamic([]any{map[string]any{"payload_type": "existing"}})
-	model := &BlueprintResourceModel{LegacyPayloads: existingDyn}
-	updateLegacyPayloadsFromAPI(ctx, model, apiComponents, rawIdentifiers)
+	got := flattenFlatLegacyPayloads(existingDyn, apiComponents, rawIdentifiers)
 
-	raw, err := helpers.TerraformDynamicToJSON(model.LegacyPayloads)
+	raw, err := helpers.TerraformDynamicToJSON(got)
 	if err != nil {
 		t.Fatalf("failed to convert: %v", err)
 	}
@@ -165,20 +153,17 @@ func TestUpdateLegacyPayloadsFromAPI_HandledAsRaw(t *testing.T) {
 	}
 }
 
-func TestUpdateLegacyPayloadsFromAPI_NoPayloadContent(t *testing.T) {
-	ctx := t.Context()
+func TestFlattenFlatLegacyPayloads_NoPayloadContent(t *testing.T) {
 	apiComponents := map[string]blueprints.Component{
 		"com.jamf.ddm-configuration-profile": {
 			Identifier:    "com.jamf.ddm-configuration-profile",
 			Configuration: json.RawMessage(`{"payloadDisplayName":"Test"}`),
 		},
 	}
-	rawIdentifiers := map[string]struct{}{}
 
-	model := &BlueprintResourceModel{}
-	updateLegacyPayloadsFromAPI(ctx, model, apiComponents, rawIdentifiers)
+	got := flattenFlatLegacyPayloads(types.DynamicNull(), apiComponents, map[string]struct{}{})
 
-	if !model.LegacyPayloads.IsNull() {
+	if !got.IsNull() {
 		t.Error("expected null legacy payloads when payloadContent is absent")
 	}
 }
@@ -308,9 +293,7 @@ func TestUpdateModelFromAPIResponse_NoSteps(t *testing.T) {
 // #282 fix: when the server response is semantically identical to the incoming
 // (configuration-shaped) value, the reader keeps that value verbatim so the
 // dynamic null-typing does not manufacture a diff.
-func TestUpdateLegacyPayloadsFromAPI_PreservesConfigShapeOnMatch(t *testing.T) {
-	ctx := t.Context()
-
+func TestFlattenFlatLegacyPayloads_PreservesConfigShapeOnMatch(t *testing.T) {
 	prior, err := helpers.JSONToTerraformDynamic([]any{
 		map[string]any{
 			"payload_type": "com.apple.notificationsettings",
@@ -337,19 +320,16 @@ func TestUpdateLegacyPayloadsFromAPI_PreservesConfigShapeOnMatch(t *testing.T) {
 		},
 	}
 
-	model := &BlueprintResourceModel{LegacyPayloads: prior}
-	updateLegacyPayloadsFromAPI(ctx, model, apiComponents, map[string]struct{}{})
+	got := flattenFlatLegacyPayloads(prior, apiComponents, map[string]struct{}{})
 
-	if !model.LegacyPayloads.Equal(prior) {
-		t.Errorf("expected config-shaped prior value to be preserved on semantic match, got %#v", model.LegacyPayloads)
+	if !got.Equal(prior) {
+		t.Errorf("expected config-shaped prior value to be preserved on semantic match, got %#v", got)
 	}
 }
 
 // TestUpdateLegacyPayloadsFromAPI_OverwritesOnMismatch verifies that a genuine
 // server-side difference is still surfaced rather than masked by the reconcile.
-func TestUpdateLegacyPayloadsFromAPI_OverwritesOnMismatch(t *testing.T) {
-	ctx := t.Context()
-
+func TestFlattenFlatLegacyPayloads_OverwritesOnMismatch(t *testing.T) {
 	prior, err := helpers.JSONToTerraformDynamic([]any{
 		map[string]any{
 			"payload_type": "com.apple.notificationsettings",
@@ -367,14 +347,13 @@ func TestUpdateLegacyPayloadsFromAPI_OverwritesOnMismatch(t *testing.T) {
 		},
 	}
 
-	model := &BlueprintResourceModel{LegacyPayloads: prior}
-	updateLegacyPayloadsFromAPI(ctx, model, apiComponents, map[string]struct{}{})
+	got := flattenFlatLegacyPayloads(prior, apiComponents, map[string]struct{}{})
 
-	if model.LegacyPayloads.Equal(prior) {
+	if got.Equal(prior) {
 		t.Fatal("expected differing server value to overwrite the prior value")
 	}
 
-	raw, err := helpers.TerraformDynamicToJSON(model.LegacyPayloads)
+	raw, err := helpers.TerraformDynamicToJSON(got)
 	if err != nil {
 		t.Fatalf("failed to convert result: %v", err)
 	}


### PR DESCRIPTION
## What

Adds multi-step **component blocks** to `jamfplatform_blueprints_blueprint`, matching the Jamf Blueprints UI (each step has a name, its own activation condition, and its own components). Introduces an ordered `component_blocks` list attribute and **deprecates** the flat top-level component attributes.

## Why

The provider collapsed every component into one hardcoded `"Declaration group"` step and only read `Steps[0]` on refresh — silently dropping steps 1..N and risking **data loss** on the next `apply` against any UI-authored multi-step blueprint. Users also couldn't create named, ordered, per-block-scoped blueprints from Terraform.

## Approach — phased, additive, non-breaking

- `component_blocks` (ordered `ListNestedAttribute`) is the canonical authoring style; each block carries `name`, `activation_conditions`, and the same component set.
- Flat top-level component attributes are kept + `Deprecated` (existing configs unchanged; they compose into a single `"Declaration group"` step). The two styles are mutually exclusive (`listvalidator.ConflictsWith`).
- **Dual-mode read** keyed off prior state; empty prior (import, list resource) defaults to blocks. Flat mode warns when the wire has >1 step.
- **No schema `Version` bump** — purely additive.
- Framework constraint (Dynamic-in-collection is rejected): a block's `legacy_payloads` uses `{ payload_type, settings = jsonencode(...) }` (matching the `custom_declarations.payload` idiom); the deprecated top-level `legacy_payloads` stays dynamic.

## Deprecation policy

New STYLE_GUIDE section: Platform Services *Terraform schema* deprecations get a **90-day window**, then batch removal. Deprecated attrs carry a greppable `// PLATFORM-DEPRECATED remove-after=2026-10-22 replaced-by=component_blocks` marker; removal + schema `Version` bump + `UpgradeState` lands in a later breaking release.

## Testing

- Unit: schema (component_blocks present, flat deprecated), `buildSteps` (block + flat, repeated identifier), dual-mode read (+ multi-step warning), legacy flatten.
- **Acceptance: 20/20 green** on `platform-nmartin` — multi-block create/update/append, per-block activation, repeated component type across blocks, legacy-payload plan stability, `DeprecatedFlatMode` regression, and data sources.
- `make fix fmt lint test` clean; `make generate` docs regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)