### PR TITLE
docs: surface the Jamf Concepts getting-started guide in README and provider docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # terraform-provider-jamfplatform
 
+> **📘 Start here — [Managing the Jamf Platform with Terraform: the Jamf Platform provider](https://concepts.jamf.com/guides/infrastructure-as-code/managing-the-jamf-platform-with-terraform-the-jamf-platform-provider/)**
+>
+> The official getting-started guide on Jamf Concepts. Covers installing Terraform, creating API credentials, configuring the provider, writing your first device groups / compliance benchmarks / blueprints, applying a configuration, and bringing an existing tenant under management. New to this provider or to Terraform? Read that first.
+
 Provides resources and data sources for managing the products and services available through the [Jamf Platform API](https://developer.jamf.com/platform-api/):
 
 * [Compliance Benchmark Engine](https://learn.jamf.com/en-US/bundle/jamf-compliance-benchmarks-configuration-guide/page/Compliance_Benchmarks_Configuration_Guide.html)
@@ -40,7 +44,9 @@ Further Jamf products are expected to be added; each will get its own row, names
 
 The jamfplatform provider is published in the [Hashicorp](https://registry.terraform.io/providers/Jamf-Concepts/jamfplatform) and [OpenTofu](https://search.opentofu.org/provider/jamf-concepts/jamfplatform) registries.
 
-For usage instructions and provider block/variable reference, refer to the registry link above for your platform of choice.
+For a step-by-step walkthrough — from installing Terraform through to applying your first configuration and importing an existing tenant — see the Jamf Concepts guide: [**Managing the Jamf Platform with Terraform: the Jamf Platform provider**](https://concepts.jamf.com/guides/infrastructure-as-code/managing-the-jamf-platform-with-terraform-the-jamf-platform-provider/).
+
+For provider block/variable reference, refer to the registry link above for your platform of choice.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # terraform-provider-jamfplatform
 
-> **📘 Start here — [Managing the Jamf Platform with Terraform: the Jamf Platform provider](https://concepts.jamf.com/guides/infrastructure-as-code/managing-the-jamf-platform-with-terraform-the-jamf-platform-provider/)**
+> **📘 Start here — [Managing the Jamf Platform with Terraform: the Jamf Platform provider](https://concepts.jamf.com/en/guides/infrastructure-as-code/managing-the-jamf-platform-with-terraform-the-jamf-platform-provider/)**
 >
 > The official getting-started guide on Jamf Concepts. Covers installing Terraform, creating API credentials, configuring the provider, writing your first device groups / compliance benchmarks / blueprints, applying a configuration, and bringing an existing tenant under management. New to this provider or to Terraform? Read that first.
 
@@ -44,7 +44,7 @@ Further Jamf products are expected to be added; each will get its own row, names
 
 The jamfplatform provider is published in the [Hashicorp](https://registry.terraform.io/providers/Jamf-Concepts/jamfplatform) and [OpenTofu](https://search.opentofu.org/provider/jamf-concepts/jamfplatform) registries.
 
-For a step-by-step walkthrough — from installing Terraform through to applying your first configuration and importing an existing tenant — see the Jamf Concepts guide: [**Managing the Jamf Platform with Terraform: the Jamf Platform provider**](https://concepts.jamf.com/guides/infrastructure-as-code/managing-the-jamf-platform-with-terraform-the-jamf-platform-provider/).
+For a step-by-step walkthrough — from installing Terraform through to applying your first configuration and importing an existing tenant — see the Jamf Concepts guide: [**Managing the Jamf Platform with Terraform: the Jamf Platform provider**](https://concepts.jamf.com/en/guides/infrastructure-as-code/managing-the-jamf-platform-with-terraform-the-jamf-platform-provider/).
 
 For provider block/variable reference, refer to the registry link above for your platform of choice.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,6 +3,7 @@
 page_title: "jamfplatform Provider"
 description: |-
   Provider for Jamf Platform API Services https://developer.jamf.com/platform-api/reference/getting-started-with-platform-api. Configure base_url and credentials via the provider block, environment variables, or Terraform variables.
+  📘 New here? Start with the getting-started guide: Managing the Jamf Platform with Terraform: the Jamf Platform provider https://concepts.jamf.com/guides/infrastructure-as-code/managing-the-jamf-platform-with-terraform-the-jamf-platform-provider/ on Jamf Concepts walks through installing Terraform, creating API credentials, configuring the provider, writing your first device groups, compliance benchmarks and blueprints, applying a configuration, and bringing an existing tenant under management.
   **Note:** The Jamf Platform API is currently in public beta. Provider stability, functionality, and schemas are subject to change without notice.
   Supported Jamf products and tenant version targets
   | Product | Resource namespace | Built against API as of |
@@ -15,6 +16,8 @@ description: |-
 # jamfplatform Provider
 
 Provider for [Jamf Platform API Services](https://developer.jamf.com/platform-api/reference/getting-started-with-platform-api). Configure `base_url` and credentials via the provider block, environment variables, or Terraform variables.
+
+**📘 New here? Start with the getting-started guide:** [Managing the Jamf Platform with Terraform: the Jamf Platform provider](https://concepts.jamf.com/guides/infrastructure-as-code/managing-the-jamf-platform-with-terraform-the-jamf-platform-provider/) on Jamf Concepts walks through installing Terraform, creating API credentials, configuring the provider, writing your first device groups, compliance benchmarks and blueprints, applying a configuration, and bringing an existing tenant under management.
 
 > **Note:** The Jamf Platform API is currently in public beta. Provider stability, functionality, and schemas are subject to change without notice.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,7 +3,7 @@
 page_title: "jamfplatform Provider"
 description: |-
   Provider for Jamf Platform API Services https://developer.jamf.com/platform-api/reference/getting-started-with-platform-api. Configure base_url and credentials via the provider block, environment variables, or Terraform variables.
-  📘 New here? Start with the getting-started guide: Managing the Jamf Platform with Terraform: the Jamf Platform provider https://concepts.jamf.com/guides/infrastructure-as-code/managing-the-jamf-platform-with-terraform-the-jamf-platform-provider/ on Jamf Concepts walks through installing Terraform, creating API credentials, configuring the provider, writing your first device groups, compliance benchmarks and blueprints, applying a configuration, and bringing an existing tenant under management.
+  📘 New here? Start with the getting-started guide: Managing the Jamf Platform with Terraform: the Jamf Platform provider https://concepts.jamf.com/en/guides/infrastructure-as-code/managing-the-jamf-platform-with-terraform-the-jamf-platform-provider/ on Jamf Concepts walks through installing Terraform, creating API credentials, configuring the provider, writing your first device groups, compliance benchmarks and blueprints, applying a configuration, and bringing an existing tenant under management.
   **Note:** The Jamf Platform API is currently in public beta. Provider stability, functionality, and schemas are subject to change without notice.
   Supported Jamf products and tenant version targets
   | Product | Resource namespace | Built against API as of |
@@ -17,7 +17,7 @@ description: |-
 
 Provider for [Jamf Platform API Services](https://developer.jamf.com/platform-api/reference/getting-started-with-platform-api). Configure `base_url` and credentials via the provider block, environment variables, or Terraform variables.
 
-**📘 New here? Start with the getting-started guide:** [Managing the Jamf Platform with Terraform: the Jamf Platform provider](https://concepts.jamf.com/guides/infrastructure-as-code/managing-the-jamf-platform-with-terraform-the-jamf-platform-provider/) on Jamf Concepts walks through installing Terraform, creating API credentials, configuring the provider, writing your first device groups, compliance benchmarks and blueprints, applying a configuration, and bringing an existing tenant under management.
+**📘 New here? Start with the getting-started guide:** [Managing the Jamf Platform with Terraform: the Jamf Platform provider](https://concepts.jamf.com/en/guides/infrastructure-as-code/managing-the-jamf-platform-with-terraform-the-jamf-platform-provider/) on Jamf Concepts walks through installing Terraform, creating API credentials, configuring the provider, writing your first device groups, compliance benchmarks and blueprints, applying a configuration, and bringing an existing tenant under management.
 
 > **Note:** The Jamf Platform API is currently in public beta. Provider stability, functionality, and schemas are subject to change without notice.
 

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -185,7 +185,7 @@ func (p *JamfPlatformProvider) Schema(ctx context.Context, req provider.SchemaRe
 		MarkdownDescription: fmt.Sprintf(
 			"Provider for [Jamf Platform API Services](https://developer.jamf.com/platform-api/reference/getting-started-with-platform-api). "+
 				"Configure `base_url` and credentials via the provider block, environment variables, or Terraform variables.\n\n"+
-				"**📘 New here? Start with the getting-started guide:** [Managing the Jamf Platform with Terraform: the Jamf Platform provider](https://concepts.jamf.com/guides/infrastructure-as-code/managing-the-jamf-platform-with-terraform-the-jamf-platform-provider/) on Jamf Concepts walks through installing Terraform, creating API credentials, configuring the provider, writing your first device groups, compliance benchmarks and blueprints, applying a configuration, and bringing an existing tenant under management.\n\n"+
+				"**📘 New here? Start with the getting-started guide:** [Managing the Jamf Platform with Terraform: the Jamf Platform provider](https://concepts.jamf.com/en/guides/infrastructure-as-code/managing-the-jamf-platform-with-terraform-the-jamf-platform-provider/) on Jamf Concepts walks through installing Terraform, creating API credentials, configuring the provider, writing your first device groups, compliance benchmarks and blueprints, applying a configuration, and bringing an existing tenant under management.\n\n"+
 				"> **Note:** The Jamf Platform API is currently in public beta. Provider stability, functionality, and schemas are subject to change without notice.\n\n"+
 				"**Supported Jamf products and tenant version targets**\n\n"+
 				"| Product | Resource namespace | Built against API as of |\n"+

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -185,6 +185,7 @@ func (p *JamfPlatformProvider) Schema(ctx context.Context, req provider.SchemaRe
 		MarkdownDescription: fmt.Sprintf(
 			"Provider for [Jamf Platform API Services](https://developer.jamf.com/platform-api/reference/getting-started-with-platform-api). "+
 				"Configure `base_url` and credentials via the provider block, environment variables, or Terraform variables.\n\n"+
+				"**📘 New here? Start with the getting-started guide:** [Managing the Jamf Platform with Terraform: the Jamf Platform provider](https://concepts.jamf.com/guides/infrastructure-as-code/managing-the-jamf-platform-with-terraform-the-jamf-platform-provider/) on Jamf Concepts walks through installing Terraform, creating API credentials, configuring the provider, writing your first device groups, compliance benchmarks and blueprints, applying a configuration, and bringing an existing tenant under management.\n\n"+
 				"> **Note:** The Jamf Platform API is currently in public beta. Provider stability, functionality, and schemas are subject to change without notice.\n\n"+
 				"**Supported Jamf products and tenant version targets**\n\n"+
 				"| Product | Resource namespace | Built against API as of |\n"+


### PR DESCRIPTION
## What

Makes the official getting-started guide — [**Managing the Jamf Platform with Terraform: the Jamf Platform provider**](https://concepts.jamf.com/en/guides/infrastructure-as-code/managing-the-jamf-platform-with-terraform-the-jamf-platform-provider/) — discoverable in the repo and, importantly, to anyone landing on the provider from the Terraform or OpenTofu registries.

Companion to Jamf-Concepts/terraform-provider-jamfprotect#126, which does the same for the Protect provider.

## Changes

| File | Change |
|---|---|
| `README.md` | Blockquote callout immediately under the H1, before the API-surface list. Plus a pointer alongside the registry links in *Using the Provider in your own Terraform Projects*. |
| `internal/provider/provider.go` | Guide paragraph added to the provider schema `MarkdownDescription`, above the public-beta note. |
| `docs/index.md` | Regenerated via `make generate` — this is what renders on both registry landing pages. |

## Note on the URL

Uses the canonical `/en/` path deliberately. The locale-less path (`concepts.jamf.com/guides/…`) looks like a locale-negotiating URL but is actually a legacy redirect stub: `robots: noindex, follow`, `<title>Redirecting...</title>`, and a client-side `<meta http-equiv="refresh">` that hard-targets `/en/` regardless of the reader. Its own `<link rel="canonical">` points at `/en/`.

Callouts use **bold** rather than a Markdown heading, also deliberately: a `###` inside the schema description gets flattened into the YAML `description:` frontmatter that feeds registry search snippets, and it trips `markdownlint` MD001 in the README.

## Verification

- `make fmt lint` — clean, 0 issues.
- `make generate` — run; `docs/index.md` diff is the expected three added lines.
- Docs-only change, no resource or schema behaviour touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)