### PR TITLE
fix(blueprints): refuse a flat-mode apply that would delete unshowable component blocks

### DIFF
--- a/internal/resources/blueprints/blueprint/helpers.go
+++ b/internal/resources/blueprints/blueprint/helpers.go
@@ -23,6 +23,32 @@ func generatePayloadIdentifier(payloadType string) string {
 		hash[0:4], hash[4:6], hash[6:8], hash[8:10], hash[10:16])
 }
 
+// describeBlueprintBlocks renders one numbered line per component block, naming the block and the
+// components it carries, for the diagnostic that lists what a flat-mode configuration cannot hold
+// (see checkFlatModeBlockLoss). An unnamed block is labelled so its position stays readable.
+func describeBlueprintBlocks(steps []blueprints.BlueprintStep) string {
+	var b strings.Builder
+	for i, step := range steps {
+		name := "(unnamed)"
+		if step.Name != nil && *step.Name != "" {
+			name = *step.Name
+		}
+
+		identifiers := make([]string, 0, len(step.Components))
+		for _, comp := range step.Components {
+			identifiers = append(identifiers, comp.Identifier)
+		}
+
+		components := "no components"
+		if len(identifiers) > 0 {
+			components = strings.Join(identifiers, ", ")
+		}
+
+		fmt.Fprintf(&b, "  %d. %s — %s\n", i+1, name, components)
+	}
+	return b.String()
+}
+
 // setNestedValue sets a value in a nested map structure using underscore notation.
 func setNestedValue(obj map[string]any, key string, value string) {
 	parts := strings.Split(key, "_")

--- a/internal/resources/blueprints/blueprint/helpers_test.go
+++ b/internal/resources/blueprints/blueprint/helpers_test.go
@@ -4,10 +4,46 @@
 package blueprint
 
 import (
+	"strings"
 	"testing"
 
+	"github.com/Jamf-Concepts/jamfplatform-go-sdk/jamfplatform/blueprints"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
+
+func TestDescribeBlueprintBlocks(t *testing.T) {
+	named := "Passcode"
+	empty := ""
+
+	got := describeBlueprintBlocks([]blueprints.BlueprintStep{
+		{
+			Name: &named,
+			Components: []blueprints.Component{
+				{Identifier: "com.jamf.ddm.passcode-settings"},
+				{Identifier: "com.jamf.ddm.math-settings"},
+			},
+		},
+		{Name: nil, Components: []blueprints.Component{{Identifier: "com.jamf.ddm.safari-settings"}}},
+		{Name: &empty, Components: nil},
+	})
+
+	want := strings.Join([]string{
+		"  1. Passcode — com.jamf.ddm.passcode-settings, com.jamf.ddm.math-settings",
+		"  2. (unnamed) — com.jamf.ddm.safari-settings",
+		"  3. (unnamed) — no components",
+		"",
+	}, "\n")
+
+	if got != want {
+		t.Errorf("describeBlueprintBlocks() =\n%q\nwant\n%q", got, want)
+	}
+}
+
+func TestDescribeBlueprintBlocks_NoSteps(t *testing.T) {
+	if got := describeBlueprintBlocks(nil); got != "" {
+		t.Errorf("describeBlueprintBlocks(nil) = %q, want empty", got)
+	}
+}
 
 func TestSetNestedValue_SimpleString(t *testing.T) {
 	obj := make(map[string]any)

--- a/internal/resources/blueprints/blueprint/resource.go
+++ b/internal/resources/blueprints/blueprint/resource.go
@@ -16,6 +16,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/setvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/identityschema"
@@ -23,6 +24,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
@@ -377,6 +379,9 @@ func (r *BlueprintResource) Configure(ctx context.Context, req resource.Configur
 // state) and destroy (nil plan) are skipped — the attributes are already unknown
 // on create and there is no planned state to modify on destroy — and a plan with
 // no change is left untouched so the resource keeps showing an empty plan.
+//
+// It also refuses a flat-mode apply that would delete component blocks the diff cannot show — see
+// checkFlatModeBlockLoss.
 func (r *BlueprintResource) ModifyPlan(ctx context.Context, req resource.ModifyPlanRequest, resp *resource.ModifyPlanResponse) {
 	if req.State.Raw.IsNull() || req.Plan.Raw.IsNull() {
 		return
@@ -386,8 +391,75 @@ func (r *BlueprintResource) ModifyPlan(ctx context.Context, req resource.ModifyP
 		return
 	}
 
+	resp.Diagnostics.Append(r.checkFlatModeBlockLoss(ctx, req.Plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
 	resp.Diagnostics.Append(resp.Plan.SetAttribute(ctx, path.Root("updated"), types.StringUnknown())...)
 	resp.Diagnostics.Append(resp.Plan.SetAttribute(ctx, path.Root("deployment_state"), types.StringUnknown())...)
+}
+
+// checkFlatModeBlockLoss blocks a plan that would delete component blocks without showing them in
+// the diff. The deprecated flat top-level attributes can only carry one block, so a read maps just
+// the first one into state (see updateFlatComponentsFromAPI) — any further block is absent from
+// prior state, invisible in the diff, and still deleted by the apply, which rewrites every block at
+// once. Blocks that Terraform cannot show it is about to destroy are worth an extra read per plan,
+// so this re-reads the blueprint whenever a flat-mode configuration has a planned change.
+//
+// The gate is the *planned configuration*, not prior state: a configuration that has moved to
+// `component_blocks` is migrating and takes explicit ownership of every block it declares, so it is
+// allowed through. That is also why the error enumerates the current blocks — it is the material the
+// user needs to write that migration without dropping one.
+//
+// Block mode needs no guard: every block lands in state, so removals are already plan-visible.
+func (r *BlueprintResource) checkFlatModeBlockLoss(ctx context.Context, plannedState tfsdk.Plan) diag.Diagnostics {
+	var diags diag.Diagnostics
+
+	if r.client == nil {
+		return diags
+	}
+
+	var plan BlueprintResourceModel
+	diags.Append(plannedState.Get(ctx, &plan)...)
+	if diags.HasError() {
+		return diags
+	}
+
+	if len(plan.ComponentBlocks) > 0 || !plan.hasFlatComponents() {
+		return diags
+	}
+
+	id := plan.ID.ValueString()
+	if id == "" {
+		return diags
+	}
+
+	blueprint, err := r.client.GetBlueprint(ctx, id)
+	if err != nil {
+		diags.AddWarning(
+			"Could not check this blueprint for component blocks Terraform cannot represent",
+			"The configuration uses the deprecated top-level component attributes, which can only represent the first component block. "+
+				"The provider could not re-read the blueprint to check whether it has more: "+err.Error()+
+				". If it does, applying would delete them without showing the deletion in this plan. Migrate to `component_blocks` to manage every block.",
+		)
+		return diags
+	}
+
+	if len(blueprint.Steps) <= 1 {
+		return diags
+	}
+
+	diags.AddError(
+		"Blueprint has component blocks the configuration cannot represent",
+		fmt.Sprintf("This blueprint has %d component blocks, but the configuration uses the deprecated top-level component attributes, which can only represent the first. "+
+			"Applying would delete the rest, and because they cannot be held in state that deletion does not appear in this plan.\n\n"+
+			"Component blocks currently on this blueprint:\n%s\n"+
+			"Migrate to `component_blocks` and declare every block listed above, then apply. Leave a block out only if you mean to delete it.",
+			len(blueprint.Steps), describeBlueprintBlocks(blueprint.Steps)),
+	)
+
+	return diags
 }
 
 // ImportState handles the import of existing Blueprint resources.

--- a/internal/resources/blueprints/blueprint/resource_acceptance_test.go
+++ b/internal/resources/blueprints/blueprint/resource_acceptance_test.go
@@ -886,6 +886,94 @@ func TestAccResource_Blueprint_DeprecatedFlatMode(t *testing.T) {
 	})
 }
 
+// TestAccResource_Blueprint_DeprecatedFlatMode_BlockLossGuard proves the flat-mode guard: with a
+// second component block added outside Terraform, a flat-mode configuration cannot hold it (only the
+// first block reaches state), so an update that rewrites every block would delete it without the
+// diff ever showing it. Step 2 changes the description — a real write — and must be refused at plan
+// time, with the error naming the block that would be lost. A no-op plan is deliberately NOT
+// guarded: nothing is written, so nothing is lost.
+func TestAccResource_Blueprint_DeprecatedFlatMode_BlockLossGuard(t *testing.T) {
+	testhelpers.AccPreCheck(t)
+	suffix := testhelpers.RunSuffix()
+	name := "tf-acc-flat-guard-" + suffix
+	addr := "jamfplatform_blueprints_blueprint.test_guard"
+
+	flatConfig := func(description string) string {
+		return testBlueprintConfig(smartGroupHCL("flatguard"), fmt.Sprintf(`
+		resource "jamfplatform_blueprints_blueprint" "test_guard" {
+			name          = %q
+			description   = %q
+			deployed      = false
+			device_groups = [jamfplatform_device_group.scope.id]
+
+			passcode_policy = {
+				require_passcode = true
+				minimum_length   = 6
+			}
+		}
+	`, name, description))
+	}
+
+	var blueprintID string
+	const uiBlockName = "Acceptance UI block"
+
+	// appendBlockOutOfBand simulates an admin adding a component block in the Jamf UI: read the
+	// blueprint, pass its existing blocks back unchanged, and append one more.
+	appendBlockOutOfBand := func() {
+		client := bpSDK.New(testhelpers.NewAcceptanceClient(t))
+		ctx := context.Background()
+
+		blueprint, err := client.GetBlueprint(ctx, blueprintID)
+		if err != nil {
+			t.Fatalf("out-of-band GET: %v", err)
+		}
+
+		blockName := uiBlockName
+		steps := append(blueprint.Steps, bpSDK.BlueprintStep{
+			Name: &blockName,
+			Components: []bpSDK.Component{
+				{Identifier: "com.jamf.ddm.safari-settings", Configuration: []byte(`{}`)},
+			},
+		})
+
+		if err := client.UpdateBlueprint(ctx, blueprintID, &bpSDK.UpdateBlueprintRequest{Steps: &steps}); err != nil {
+			t.Fatalf("out-of-band block append: %v", err)
+		}
+	}
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testhelpers.AccTestProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckBlueprintResourcesDestroy(t),
+		Steps: []resource.TestStep{
+			{
+				Config: flatConfig("Acceptance test — safe to delete"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet(addr, "id"),
+					func(s *terraform.State) error {
+						blueprintID = s.RootModule().Resources[addr].Primary.ID
+						return nil
+					},
+				),
+			},
+			{
+				// Same config: the out-of-band block is invisible to flat mode, so the plan is
+				// empty, nothing is written, and the guard stays quiet.
+				PreConfig: appendBlockOutOfBand,
+				Config:    flatConfig("Acceptance test — safe to delete"),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{plancheck.ExpectEmptyPlan()},
+				},
+			},
+			{
+				// A real change now needs the whole block list rewritten, which would delete the
+				// out-of-band block unseen. Refused at plan time, listing what is there.
+				Config:      flatConfig("Acceptance test — updated, safe to delete"),
+				ExpectError: regexp.MustCompile(`(?s)Blueprint has component blocks.*cannot represent.*Acceptance UI block.*Migrate to`),
+			},
+		},
+	})
+}
+
 func TestAccDataSource_Blueprint(t *testing.T) {
 	testhelpers.AccPreCheck(t)
 	suffix := testhelpers.RunSuffix()


### PR DESCRIPTION
# Pull Request

## Description

A flat-mode blueprint apply can delete component blocks without the plan ever showing it. The deprecated flat top-level component attributes can only carry one block, so a read maps just the first one into state (`updateFlatComponentsFromAPI`). A block added outside Terraform — an admin hotfix in the Jamf UI — is therefore absent from prior state, invisible in the diff, and still deleted by the apply, which rewrites the whole block list at once.

Flat-mode plans with a planned change now re-read the blueprint and refuse to proceed while it has more than one block, listing the blocks so the user can author the migration without dropping one.

### Wire law behind the fix (probed)

| Level | Semantics |
|---|---|
| Top-level `name`/`description`/`scope`/`steps` | merge-patch (`application/merge-patch+json` → 204). Omit ⇒ preserved. |
| `steps` array | Atomic full replace. No per-step or per-component write path exists. |
| Component `configuration` | Opaque blob, stored verbatim, sparse-tolerated. |
| Identity | None. Step has no id; `name` is nullable **and** duplicates are accepted; duplicate component `identifier` within a step is accepted. |

No merge key means no read-merge-write is possible — index is the only correlation, and a UI insert at position 0 would make an index-keyed merge overlay the wrong block. So the ownership model stays as-is (config authoritative, drift-reverted) and this PR closes the one case where Terraform destroys something it cannot show.

### Design calls worth reviewing

- **Gated on the planned configuration, not prior state.** A flat→`component_blocks` migration still refreshes through the flat read path, so state-gating would trip the guard on the very migration the error asks for, trapping the user. Config-gating lets it through: declaring blocks *is* taking explicit ownership of them.
- **The error enumerates the blocks** because during the migration the diff still cannot show pre-existing blocks — the error text is the only place the user learns there are two.
- **A no-op plan is unguarded.** Nothing is written, so nothing is lost.
- **The read-side diagnostic stays a warning.** Erroring there would break `terraform destroy`, which refreshes first.
- **Block mode needs no guard** — every block lands in state, so removals are already plan-visible.

## Type of Change

- [x] Bug fix

## Resources/Data Sources Modified

- `jamfplatform_blueprints_blueprint`

## Testing

### Automated Tests

- [x] Added Go unit tests (`TestDescribeBlueprintBlocks`, `TestDescribeBlueprintBlocks_NoSteps` in `helpers_test.go`)
- [x] Added Go acceptance tests (`TestAccResource_Blueprint_DeprecatedFlatMode_BlockLossGuard`, covering all three plan cases)
- [x] `make fix fmt lint test` passes locally
- [ ] `make generate` — not required, no schema description changed

### Manual Testing

- [x] Tested `terraform apply` against a test Jamf instance
- [x] Tested resource/data source CRUD operations (Create, Read, Update, Delete)
- [ ] Verified resources appear correctly in Jamf Pro UI — Blueprints is a Platform Services surface; verification was done against the live blueprint payload rather than the console

Verified live, all four cases:

| Case | Result |
|---|---|
| No config change, out-of-band block present | `No changes` + warning, guard silent |
| `description` changed | Refused at plan time, error listed both blocks |
| `apply` of the same | Refused identically |
| Migrated to `component_blocks` declaring both | Applied clean; both blocks confirmed intact |

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation — see "Deliberately not in this PR"
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective
- [x] New and existing Go unit tests pass locally; acceptance is unrun locally and left to CI
- [x] Any dependent changes have been merged and published

## Additional Context

**Deliberately not in this PR:**

1. **The ownership contract sentence** on `component_blocks` ("Terraform owns every declared block, component, and field; anything added in the UI inside a managed blueprint is reverted"). Same subject, but it needs a `make generate` docs regen — happy to fold in if reviewers prefer it here.
2. **Omitting the fabricated `Included: false` wrappers.** For an undeclared field the provider emits e.g. `{"Value":"Allowed","Included":false}` rather than omitting the key. State round-trips identically either way (`FromRawConfiguration` gates on `Included == true`), so this is payload hygiene — and it needs someone to check in the console whether the Blueprints UI renders `Included: false` differently from an absent key before it is worth changing.
3. **A "manage the shell, contents in the UI" path.** Omitting all components today yields a raw `400 [NotNull] steps[0].components`. Merge-patch would allow it by not sending `steps` at all, but that is a feature, not a defect, and it carries an import wrinkle (the importer cannot infer which collections are unmanaged).

Note the flat attributes are scheduled for removal on 2026-10-22, so this guard is scaffolding with a known end date. It earns its keep if that date slips.

**Unrelated pre-existing breakage spotted, not fixed here:** `make fix` on a clean `main` rewrites `strptr(s)` to `new(s)` with a `//go:fix inline` directive in `component_blocks_test.go`, which orphans the helper and makes `make lint` fail on `unused`. That churn was reverted off this branch to keep the diff focused; it wants its own one-line commit deleting `strptr`.

## Related Issues

Relates to #299

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
