### PR TITLE
fix(pro_computer_extension_attribute): only send manage_existing_data when a SCRIPT EA is disabled

### DIFF
--- a/docs/resources/pro_computer_extension_attribute.md
+++ b/docs/resources/pro_computer_extension_attribute.md
@@ -50,22 +50,38 @@ resource "jamfplatform_pro_computer_extension_attribute" "department_class" {
   popup_menu_choices = ["Standard", "Restricted", "Kiosk"]
 }
 
-# Script extension attribute. Only SCRIPT extension attributes may be disabled,
-# and `script` is required. `manage_existing_data` is a write-only flag.
+# Script extension attribute. `script` is required, and only SCRIPT extension
+# attributes may be disabled.
 resource "jamfplatform_pro_computer_extension_attribute" "quarantine_status" {
-  name                 = "Quarantine Status"
-  data_type            = "STRING"
-  input_type           = "SCRIPT"
-  inventory_display    = "GENERAL"
-  enabled              = true
-  manage_existing_data = "RETAIN"
-  script               = <<-EOT
+  name              = "Quarantine Status"
+  data_type         = "STRING"
+  input_type        = "SCRIPT"
+  inventory_display = "GENERAL"
+  enabled           = true
+  script            = <<-EOT
     #!/bin/bash
     if [[ -d "/Library/Application Support/JamfProtect/Quarantine" ]]; then
       echo "<result>Present</result>"
     else
       echo "<result>Absent</result>"
     fi
+  EOT
+}
+
+# Disabled script extension attribute. `manage_existing_data` is a write-only
+# instruction saying what to do with the inventory values already collected, and
+# is valid only while the extension attribute is disabled (`RETAIN` is sent when
+# it is omitted).
+resource "jamfplatform_pro_computer_extension_attribute" "legacy_probe" {
+  name                 = "Legacy Probe"
+  data_type            = "STRING"
+  input_type           = "SCRIPT"
+  inventory_display    = "GENERAL"
+  enabled              = false
+  manage_existing_data = "RETAIN"
+  script               = <<-EOT
+    #!/bin/bash
+    echo "<result>retired</result>"
   EOT
 }
 
