### PR TITLE
chore: apply go fix modernisation and clear the acceptance-tag lint backlog

### DIFF
--- a/internal/resources/blueprints/blueprint/component_blocks_test.go
+++ b/internal/resources/blueprints/blueprint/component_blocks_test.go
@@ -15,8 +15,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
-func strptr(s string) *string { return &s }
-
 // --- Schema ---
 
 func TestBlueprintResource_SchemaComponentBlocks(t *testing.T) {
@@ -191,12 +189,12 @@ func TestUpdateModelFromAPIResponse_BlockMode(t *testing.T) {
 		DeploymentState: &blueprints.DeploymentState{State: "DEPLOYED"},
 		Steps: []blueprints.BlueprintStep{
 			{
-				Name:       strptr("Step 1"),
+				Name:       new("Step 1"),
 				Components: []blueprints.Component{{Identifier: "com.jamf.custom.thing", Configuration: json.RawMessage(`{"a":"1"}`)}},
 			},
 			{
-				Name:                strptr("Step 2"),
-				ActivationPredicate: strptr("ANY @status(x) == 'y'"),
+				Name:                new("Step 2"),
+				ActivationPredicate: new("ANY @status(x) == 'y'"),
 				Components:          []blueprints.Component{{Identifier: "com.jamf.custom.thing", Configuration: json.RawMessage(`{"a":"2"}`)}},
 			},
 		},
@@ -276,7 +274,7 @@ func TestUpdateModelFromAPIResponse_EmptyPriorUsesBlockMode(t *testing.T) {
 	blueprint := &blueprints.BlueprintDetail{
 		DeploymentState: &blueprints.DeploymentState{State: "NOT_DEPLOYED"},
 		Steps: []blueprints.BlueprintStep{
-			{Name: strptr("Only Block"), Components: []blueprints.Component{{Identifier: "com.jamf.custom.x", Configuration: json.RawMessage(`{"k":"v"}`)}}},
+			{Name: new("Only Block"), Components: []blueprints.Component{{Identifier: "com.jamf.custom.x", Configuration: json.RawMessage(`{"k":"v"}`)}}},
 		},
 	}
 

--- a/internal/resources/blueprints/blueprint/resource.go
+++ b/internal/resources/blueprints/blueprint/resource.go
@@ -6,6 +6,7 @@ package blueprint
 import (
 	"context"
 	"fmt"
+	"maps"
 	"regexp"
 	"time"
 
@@ -146,9 +147,7 @@ func (r *BlueprintResource) Schema(ctx context.Context, req resource.SchemaReque
 		},
 	}
 
-	for name, attr := range sharedComponentAttributes(componentAttrDeprecation) {
-		attributes[name] = attr
-	}
+	maps.Copy(attributes, sharedComponentAttributes(componentAttrDeprecation))
 
 	resp.Schema = schema.Schema{
 		Version:             3,
@@ -304,9 +303,7 @@ func componentBlockAttributes() map[string]schema.Attribute {
 		},
 	}
 
-	for name, attr := range sharedComponentAttributes("") {
-		attributes[name] = attr
-	}
+	maps.Copy(attributes, sharedComponentAttributes(""))
 
 	return attributes
 }

--- a/internal/resources/cbengine/benchmark/resource_acceptance_test.go
+++ b/internal/resources/cbengine/benchmark/resource_acceptance_test.go
@@ -194,7 +194,7 @@ func TestAccResource_Benchmark_CustomRules_MonitorAndEnforce(t *testing.T) {
 	}
 
 	var ruleBlocks []string
-	for i := 0; i < 2; i++ {
+	for i := range 2 {
 		r := rules.Rules[i]
 		block := fmt.Sprintf(`{ id = %q, enabled = true`, r.ID)
 		if r.ODV != nil {

--- a/internal/resources/pro/account/resource_acceptance_test.go
+++ b/internal/resources/pro/account/resource_acceptance_test.go
@@ -13,6 +13,7 @@ package account_test
 import (
 	"context"
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/Jamf-Concepts/jamfplatform-go-sdk/jamfplatform/pro"
@@ -45,12 +46,12 @@ func testAccCheckAccountDestroy(t *testing.T) resource.TestCheckFunc {
 }
 
 func customAccountConfig(suffix string, objects ...string) string {
-	quoted := ""
+	var quoted strings.Builder
 	for i, p := range objects {
 		if i > 0 {
-			quoted += ", "
+			quoted.WriteString(", ")
 		}
-		quoted += fmt.Sprintf("%q", p)
+		fmt.Fprintf(&quoted, "%q", p)
 	}
 	return fmt.Sprintf(`
 resource "jamfplatform_pro_account" "test" {
@@ -67,7 +68,7 @@ resource "jamfplatform_pro_account" "test" {
     jamf_pro_server_objects = [%[2]s]
   }
 }
-`, suffix, quoted)
+`, suffix, quoted.String())
 }
 
 // TestAccResource_ProAccount covers the create + privilege-only update + import

--- a/internal/resources/pro/account_group/resource_acceptance_test.go
+++ b/internal/resources/pro/account_group/resource_acceptance_test.go
@@ -13,6 +13,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/Jamf-Concepts/jamfplatform-go-sdk/jamfplatform/proclassic"
@@ -47,12 +48,12 @@ func testAccCheckAccountGroupDestroy(t *testing.T) resource.TestCheckFunc {
 // customGroupConfig builds a Custom-privilege-set group with the given
 // jamf_pro_server_objects privileges.
 func customGroupConfig(displayName string, objects ...string) string {
-	quoted := ""
+	var quoted strings.Builder
 	for i, p := range objects {
 		if i > 0 {
-			quoted += ", "
+			quoted.WriteString(", ")
 		}
-		quoted += fmt.Sprintf("%q", p)
+		fmt.Fprintf(&quoted, "%q", p)
 	}
 	return fmt.Sprintf(`
 resource "jamfplatform_pro_account_group" "test" {
@@ -63,7 +64,7 @@ resource "jamfplatform_pro_account_group" "test" {
     jamf_pro_server_objects = [%s]
   }
 }
-`, displayName, quoted)
+`, displayName, quoted.String())
 }
 
 // TestAccResource_ProAccountGroup exercises the full lifecycle plus the privilege

--- a/internal/resources/pro/computer_extension_attribute/resource_acceptance_test.go
+++ b/internal/resources/pro/computer_extension_attribute/resource_acceptance_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"regexp"
+	"strings"
 	"testing"
 
 	"github.com/Jamf-Concepts/jamfplatform-go-sdk/jamfplatform/pro"
@@ -606,15 +607,15 @@ func TestAccResource_ProComputerExtensionAttribute_ValidatorErrors(t *testing.T)
 // ceaBad assembles a resource block from arbitrary attribute lines, for the
 // negative validator cases.
 func ceaBad(lines ...string) string {
-	body := ""
+	var body strings.Builder
 	for _, l := range lines {
-		body += "\t\t\t" + l + "\n"
+		body.WriteString("\t\t\t" + l + "\n")
 	}
 	return fmt.Sprintf(`
 		resource "jamfplatform_pro_computer_extension_attribute" "test" {
 			name = "tf-acc-cea-bad"
 %s		}
-	`, body)
+	`, body.String())
 }
 
 func TestAccDataSource_ProComputerExtensionAttribute_ByIDAndName(t *testing.T) {

--- a/internal/resources/pro/licensed_software/resource_acceptance_test.go
+++ b/internal/resources/pro/licensed_software/resource_acceptance_test.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"fmt"
 	"regexp"
+	"strings"
 	"testing"
 
 	"github.com/Jamf-Concepts/jamfplatform-go-sdk/jamfplatform/proclassic"
@@ -241,12 +242,12 @@ func TestAccResource_ProLicensedSoftware(t *testing.T) {
 // default ("like") is exercised end-to-end. licence_count is derived from the
 // 1-based position so a value landing at the wrong index is detectable.
 func posListsConfig(name string, defNames, licSerials []string) string {
-	defs := ""
+	var defs strings.Builder
 	for _, d := range defNames {
 		if d == "Bravo" {
-			defs += fmt.Sprintf("\t\t\t\t{ name = %q, version = \"2.0\" },\n", d) // compare_type omitted -> default "like"
+			fmt.Fprintf(&defs, "\t\t\t\t{ name = %q, version = \"2.0\" },\n", d) // compare_type omitted -> default "like"
 		} else {
-			defs += fmt.Sprintf("\t\t\t\t{ name = %q, version = \"1.0\", compare_type = \"is\" },\n", d)
+			fmt.Fprintf(&defs, "\t\t\t\t{ name = %q, version = \"1.0\", compare_type = \"is\" },\n", d)
 		}
 	}
 	lics := ""
@@ -261,7 +262,7 @@ func posListsConfig(name string, defNames, licSerials []string) string {
 			licenses = [
 %s			]
 		}
-	`, name, defs, lics)
+	`, name, defs.String(), lics)
 }
 
 // TestAccResource_ProLicensedSoftware_PositionalLists targets the defining risk

--- a/internal/resources/pro/login_page/resource_acceptance_test.go
+++ b/internal/resources/pro/login_page/resource_acceptance_test.go
@@ -16,9 +16,6 @@ import (
 	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/testhelpers"
 )
 
-// strptr is a small helper for building *string PUT payloads in out-of-band baselines.
-func strptr(s string) *string { return &s }
-
 // checkSingletonRecordStillExists verifies the Jamf Pro login page settings record persists
 // on the tenant after Terraform destroys the resource from state. Canonical singleton
 // acceptance check: the remote Delete is a no-op, so the API must still return the record.
@@ -105,9 +102,9 @@ func TestAccResource_ProLoginPageSettings_CreateAdopt(t *testing.T) {
 		c := pro.New(testhelpers.NewAcceptanceClient(t))
 		body := &pro.LoginContentPut{
 			IncludeCustomDisclaimer: true,
-			DisclaimerHeading:       strptr("Baseline Heading"),
-			DisclaimerMainText:      strptr("Baseline main disclaimer body."),
-			ActionText:              strptr("Acknowledge"),
+			DisclaimerHeading:       new("Baseline Heading"),
+			DisclaimerMainText:      new("Baseline main disclaimer body."),
+			ActionText:              new("Acknowledge"),
 		}
 		if _, err := c.UpdateLoginCustomizationV1(context.Background(), body); err != nil {
 			t.Fatalf("out-of-band baseline PUT: %v", err)

--- a/internal/resources/pro/macos_configuration_profile/resource_acceptance_test.go
+++ b/internal/resources/pro/macos_configuration_profile/resource_acceptance_test.go
@@ -240,11 +240,7 @@ func createDummyComputer(t *testing.T, name string) string {
 	}); err != nil {
 		t.Fatalf("CreateComputerByID(%q): %v", name, err)
 	}
-	got, err := c.GetComputerByName(ctx, name)
-	if err != nil || got == nil || got.General == nil || got.General.ID == nil {
-		t.Fatalf("GetComputerByName(%q) after create: %v", name, err)
-	}
-	id := fmt.Sprintf("%d", *got.General.ID)
+	id := testhelpers.ResolveComputerIDByName(ctx, t, name)
 	t.Cleanup(func() {
 		if err := c.DeleteComputerByID(context.Background(), id); err != nil && !helpers.IsNotFoundError(err) {
 			t.Logf("cleanup DeleteComputerByID(%s): %v", id, err)

--- a/internal/resources/pro/mobile_device_prestage_enrollment/resource_acceptance_test.go
+++ b/internal/resources/pro/mobile_device_prestage_enrollment/resource_acceptance_test.go
@@ -113,7 +113,7 @@ func requireADEMultiSerialsFixture(t *testing.T, min int) []string {
 		t.Skipf("JAMFPLATFORM_ADE_MOBILE_SERIALS not set — multi-serial scope acc test requires %d comma-separated ADE-bound mobile-device serials.", min)
 	}
 	var serials []string
-	for _, s := range strings.Split(raw, ",") {
+	for s := range strings.SplitSeq(raw, ",") {
 		if s = strings.TrimSpace(s); s != "" {
 			serials = append(serials, s)
 		}

--- a/internal/resources/pro/package/fixtures_acceptance_test.go
+++ b/internal/resources/pro/package/fixtures_acceptance_test.go
@@ -6,10 +6,8 @@
 package pkg_test
 
 import (
-	"context"
 	"crypto/sha3"
 	"encoding/hex"
-	"fmt"
 	"io"
 	"net/http"
 	"os"
@@ -127,16 +125,6 @@ func downloadAndHashURL(t *testing.T, url string) (string, string) {
 func staticDigest(d string) func() string {
 	return func() string { return strings.ToLower(d) }
 }
-
-// renderHCL is a small sprintf wrapper that keeps the test bodies easy to
-// scan when interpolating display_name / source / hash values.
-func renderHCL(template string, args ...any) string {
-	return fmt.Sprintf(template, args...)
-}
-
-// withContext returns a derived context for in-test SDK calls. Keeps the
-// test bodies short.
-func withContext() context.Context { return context.Background() }
 
 // writeTempManifest stages a synthetic plist body in the test's tempdir.
 // Returned path is auto-removed by the testing framework when the test

--- a/internal/resources/pro/patch_software_title/resource_acceptance_test.go
+++ b/internal/resources/pro/patch_software_title/resource_acceptance_test.go
@@ -21,7 +21,7 @@ import (
 	"regexp"
 	"testing"
 
-	"github.com/Jamf-Concepts/jamfplatform-go-sdk/jamfplatform/proclassic"
+	"github.com/Jamf-Concepts/jamfplatform-go-sdk/jamfplatform/pro"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/querycheck"
@@ -43,16 +43,22 @@ const (
 
 // testAccCheckPatchSoftwareTitleDestroy verifies titles created during the test
 // were destroyed.
+//
+// The read goes through the v2 patch software title configurations endpoint. The
+// resource itself is ProClassic-backed, but the classic by-id read is deprecated
+// in the Jamf API spec, and both endpoints address the same object: wire-probed
+// 2026-08-03, each returns 404 for an id that does not exist, so
+// helpers.IsNotFoundError classifies them identically.
 func testAccCheckPatchSoftwareTitleDestroy(t *testing.T) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		c := proclassic.New(testhelpers.NewAcceptanceClient(t))
+		c := pro.New(testhelpers.NewAcceptanceClient(t))
 		ctx := context.Background()
 
 		for _, rs := range s.RootModule().Resources {
 			if rs.Type != patchSoftwareType {
 				continue
 			}
-			_, err := c.GetPatchSoftwareTitleByID(ctx, rs.Primary.ID)
+			_, err := c.GetPatchSoftwareTitleConfigurationV2(ctx, rs.Primary.ID)
 			if err != nil {
 				if helpers.IsNotFoundError(err) {
 					continue

--- a/internal/resources/pro/policy/resource_acceptance_test.go
+++ b/internal/resources/pro/policy/resource_acceptance_test.go
@@ -46,11 +46,7 @@ func createDummyComputer(t *testing.T, name string) string {
 	}); err != nil {
 		t.Fatalf("CreateComputerByID(%q): %v", name, err)
 	}
-	got, err := c.GetComputerByName(ctx, name)
-	if err != nil || got == nil || got.General == nil || got.General.ID == nil {
-		t.Fatalf("GetComputerByName(%q) after create: %v", name, err)
-	}
-	id := fmt.Sprintf("%d", *got.General.ID)
+	id := testhelpers.ResolveComputerIDByName(ctx, t, name)
 	t.Cleanup(func() {
 		if err := c.DeleteComputerByID(context.Background(), id); err != nil && !helpers.IsNotFoundError(err) {
 			t.Logf("cleanup DeleteComputerByID(%s): %v", id, err)

--- a/internal/resources/pro/self_service_branding_image/resource_acceptance_test.go
+++ b/internal/resources/pro/self_service_branding_image/resource_acceptance_test.go
@@ -30,8 +30,8 @@ var imageSourceHashRegex = regexp.MustCompile(`^sha256:[0-9a-f]{64}$`)
 func writePNG(t *testing.T, dir, name string, w, h int, tint uint8) string {
 	t.Helper()
 	m := image.NewRGBA(image.Rect(0, 0, w, h))
-	for y := 0; y < h; y++ {
-		for x := 0; x < w; x++ {
+	for y := range h {
+		for x := range w {
 			m.Set(x, y, color.RGBA{uint8(x), uint8(y), tint, 255})
 		}
 	}
@@ -40,9 +40,15 @@ func writePNG(t *testing.T, dir, name string, w, h int, tint uint8) string {
 	if err != nil {
 		t.Fatalf("creating PNG fixture: %v", err)
 	}
-	defer f.Close()
 	if err := png.Encode(f, m); err != nil {
+		_ = f.Close()
 		t.Fatalf("encoding PNG fixture: %v", err)
+	}
+	// Close is checked rather than deferred: a dropped Close can hide a flush
+	// failure that leaves the fixture truncated, which then fails somewhere far
+	// less obvious than here.
+	if err := f.Close(); err != nil {
+		t.Fatalf("closing PNG fixture: %v", err)
 	}
 	return p
 }

--- a/internal/resources/pro/self_service_branding_ios/resource_acceptance_test.go
+++ b/internal/resources/pro/self_service_branding_ios/resource_acceptance_test.go
@@ -89,8 +89,8 @@ func checkIosAbsent(t *testing.T) resource.TestCheckFunc {
 func writeIosPNG(t *testing.T, path string) {
 	t.Helper()
 	m := image.NewRGBA(image.Rect(0, 0, 180, 180))
-	for y := 0; y < 180; y++ {
-		for x := 0; x < 180; x++ {
+	for y := range 180 {
+		for x := range 180 {
 			m.Set(x, y, color.RGBA{uint8(x), uint8(y), 200, 255})
 		}
 	}
@@ -98,9 +98,15 @@ func writeIosPNG(t *testing.T, path string) {
 	if err != nil {
 		t.Fatalf("creating PNG: %v", err)
 	}
-	defer f.Close()
 	if err := png.Encode(f, m); err != nil {
+		_ = f.Close()
 		t.Fatalf("encoding PNG: %v", err)
+	}
+	// Close is checked rather than deferred: a dropped Close can hide a flush
+	// failure that leaves the fixture truncated, which then fails somewhere far
+	// less obvious than here.
+	if err := f.Close(); err != nil {
+		t.Fatalf("closing PNG: %v", err)
 	}
 }
 

--- a/internal/resources/pro/self_service_branding_macos/resource_acceptance_test.go
+++ b/internal/resources/pro/self_service_branding_macos/resource_acceptance_test.go
@@ -93,8 +93,8 @@ func checkMacosAbsent(t *testing.T) resource.TestCheckFunc {
 func writeMacosPNG(t *testing.T, path string, w, h int) {
 	t.Helper()
 	m := image.NewRGBA(image.Rect(0, 0, w, h))
-	for y := 0; y < h; y++ {
-		for x := 0; x < w; x++ {
+	for y := range h {
+		for x := range w {
 			m.Set(x, y, color.RGBA{uint8(x), uint8(y), 128, 255})
 		}
 	}
@@ -102,9 +102,15 @@ func writeMacosPNG(t *testing.T, path string, w, h int) {
 	if err != nil {
 		t.Fatalf("creating PNG: %v", err)
 	}
-	defer f.Close()
 	if err := png.Encode(f, m); err != nil {
+		_ = f.Close()
 		t.Fatalf("encoding PNG: %v", err)
+	}
+	// Close is checked rather than deferred: a dropped Close can hide a flush
+	// failure that leaves the fixture truncated, which then fails somewhere far
+	// less obvious than here.
+	if err := f.Close(); err != nil {
+		t.Fatalf("closing PNG: %v", err)
 	}
 }
 

--- a/internal/resources/pro/service_discovery_enrollment/resource_acceptance_test.go
+++ b/internal/resources/pro/service_discovery_enrollment/resource_acceptance_test.go
@@ -141,7 +141,7 @@ func TestAccResource_ProServiceDiscoveryEnrollment_Basic(t *testing.T) {
 					if err != nil || n < 1 {
 						return fmt.Errorf("imported state has no well_known_setting rows (#=%q)", s.Attributes["well_known_setting.#"])
 					}
-					for i := 0; i < n; i++ {
+					for i := range n {
 						if s.Attributes[fmt.Sprintf("well_known_setting.%d.enrollment_type", i)] == "mdm-adde" {
 							return nil
 						}

--- a/internal/resources/pro/user_group/resource_acceptance_test.go
+++ b/internal/resources/pro/user_group/resource_acceptance_test.go
@@ -349,7 +349,6 @@ func TestAccResource_ProUserGroup_Smart_AllOperators(t *testing.T) {
 	}
 
 	for _, spec := range specs {
-		spec := spec
 		t.Run(spec.op, func(t *testing.T) {
 			suffix := testhelpers.RunSuffix()
 			groupName := "tf-acc-pro-ug-op-" + suffix

--- a/internal/resources/pro/webhook/resource_acceptance_test.go
+++ b/internal/resources/pro/webhook/resource_acceptance_test.go
@@ -292,7 +292,6 @@ func TestAccResource_ProWebhook_AllEvents(t *testing.T) {
 
 	steps := make([]resource.TestStep, 0, len(allWebhookEvents))
 	for _, ev := range allWebhookEvents {
-		ev := ev
 		steps = append(steps, resource.TestStep{
 			Config: webhookEventOnlyConfig(name, ev),
 			Check: resource.ComposeAggregateTestCheckFunc(

--- a/internal/testhelpers/acceptance_assertions.go
+++ b/internal/testhelpers/acceptance_assertions.go
@@ -36,6 +36,33 @@ func NewProClassicClient(t *testing.T) *proclassic.Client {
 	return proclassic.New(NewAcceptanceClient(t))
 }
 
+// ResolveComputerIDByName returns the Jamf Pro computer id for a computer name.
+//
+// It reads the Pro computer inventory rather than the classic by-name lookup:
+// Jamf deprecated that endpoint (2025-02-11) along with the rest of the classic
+// computer-listing surface, so there is no non-deprecated classic equivalent to
+// fall back on. Fixtures need this because the classic create call returns the
+// new id on the wire but the SDK signature discards it.
+//
+// V3 is the current inventory version; V1 and V2 are both deprecated in the
+// spec. Wire-probed 2026-08-03: a computer created through the classic endpoint
+// is visible in V3 immediately and under the same id, so this is safe to call
+// directly after a create with no settling delay.
+func ResolveComputerIDByName(ctx context.Context, t *testing.T, name string) string {
+	t.Helper()
+
+	matches, err := pro.New(NewAcceptanceClient(t)).ListComputersInventoryV3(
+		ctx, []string{"GENERAL"}, nil, fmt.Sprintf("general.name==%q", name),
+	)
+	if err != nil {
+		t.Fatalf("resolving computer %q: %v", name, err)
+	}
+	if len(matches) == 0 {
+		t.Fatalf("no computer matched name %q", name)
+	}
+	return matches[0].ID
+}
+
 // RequireSingletonStillExists returns a CheckDestroy that asserts a Pro singleton
 // record still exists on the tenant after Terraform destroy — the convention for
 // update-only singleton resources whose Delete is a no-op. label names the record

--- a/internal/testhelpers/acceptance_client.go
+++ b/internal/testhelpers/acceptance_client.go
@@ -36,8 +36,7 @@ func RunSuffix() string {
 }
 
 // strPtr returns a pointer to the given string literal.
-func strPtr(s string) *string { return &s }
-
+//
 // initAcceptanceClient creates and validates the singleton acceptance client once.
 var initAcceptanceClient = sync.OnceValues(func() (*jamfplatform.Client, error) {
 	baseURL := os.Getenv("JAMFPLATFORM_BASE_URL")
@@ -118,7 +117,7 @@ func RequireSmartGroupFixture(t *testing.T) string {
 
 		req := &devicegroups.DeviceGroupCreateRepresentationV1{
 			Name:        smartGroupFixtureName(),
-			Description: strPtr("Terraform provider acceptance test fixture — safe to delete"),
+			Description: new("Terraform provider acceptance test fixture — safe to delete"),
 			DeviceType:  "COMPUTER",
 			GroupType:   "SMART",
 			Criteria: &[]devicegroups.DeviceGroupCriteriaRepresentationV1{

--- a/internal/testhelpers/acceptance_provider.go
+++ b/internal/testhelpers/acceptance_provider.go
@@ -37,7 +37,9 @@ func AccPreCheck(t *testing.T) {
 		t.Skip("JAMFPLATFORM_TENANT_ID must be set for acceptance tests")
 	}
 
-	os.Setenv("TF_ACC", "1")
+	if err := os.Setenv("TF_ACC", "1"); err != nil {
+		t.Fatalf("setting TF_ACC: %v", err)
+	}
 }
 
 // AccPreCheckOffline is the precheck for acceptance tests that need no tenant —

--- a/internal/testhelpers/ldap_fixture.go
+++ b/internal/testhelpers/ldap_fixture.go
@@ -211,7 +211,7 @@ func EnsureLdapServerFixture(t *testing.T, prefix string, e OktaLdapEnv) string 
 		// a disabled directory is skipped for group resolution and so will not cause
 		// "group name not unique" failures in later runs. Best-effort.
 		if err := client.UpdateLDAPServerByID(ctx, id, &proclassic.LdapServerPost{
-			Connection: &proclassic.LdapServerPostConnection{IsEnabled: ptr(false)},
+			Connection: &proclassic.LdapServerPostConnection{IsEnabled: new(false)},
 		}); err != nil {
 			t.Logf("LDAP fixture %s: delete blocked and disable fallback failed: %v", id, err)
 		} else {
@@ -225,55 +225,53 @@ func EnsureLdapServerFixture(t *testing.T, prefix string, e OktaLdapEnv) string 
 func oktaLdapServerPost(c oktaLdapConfig) *proclassic.LdapServerPost {
 	return &proclassic.LdapServerPost{
 		Connection: &proclassic.LdapServerPostConnection{
-			Name:               ptr(c.displayName),
-			ServerType:         ptr("Custom"),
-			Hostname:           ptr(c.hostname),
-			Port:               ptr(636),
-			UseSsl:             ptr(true),
-			AuthenticationType: ptr("simple"),
-			OpenCloseTimeout:   ptr(15),
-			SearchTimeout:      ptr(60),
-			UseWildcards:       ptr(true),
+			Name:               new(c.displayName),
+			ServerType:         new("Custom"),
+			Hostname:           new(c.hostname),
+			Port:               new(636),
+			UseSsl:             new(true),
+			AuthenticationType: new("simple"),
+			OpenCloseTimeout:   new(15),
+			SearchTimeout:      new(60),
+			UseWildcards:       new(true),
 			Account: &proclassic.LdapServerConnectionAccount{
-				DistinguishedUsername: ptr(fmt.Sprintf("uid=%s,%s", c.username, c.dn)),
-				Password:              ptr(c.password),
+				DistinguishedUsername: new(fmt.Sprintf("uid=%s,%s", c.username, c.dn)),
+				Password:              new(c.password),
 			},
 		},
 		MappingsForUsers: &proclassic.LdapServerPostMappingsForUsers{
 			UserMappings: &proclassic.LdapServerMappingsForUsersUserMappings{
-				MapObjectClassToAnyOrAll: ptr("all"),
-				ObjectClasses:            ptr("inetOrgPerson"),
-				SearchBase:               ptr("ou=users," + c.dn),
-				SearchScope:              ptr("All Subtrees"),
-				MapUserID:                ptr("uid"),
-				MapUsername:              ptr("uid"),
-				MapRealname:              ptr("cn"),
-				MapEmailAddress:          ptr("mail"),
-				MapDepartment:            ptr("department"),
-				MapPosition:              ptr("title"),
-				MapUserUUID:              ptr("uid"),
+				MapObjectClassToAnyOrAll: new("all"),
+				ObjectClasses:            new("inetOrgPerson"),
+				SearchBase:               new("ou=users," + c.dn),
+				SearchScope:              new("All Subtrees"),
+				MapUserID:                new("uid"),
+				MapUsername:              new("uid"),
+				MapRealname:              new("cn"),
+				MapEmailAddress:          new("mail"),
+				MapDepartment:            new("department"),
+				MapPosition:              new("title"),
+				MapUserUUID:              new("uid"),
 			},
 			UserGroupMappings: &proclassic.LdapServerMappingsForUsersUserGroupMappings{
-				MapObjectClassToAnyOrAll: ptr("all"),
-				ObjectClasses:            ptr("groupofUniqueNames"),
-				SearchBase:               ptr("ou=groups," + c.dn),
-				SearchScope:              ptr("All Subtrees"),
-				MapGroupID:               ptr("uniqueIdentifier"),
-				MapGroupName:             ptr("cn"),
-				MapGroupUUID:             ptr("uniqueIdentifier"),
+				MapObjectClassToAnyOrAll: new("all"),
+				ObjectClasses:            new("groupofUniqueNames"),
+				SearchBase:               new("ou=groups," + c.dn),
+				SearchScope:              new("All Subtrees"),
+				MapGroupID:               new("uniqueIdentifier"),
+				MapGroupName:             new("cn"),
+				MapGroupUUID:             new("uniqueIdentifier"),
 			},
 			UserGroupMembershipMappings: &proclassic.LdapServerMappingsForUsersUserGroupMembershipMappings{
-				UserGroupMembershipStoredIn:   ptr("group object"),
-				MapUserMembershipToGroupField: ptr("uniqueMember"),
-				UseDn:                         ptr(false),
-				RecursiveLookups:              ptr(false),
-				MapUserMembershipUseDn:        ptr(true),
-				MapObjectClassToAnyOrAll:      ptr("all"),
-				SearchScope:                   ptr("All Subtrees"),
-				MembershipScopingOptimization: ptr(true),
+				UserGroupMembershipStoredIn:   new("group object"),
+				MapUserMembershipToGroupField: new("uniqueMember"),
+				UseDn:                         new(false),
+				RecursiveLookups:              new(false),
+				MapUserMembershipUseDn:        new(true),
+				MapObjectClassToAnyOrAll:      new("all"),
+				SearchScope:                   new("All Subtrees"),
+				MembershipScopingOptimization: new(true),
 			},
 		},
 	}
 }
-
-func ptr[T any](v T) *T { return &v }


### PR DESCRIPTION
## Why

`make fix fmt lint test` — the documented pre-commit sequence in `CLAUDE.md` — **currently fails on a clean tree**. Go 1.26's `go fix` rewrites four pointer helpers to the new `new(expr)` form and inlines their call sites, orphaning the helpers, so `make lint` then reports them as unused. Found while working on #307; reverted there as out of scope.

## `go fix` modernisation

- **`new(expr)`** replaces the `&local` idiom in `strptr` / `strPtr` / `ptr` helpers. `go fix` inlined every call site, so all four helpers are now unused and deleted.
- **`maps.Copy`** replaces a manual copy loop in the blueprint resource schema.

`go fix` was also run with `-tags acceptance`, which the bare `./...` invocation cannot see — otherwise the acceptance suite drifts from the rest of the tree and the next person hits the same failure.

## Acceptance-tag lint backlog

`golangci-lint` under `--build-tags acceptance` reported **13 issues that `make lint` never sees**, because the acceptance files are excluded from the untagged build. The default `max-same-issues` cap was also hiding some, so the full set only appears with the cap lifted.

All 13 fixed — 3 were introduced by the `go fix` run above, 10 pre-existed on `main`:

| Category | Count | Fix |
|---|---|---|
| `QF1012` | 4 | `fmt.Fprintf` replaces `WriteString(fmt.Sprintf(...))` |
| `errcheck` `f.Close` | 3 | Close made explicit and checked |
| `errcheck` `os.Setenv` | 1 | `TF_ACC` failure now fails the test |
| `unused` | 2 | `renderHCL` / `withContext` had no callers |
| `SA1019` deprecated | 3 | migrated, not suppressed — see below |

**On `f.Close`:** the three PNG fixture writers used `defer f.Close()` unchecked. That can swallow a flush failure and leave a truncated fixture, which then fails somewhere far less obvious than the write itself — worth an explicit check rather than a `_ =`.

## The three deprecated endpoints — migrated, not `nolint`ed

I probed each against a live tenant before changing it, because both are used in `CheckDestroy`/fixture paths where wrong behaviour means a silently false-passing test.

**Computer lookup by name** (`macos_configuration_profile`, `policy`). These resolve a just-created computer's ID through the classic by-name endpoint, deprecated 2025-02-11 — and **every** classic alternative (`ListComputers`, `GetComputersBasic`) carries the same deprecation date, so there is no classic fallback. They needed the lookup at all only because the classic create returns the new ID on the wire but the SDK signature discards it.

Both now share a new `testhelpers.ResolveComputerIDByName` reading the Pro **V3** inventory (V1 is deprecated 2025-06-30, V2 2025-11-06 — V3 is the current one). The risk was inventory-indexing lag on a brand-new record, so I checked:

```
classic POST /computers/id/0        -> 201, id 842
GET /v3/computers-inventory?filter=general.name=="..."  (immediately)
                                   -> 200, totalCount 1, id 842
```

Visible at once, same ID, so no settling delay is needed. Probe records were cleaned up.

**Patch software title `CheckDestroy`** now reads the V2 configurations endpoint. The resource stays ProClassic-backed; both endpoints address the same object, and the only thing the destroy check depends on is not-found classification:

```
GET /v2/patch-software-title-configurations/999999999  -> 404
GET /JSSResource/patchsoftwaretitles/id/999999999      -> 404
```

Identical, so `helpers.IsNotFoundError` behaves the same and the check keeps its meaning.

## Verified

- `make lint` → **0 issues**
- `golangci-lint --build-tags acceptance --max-same-issues=0` → **0 issues**
- `go vet -tags acceptance ./...` → clean
- `make test` → **3304 pass**
- `make generate` → no diff

**Not verified:** the acceptance tests using the two migrated fixtures were not run end to end. The endpoint swaps were probed directly against a live tenant as shown above, but a full `make testacc` over `macos_configuration_profile`, `policy`, and `patch_software_title` would confirm the fixtures still behave in context.

## Note for review

This is pure cleanup — no provider behaviour changes, no schema or docs changes. Worth a look at whether `--build-tags acceptance` should join CI lint, since that is what let 10 issues accumulate unseen.

Stacked context: #307 is the actions docs/validation audit that surfaced this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