@@ -99,7 +115,7 @@ resource "jamfplatform_pro_computer_extension_attribute" "ad_department" {
 - `description` (String) **"Description"** in the Jamf Pro admin UI. Optional free-text description of the extension attribute. Omit to leave any existing value untouched (it is not cleared on update); set to `""` to clear it.
 - `directory_service_attribute` (String) **"Directory Service Attribute"** in the Jamf Pro admin UI. The directory-service attribute name mapped to this EA. Required when `input_type = DIRECTORY_SERVICE_ATTRIBUTE_MAPPING`; must be omitted for every other input type.
 - `enabled` (Boolean) **"Enable"** in the Jamf Pro admin UI. Whether the extension attribute is enabled. Only `SCRIPT` extension attributes may be disabled; for every other input type Jamf Pro forces this to `true`. Defaults to `true`.
-- `manage_existing_data` (String, [Write-only](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments)) Behavioural instruction (no admin-UI field) controlling how Jamf Pro handles already-collected inventory data when a `SCRIPT` extension attribute is updated: `RETAIN` keeps existing values, `DELETE` clears them. Valid only with `input_type = SCRIPT`. This is a Terraform `WriteOnly` attribute — it is sent to Jamf Pro on create/update but never stored in state (Jamf Pro never returns it, and it is an instruction, not a persistent property). Jamf Pro requires it on a SCRIPT update, so when omitted the provider sends `RETAIN`. Changing only this value does not trigger an update; it takes effect alongside other changes to the extension attribute.
+- `manage_existing_data` (String, [Write-only](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments)) Behavioural instruction (no admin-UI field) controlling what Jamf Pro does with the inventory data already collected by a `SCRIPT` extension attribute when that attribute is **disabled**: `RETAIN` keeps the existing values, `DELETE` clears them. Valid only with `input_type = SCRIPT` **and** `enabled = false` — Jamf Pro rejects it on any other update, and on create. Jamf Pro requires it when an enabled SCRIPT extension attribute is being disabled, so `RETAIN` is sent when it is omitted. This is a Terraform `WriteOnly` attribute — it is sent to Jamf Pro on update but never stored in state (Jamf Pro never returns it, and it is an instruction, not a persistent property). Changing only this value does not trigger an update; it takes effect alongside other changes to the extension attribute.
 - `popup_menu_choices` (Set of String) **"Pop-up menu choices"** in the Jamf Pro admin UI. The set of choices presented for a pop-up menu attribute. Valid only when `input_type = POPUP` (optional even then). Modelled as a set because Jamf Pro returns the choices sorted alphabetically rather than in the submitted order. Omit to leave any existing choices untouched (they are not cleared on an unrelated update); set to `[]` to clear them. Changing `input_type` away from `POPUP` clears the choices.
 - `script` (String) **"Script"** in the Jamf Pro admin UI. Script contents collected as the attribute value. Required when `input_type = SCRIPT`; must be omitted for every other input type. Jamf Pro normalises the stored script (notably appending a trailing newline); the provider tolerates that so it does not show as a perpetual diff.
 - `timeouts` (Attributes) (see [below for nested schema](#nestedatt--timeouts))

--- a/examples/resources/jamfplatform_pro_computer_extension_attribute/resource.tf
+++ b/examples/resources/jamfplatform_pro_computer_extension_attribute/resource.tf
@@ -16,22 +16,38 @@ resource "jamfplatform_pro_computer_extension_attribute" "department_class" {
   popup_menu_choices = ["Standard", "Restricted", "Kiosk"]
 }
 
-# Script extension attribute. Only SCRIPT extension attributes may be disabled,
-# and `script` is required. `manage_existing_data` is a write-only flag.
+# Script extension attribute. `script` is required, and only SCRIPT extension
+# attributes may be disabled.
 resource "jamfplatform_pro_computer_extension_attribute" "quarantine_status" {
-  name                 = "Quarantine Status"
-  data_type            = "STRING"
-  input_type           = "SCRIPT"
-  inventory_display    = "GENERAL"
-  enabled              = true
-  manage_existing_data = "RETAIN"
-  script               = <<-EOT
+  name              = "Quarantine Status"
+  data_type         = "STRING"
+  input_type        = "SCRIPT"
+  inventory_display = "GENERAL"
+  enabled           = true
+  script            = <<-EOT
     #!/bin/bash
     if [[ -d "/Library/Application Support/JamfProtect/Quarantine" ]]; then
       echo "<result>Present</result>"
     else
       echo "<result>Absent</result>"
     fi
+  EOT
+}
+
+# Disabled script extension attribute. `manage_existing_data` is a write-only
+# instruction saying what to do with the inventory values already collected, and
+# is valid only while the extension attribute is disabled (`RETAIN` is sent when
+# it is omitted).
+resource "jamfplatform_pro_computer_extension_attribute" "legacy_probe" {
+  name                 = "Legacy Probe"
+  data_type            = "STRING"
+  input_type           = "SCRIPT"
+  inventory_display    = "GENERAL"
+  enabled              = false
+  manage_existing_data = "RETAIN"
+  script               = <<-EOT
+    #!/bin/bash
+    echo "<result>retired</result>"
   EOT
 }
 

--- a/internal/resources/pro/computer_extension_attribute/input_builders.go
+++ b/internal/resources/pro/computer_extension_attribute/input_builders.go
@@ -26,9 +26,8 @@ import (
 // POPUP, so a stale foreign value can never reach the wire (which would 400).
 // manageExistingData is the WriteOnly value, read from config by the caller (it
 // is null in plan/state, so it cannot come from `plan`). isCreate must be true
-// only when building the Create payload: Jamf Pro 400s
-// ("This field should be blank for first time CEA creation.") if
-// manageExistingData is present on create, and only accepts it on update.
+// only when building the Create payload — see manageExistingDataFor for the
+// wire law that governs when the field may be sent.
 func buildComputerExtensionAttributeInput(ctx context.Context, plan ComputerExtensionAttributeResourceModel, manageExistingData types.String, isCreate bool) (*pro.ComputerExtensionAttributes, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
@@ -47,18 +46,7 @@ func buildComputerExtensionAttributeInput(ctx context.Context, plan ComputerExte
 	switch inputType {
 	case inputTypeScript:
 		ea.ScriptContents = helpers.OptionalStringPointer(plan.Script)
-		// manageExistingData is required (and only valid) for SCRIPT EAs on
-		// update: Jamf Pro 400s a SCRIPT update without it, and 400s a SCRIPT
-		// create with it present. Send the user's value, or RETAIN when
-		// omitted, but only on update. Never send it for non-SCRIPT EAs or on
-		// create.
-		if !isCreate {
-			mode := manageExistingDataDefault
-			if v := helpers.OptionalStringPointer(manageExistingData); v != nil {
-				mode = *v
-			}
-			ea.ManageExistingData = &mode
-		}
+		ea.ManageExistingData = manageExistingDataFor(plan.Enabled, manageExistingData, isCreate)
 	case inputTypeLDAP:
 		ea.LdapAttributeMapping = helpers.OptionalStringPointer(plan.DirectoryServiceAttribute)
 	case inputTypePopup:
@@ -73,4 +61,41 @@ func buildComputerExtensionAttributeInput(ctx context.Context, plan ComputerExte
 	}
 
 	return ea, diags
+}
+
+// manageExistingDataFor decides whether the SCRIPT-only manageExistingData
+// instruction belongs on this request, and with what value. It returns nil when
+// the field must be omitted.
+//
+// Wire law (live-probed 2026-07-28, issue #302 — the field says what to do with
+// already-collected inventory values when a SCRIPT EA is *disabled*, so Jamf Pro
+// only tolerates it on a request that lands the EA disabled):
+//
+//	POST (any enabled value)      → must be absent
+//	                                400 "[INVALID_CONTENT] manageExistingData: This field
+//	                                should be blank for first time CEA creation."
+//	PUT landing enabled = true    → must be absent
+//	                                400 "[INVALID_CONTENT] manageExistingData: This field
+//	                                should be blank if the input type is not 'SCRIPT' and
+//	                                enabled value is not false."
+//	PUT landing enabled = false   → REQUIRED on the enabled true→false transition
+//	                                (400 "This field is required and possible values can
+//	                                be [ DELETE, RETAIN ]." when omitted); accepted, and a
+//	                                no-op, when the EA is already disabled.
+//
+// So it is sent on every update that lands enabled = false — which covers the
+// transition without needing prior state — and never otherwise. enabled is
+// Computed with a true default, so a null/unknown plan value means "enabled".
+func manageExistingDataFor(enabled types.Bool, manageExistingData types.String, isCreate bool) *string {
+	if isCreate {
+		return nil
+	}
+	if enabled.IsNull() || enabled.IsUnknown() || enabled.ValueBool() {
+		return nil
+	}
+	mode := manageExistingDataDefault
+	if v := helpers.OptionalStringPointer(manageExistingData); v != nil {
+		mode = *v
+	}
+	return &mode
 }

--- a/internal/resources/pro/computer_extension_attribute/input_builders_test.go
+++ b/internal/resources/pro/computer_extension_attribute/input_builders_test.go
@@ -10,32 +10,84 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
-// TestBuildComputerExtensionAttributeInput_ManageExistingDataCreateVsUpdate
-// guards against the regression that produced
-// "[INVALID_CONTENT] manageExistingData: This field should be blank for
-// first time CEA creation." on live SCRIPT-EA create: Jamf Pro 400s if
-// manageExistingData is present on create, and requires it on update.
-func TestBuildComputerExtensionAttributeInput_ManageExistingDataCreateVsUpdate(t *testing.T) {
-	plan := ComputerExtensionAttributeResourceModel{
+// scriptPlan renders a minimal SCRIPT-EA plan model with the given enabled value.
+func scriptPlan(enabled types.Bool) ComputerExtensionAttributeResourceModel {
+	return ComputerExtensionAttributeResourceModel{
 		Name:      types.StringValue("zz-script"),
 		DataType:  types.StringValue("STRING"),
 		InputType: types.StringValue(inputTypeScript),
 		Script:    types.StringValue("#!/bin/sh\necho 1"),
+		Enabled:   enabled,
+	}
+}
+
+// TestBuildComputerExtensionAttributeInput_ManageExistingData pins the wire law
+// documented on manageExistingDataFor. It guards two live 400s:
+//
+//   - create: "[INVALID_CONTENT] manageExistingData: This field should be blank
+//     for first time CEA creation."
+//   - update of an ENABLED SCRIPT EA (issue #302): "[INVALID_CONTENT]
+//     manageExistingData: This field should be blank if the input type is not
+//     'SCRIPT' and enabled value is not false"
+//
+// and the third case, an update that disables the EA, where Jamf Pro *requires*
+// the field.
+func TestBuildComputerExtensionAttributeInput_ManageExistingData(t *testing.T) {
+	tests := []struct {
+		name     string
+		enabled  types.Bool
+		config   types.String
+		isCreate bool
+		want     *string // nil = must be omitted
+	}{
+		{"create enabled omits", types.BoolValue(true), types.StringNull(), true, nil},
+		{"create disabled omits", types.BoolValue(false), types.StringNull(), true, nil},
+		{"create disabled ignores explicit value", types.BoolValue(false), types.StringValue("DELETE"), true, nil},
+		{"update enabled omits", types.BoolValue(true), types.StringNull(), false, nil},
+		{"update enabled omits even when configured", types.BoolValue(true), types.StringValue("DELETE"), false, nil},
+		{"update null enabled treated as enabled", types.BoolNull(), types.StringNull(), false, nil},
+		{"update unknown enabled treated as enabled", types.BoolUnknown(), types.StringNull(), false, nil},
+		{"update disabled defaults to RETAIN", types.BoolValue(false), types.StringNull(), false, new(manageExistingDataDefault)},
+		{"update disabled honours DELETE", types.BoolValue(false), types.StringValue("DELETE"), false, new("DELETE")},
+		{"update disabled honours RETAIN", types.BoolValue(false), types.StringValue("RETAIN"), false, new("RETAIN")},
 	}
 
-	created, diags := buildComputerExtensionAttributeInput(context.Background(), plan, types.StringNull(), true)
-	if diags.HasError() {
-		t.Fatalf("create diags: %v", diags)
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ea, diags := buildComputerExtensionAttributeInput(context.Background(), scriptPlan(tc.enabled), tc.config, tc.isCreate)
+			if diags.HasError() {
+				t.Fatalf("diags: %v", diags)
+			}
+			switch {
+			case tc.want == nil && ea.ManageExistingData != nil:
+				t.Fatalf("manageExistingData must be omitted, got %q", *ea.ManageExistingData)
+			case tc.want != nil && ea.ManageExistingData == nil:
+				t.Fatalf("manageExistingData must be %q, got nil", *tc.want)
+			case tc.want != nil && *ea.ManageExistingData != *tc.want:
+				t.Fatalf("manageExistingData = %q, want %q", *ea.ManageExistingData, *tc.want)
+			}
+		})
 	}
-	if created.ManageExistingData != nil {
-		t.Fatalf("Create must omit manageExistingData, got %q", *created.ManageExistingData)
-	}
+}
 
-	updated, diags := buildComputerExtensionAttributeInput(context.Background(), plan, types.StringNull(), false)
-	if diags.HasError() {
-		t.Fatalf("update diags: %v", diags)
-	}
-	if updated.ManageExistingData == nil || *updated.ManageExistingData != manageExistingDataDefault {
-		t.Fatalf("Update must default manageExistingData to %q, got %v", manageExistingDataDefault, updated.ManageExistingData)
+// TestBuildComputerExtensionAttributeInput_ManageExistingDataNonScript proves the
+// field never reaches the wire for a non-SCRIPT input type, on create or update.
+func TestBuildComputerExtensionAttributeInput_ManageExistingDataNonScript(t *testing.T) {
+	for _, inputType := range []string{inputTypeText, inputTypePopup, inputTypeLDAP} {
+		for _, isCreate := range []bool{true, false} {
+			plan := ComputerExtensionAttributeResourceModel{
+				Name:      types.StringValue("zz-other"),
+				DataType:  types.StringValue("STRING"),
+				InputType: types.StringValue(inputType),
+				Enabled:   types.BoolValue(true),
+			}
+			ea, diags := buildComputerExtensionAttributeInput(context.Background(), plan, types.StringValue("RETAIN"), isCreate)
+			if diags.HasError() {
+				t.Fatalf("%s create=%v diags: %v", inputType, isCreate, diags)
+			}
+			if ea.ManageExistingData != nil {
+				t.Fatalf("%s create=%v must omit manageExistingData, got %q", inputType, isCreate, *ea.ManageExistingData)
+			}
+		}
 	}
 }

--- a/internal/resources/pro/computer_extension_attribute/resource.go
+++ b/internal/resources/pro/computer_extension_attribute/resource.go
@@ -159,7 +159,7 @@ func (r *ComputerExtensionAttributeResource) Schema(ctx context.Context, req res
 				},
 			},
 			"manage_existing_data": schema.StringAttribute{
-				MarkdownDescription: "Behavioural instruction (no admin-UI field) controlling how Jamf Pro handles already-collected inventory data when a `SCRIPT` extension attribute is updated: `RETAIN` keeps existing values, `DELETE` clears them. Valid only with `input_type = SCRIPT`. This is a Terraform `WriteOnly` attribute — it is sent to Jamf Pro on create/update but never stored in state (Jamf Pro never returns it, and it is an instruction, not a persistent property). Jamf Pro requires it on a SCRIPT update, so when omitted the provider sends `RETAIN`. Changing only this value does not trigger an update; it takes effect alongside other changes to the extension attribute.",
+				MarkdownDescription: "Behavioural instruction (no admin-UI field) controlling what Jamf Pro does with the inventory data already collected by a `SCRIPT` extension attribute when that attribute is **disabled**: `RETAIN` keeps the existing values, `DELETE` clears them. Valid only with `input_type = SCRIPT` **and** `enabled = false` — Jamf Pro rejects it on any other update, and on create. Jamf Pro requires it when an enabled SCRIPT extension attribute is being disabled, so `RETAIN` is sent when it is omitted. This is a Terraform `WriteOnly` attribute — it is sent to Jamf Pro on update but never stored in state (Jamf Pro never returns it, and it is an instruction, not a persistent property). Changing only this value does not trigger an update; it takes effect alongside other changes to the extension attribute.",
 				Optional:            true,
 				WriteOnly:           true,
 				Validators: []validator.String{

--- a/internal/resources/pro/computer_extension_attribute/resource_acceptance_test.go
+++ b/internal/resources/pro/computer_extension_attribute/resource_acceptance_test.go
@@ -11,6 +11,8 @@
 //   - empty-echo normalization (no perma-diff on a bare TEXT EA)
 //   - script trailing-newline tolerance (import ignores `script`; server appends \n)
 //   - manage_existing_data is write-only (import ignores it; never returned)
+//   - manage_existing_data is sent only on an update that disables a SCRIPT EA
+//     (issue #302 — see TestAccResource_ProComputerExtensionAttribute_ScriptEnabledUpdate)
 
 package computer_extension_attribute_test
 
@@ -316,6 +318,112 @@ func TestAccResource_ProComputerExtensionAttribute_SplitOwnership(t *testing.T) 
 	})
 }
 
+// ceaScriptEnabled renders an ENABLED SCRIPT EA with the given script body and
+// no manage_existing_data — the shape from issue #302.
+func ceaScriptEnabled(name, script string) string {
+	return fmt.Sprintf(`
+		resource "jamfplatform_pro_computer_extension_attribute" "test" {
+			name              = %q
+			description       = "issue 302 regression"
+			data_type         = "STRING"
+			input_type        = "SCRIPT"
+			inventory_display = "GENERAL"
+			enabled           = true
+			script            = %q
+		}
+	`, name, script)
+}
+
+// TestAccResource_ProComputerExtensionAttribute_ScriptEnabledUpdate is the
+// issue #302 regression test: updating an ENABLED SCRIPT EA used to 400 with
+// "[INVALID_CONTENT] manageExistingData: This field should be blank if the input
+// type is not 'SCRIPT' and enabled value is not false" because the provider sent
+// manageExistingData = RETAIN on every SCRIPT update. Jamf Pro accepts the field
+// only on an update that lands the EA disabled, and requires it on the
+// enabled→disabled transition. This walks the whole enabled/disabled matrix:
+//
+//	step 1  create enabled            (field must be absent on POST)
+//	step 2  edit script, still enabled (field must be absent — the #302 repro)
+//	step 3  disable                    (field REQUIRED; provider defaults to RETAIN)
+//	step 4  edit script while disabled (field sent, already-disabled no-op)
+//	step 5  re-enable + edit script    (field must be absent again)
+func TestAccResource_ProComputerExtensionAttribute_ScriptEnabledUpdate(t *testing.T) {
+	testhelpers.AccPreCheck(t)
+	suffix := testhelpers.RunSuffix()
+	name := "tf-acc-cea-script-enabled-" + suffix
+
+	const scriptV1 = "#!/bin/sh\necho \"<result>v1</result>\""
+	const scriptV2 = "#!/bin/sh\necho \"<result>v2</result>\""
+	const scriptV3 = "#!/bin/sh\necho \"<result>v3</result>\""
+	const scriptV4 = "#!/bin/sh\necho \"<result>v4</result>\""
+
+	// Disabled steps carry manage_existing_data explicitly (step 3) and omitted
+	// (step 4) to cover both the "user supplied" and "provider defaults to
+	// RETAIN" paths of the required-on-disable rule.
+	disabled := func(script, medLine string) string {
+		return fmt.Sprintf(`
+			resource "jamfplatform_pro_computer_extension_attribute" "test" {
+				name              = %q
+				description       = "issue 302 regression"
+				data_type         = "STRING"
+				input_type        = "SCRIPT"
+				inventory_display = "GENERAL"
+				enabled           = false
+				script            = %q
+				%s
+			}
+		`, name, script, medLine)
+	}
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testhelpers.AccTestProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckCEADestroy(t),
+		Steps: []resource.TestStep{
+			{
+				Config: ceaScriptEnabled(name, scriptV1),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet(ceaResource, "id"),
+					resource.TestCheckResourceAttr(ceaResource, "enabled", "true"),
+					resource.TestCheckResourceAttr(ceaResource, "script", scriptV1),
+				),
+			},
+			{
+				// The #302 repro: change only the script, EA stays enabled.
+				Config: ceaScriptEnabled(name, scriptV2),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(ceaResource, "enabled", "true"),
+					resource.TestCheckResourceAttr(ceaResource, "script", scriptV2),
+				),
+			},
+			{
+				// enabled true→false: Jamf Pro requires manage_existing_data.
+				Config: disabled(scriptV3, `manage_existing_data = "RETAIN"`),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(ceaResource, "enabled", "false"),
+					resource.TestCheckResourceAttr(ceaResource, "script", scriptV3),
+				),
+			},
+			{
+				// Already disabled, manage_existing_data omitted: the provider
+				// still sends RETAIN, which Jamf Pro accepts as a no-op.
+				Config: disabled(scriptV4, ""),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(ceaResource, "enabled", "false"),
+					resource.TestCheckResourceAttr(ceaResource, "script", scriptV4),
+				),
+			},
+			{
+				// Re-enable: the field must drop off the payload again.
+				Config: ceaScriptEnabled(name, scriptV1),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(ceaResource, "enabled", "true"),
+					resource.TestCheckResourceAttr(ceaResource, "script", scriptV1),
+				),
+			},
+		},
+	})
+}
+
 // ceaPopupNoChoices renders a POPUP EA that OMITS popup_menu_choices, varying
 // inventory_display so an unrelated change can be applied.
 func ceaPopupNoChoices(name, inventoryDisplay string) string {
@@ -472,6 +580,14 @@ func TestAccResource_ProComputerExtensionAttribute_ValidatorErrors(t *testing.T)
 			name:   "enabled false forbidden on TEXT",
 			config: ceaBad(`data_type = "STRING"`, `input_type = "TEXT"`, `inventory_display = "GENERAL"`, `enabled = false`),
 			expect: regexp.MustCompile(`SCRIPT`),
+		},
+		{
+			// Issue #302: Jamf Pro only accepts manage_existing_data on an update
+			// that disables the EA, so an enabled SCRIPT EA must not declare it.
+			name: "manage_existing_data forbidden while enabled",
+			config: ceaBad(`data_type = "STRING"`, `input_type = "SCRIPT"`, `inventory_display = "GENERAL"`,
+				`script = "echo hi"`, `enabled = true`, `manage_existing_data = "RETAIN"`),
+			expect: regexp.MustCompile(`manage_existing_data`),
 		},
 	}
 

--- a/internal/resources/pro/computer_extension_attribute/schema_types.go
+++ b/internal/resources/pro/computer_extension_attribute/schema_types.go
@@ -33,9 +33,10 @@ var (
 	// (wire-probed: the Pro PUT for a SCRIPT EA requires DELETE or RETAIN).
 	validManageExistingData = []string{"DELETE", "RETAIN"}
 
-	// manageExistingDataDefault is sent for SCRIPT EAs when the user omits
-	// manage_existing_data — RETAIN preserves already-collected inventory data,
-	// the safe default. Jamf Pro requires this field on a SCRIPT EA update.
+	// manageExistingDataDefault is sent when a SCRIPT EA update disables the EA
+	// and the user omitted manage_existing_data — RETAIN preserves
+	// already-collected inventory data, the safe default. See
+	// manageExistingDataFor for when the field is sent at all.
 	manageExistingDataDefault = "RETAIN"
 
 	// validInventoryDisplays is the "Inventory display" dropdown (6 tabs).

--- a/internal/resources/pro/computer_extension_attribute/validators.go
+++ b/internal/resources/pro/computer_extension_attribute/validators.go
@@ -27,6 +27,8 @@ import (
 //	enabled = false                                  → only valid when input_type = SCRIPT
 //	allow_multiple_values = true                     → only valid when input_type =
 //	                                                   DIRECTORY_SERVICE_ATTRIBUTE_MAPPING
+//	manage_existing_data                             → only valid when input_type = SCRIPT
+//	                                                   AND enabled = false
 //
 // Off-the-shelf validators (ConflictsWith / AlsoRequires) fire regardless of the
 // discriminator value, which is the wrong shape — the constraint is value-specific.
@@ -36,7 +38,7 @@ type inputTypeConfigValidator struct{}
 
 // Description returns a plain-text description of the validator.
 func (inputTypeConfigValidator) Description(context.Context) string {
-	return "the companion fields permitted for an extension attribute are keyed off input_type: SCRIPT requires script; DIRECTORY_SERVICE_ATTRIBUTE_MAPPING requires directory_service_attribute; popup_menu_choices is only valid with POPUP; only SCRIPT EAs may be disabled; allow_multiple_values is only valid with DIRECTORY_SERVICE_ATTRIBUTE_MAPPING"
+	return "the companion fields permitted for an extension attribute are keyed off input_type: SCRIPT requires script; DIRECTORY_SERVICE_ATTRIBUTE_MAPPING requires directory_service_attribute; popup_menu_choices is only valid with POPUP; only SCRIPT EAs may be disabled; allow_multiple_values is only valid with DIRECTORY_SERVICE_ATTRIBUTE_MAPPING; manage_existing_data is only valid on a disabled SCRIPT EA"
 }
 
 // MarkdownDescription returns the markdown description.
@@ -102,8 +104,22 @@ func (inputTypeConfigValidator) ValidateResource(ctx context.Context, req resour
 			fmt.Sprintf("`allow_multiple_values` applies only to directory-service-mapped attributes; input_type = %q does not permit it.", inputType))
 	}
 
-	// manage_existing_data is only meaningful for SCRIPT EAs.
-	forbid(resp, "manage_existing_data", isStringSet(data.ManageExistingData) && inputType != inputTypeScript, inputType, inputTypeScript)
+	// manage_existing_data is only meaningful when a SCRIPT EA is disabled — it
+	// says what to do with the inventory values already collected. Jamf Pro
+	// rejects it on every other request (issue #302).
+	if isStringSet(data.ManageExistingData) {
+		switch {
+		case inputType != inputTypeScript:
+			forbid(resp, "manage_existing_data", true, inputType, inputTypeScript)
+		case data.Enabled.IsUnknown():
+			// Defer: enabled is interpolated, so the rule cannot be evaluated.
+		case data.Enabled.IsNull() || data.Enabled.ValueBool():
+			// enabled defaults to true, so an omitted enabled is an enabled EA.
+			resp.Diagnostics.AddAttributeError(path.Root("manage_existing_data"),
+				"manage_existing_data may only be set when enabled = false",
+				"`manage_existing_data` tells Jamf Pro what to do with the inventory data already collected by a SCRIPT extension attribute when that attribute is disabled, so Jamf Pro accepts it only on an update that sets `enabled = false`. Remove it, or set `enabled = false`.")
+		}
+	}
 }
 
 // isStringSet reports whether a string attribute carries a usable (known,

--- a/internal/resources/pro/computer_extension_attribute/validators_test.go
+++ b/internal/resources/pro/computer_extension_attribute/validators_test.go
@@ -68,6 +68,7 @@ func TestInputTypeValidator_Computer_DefersOnUnknownCompanion(t *testing.T) {
 	}{
 		{"SCRIPT with unknown script", map[string]tftypes.Value{"input_type": str("SCRIPT"), "script": unknown}},
 		{"DSAM with unknown directory_service_attribute", map[string]tftypes.Value{"input_type": str("DIRECTORY_SERVICE_ATTRIBUTE_MAPPING"), "directory_service_attribute": unknown}},
+		{"SCRIPT manage_existing_data with unknown enabled", map[string]tftypes.Value{"input_type": str("SCRIPT"), "script": str("x"), "enabled": tftypes.NewValue(tftypes.Bool, tftypes.UnknownValue), "manage_existing_data": str("RETAIN")}},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -111,8 +112,11 @@ func TestInputTypeValidator_Computer(t *testing.T) {
 		{"text disabled forbidden", map[string]tftypes.Value{"input_type": str("TEXT"), "enabled": boolv(false)}, true},
 		{"text allow multiple forbidden", map[string]tftypes.Value{"input_type": str("TEXT"), "allow_multiple_values": boolv(true)}, true},
 
-		// manage_existing_data is SCRIPT-only.
-		{"script manage_existing_data ok", map[string]tftypes.Value{"input_type": str("SCRIPT"), "script": str("x"), "manage_existing_data": str("RETAIN")}, false},
+		// manage_existing_data is valid only on a DISABLED SCRIPT EA (issue #302:
+		// Jamf Pro 400s the field on an enabled-SCRIPT update).
+		{"script disabled manage_existing_data ok", map[string]tftypes.Value{"input_type": str("SCRIPT"), "script": str("x"), "enabled": boolv(false), "manage_existing_data": str("RETAIN")}, false},
+		{"script enabled manage_existing_data forbidden", map[string]tftypes.Value{"input_type": str("SCRIPT"), "script": str("x"), "enabled": boolv(true), "manage_existing_data": str("RETAIN")}, true},
+		{"script omitted enabled manage_existing_data forbidden", map[string]tftypes.Value{"input_type": str("SCRIPT"), "script": str("x"), "manage_existing_data": str("RETAIN")}, true},
 		{"text manage_existing_data forbidden", map[string]tftypes.Value{"input_type": str("TEXT"), "manage_existing_data": str("RETAIN")}, true},
 	}
 


### PR DESCRIPTION
Fixes #302

## The bug

Updating an **enabled** `SCRIPT` computer extension attribute — e.g. editing the script body — always failed:

```
[INVALID_CONTENT] manageExistingData: This field should be blank if the
input type is not 'SCRIPT' and enabled value is not false
```

Create and destroy were unaffected; only update. There was no config that worked: omitting `manage_existing_data` still sent `RETAIN`, and setting it explicitly (or to `""`/`null`) either hit the same 400 or the `OneOf` validator.

## Root cause

`buildComputerExtensionAttributeInput` sent `manageExistingData` (defaulting to `RETAIN`) on **every** SCRIPT update. Jamf Pro only tolerates the field on a request that lands the EA **disabled** — it is the instruction for what to do with the inventory values already collected when the attribute is switched off.

Live-probed law (test tenant, 2026-07-28):

| Request | `manageExistingData` |
|---|---|
| create, any `enabled` | must be **absent** — `400 "This field should be blank for first time CEA creation."` |
| update landing `enabled = true` | must be **absent** — the 400 above |
| update landing `enabled = false` | **REQUIRED** on the `true→false` transition (`400 "This field is required and possible values can be [ DELETE, RETAIN ]."`); accepted as a no-op when the EA is already disabled |

The original "required on every SCRIPT update" reading came from an acceptance step that only ever *disabled* the EA (`ceaScript` sets `enabled = false`), so the common case — editing an enabled script EA — was never exercised.

## The fix

- New `manageExistingDataFor` sends the field only on an update whose **target** state is `enabled = false`. Keying off the target rather than prior state covers the transition and the already-disabled no-op in one rule, with no prior-state plumbing.
- The plan-time discriminator validator gains the matching rule: `manage_existing_data` requires `input_type = SCRIPT` **and** `enabled = false`. A config that would 400 now errors at plan time rather than having the value silently dropped from the payload. It defers when `enabled` is unknown (§436).
- The registry example was itself the broken shape (`enabled = true` + `manage_existing_data = "RETAIN"`), so it is split into an enabled SCRIPT EA and a disabled one that carries the instruction.
- Schema description rewritten to state the actual contract.

## Testing

**Unit** — table-driven coverage of the full matrix (create/update × enabled/disabled/null/unknown × omitted/`RETAIN`/`DELETE`), plus a non-SCRIPT guard. `make fix fmt lint test` clean; `make generate` clean.

**Live** (test tenant, `dev_overrides`):

1. Reproduced the 400 on a **pre-fix** binary: create enabled SCRIPT EA → edit script → `Error: ... [INVALID_CONTENT] manageExistingData ...`
2. Same edit on the **fixed** binary → applied; follow-up plan empty.
3. Disable + edit script with explicit `manage_existing_data = "RETAIN"` (the server-required path) → applied.
4. Edit script while already disabled, `manage_existing_data` **omitted** → applied.
5. Re-enable + edit script → applied.
6. Fresh create with `enabled = false` + `manage_existing_data = "DELETE"` → applied (field dropped from create).
7. `enabled = true` + `manage_existing_data` → plan fails with the new validator error.
8. Destroy clean; no leftovers on the tenant.

**Acceptance** — new `TestAccResource_ProComputerExtensionAttribute_ScriptEnabledUpdate` walks steps 1–5 above, and the validator matrix gains the `manage_existing_data`-while-enabled case. Not run in CI here (maintainer runs `make testacc`).

## Note for reviewers

`go fix ./...` also wants to modernise unrelated blueprint code merged in #299 (`new(expr)` pointer literals, `maps.Copy`) — reverted here to keep this PR scoped. Worth a separate housekeeping PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)