### PR TITLE
docs: standardise endpoint-deprecation migration tracking

### DIFF
--- a/.github/ISSUE_TEMPLATE/deprecation_migration.md
+++ b/.github/ISSUE_TEMPLATE/deprecation_migration.md
@@ -1,0 +1,67 @@
+---
+name: Deprecation migration
+about: Track migrating off a Jamf-deprecated API surface (maintainers)
+title: "deprecation(<pro|proclassic|platform>): <surface> <from>→<to> — migrate by YYYY-MM-DD"
+labels: deprecation-migration
+assignees: neilmartin83
+
+---
+
+<!--
+Conventions are mandatory — see STYLE_GUIDE.md §Deprecation migration timeline →
+"Tracking — the migration issue". In short:
+
+- Title carries the binding date; edit it if the date moves.
+- Add `blocked-upstream` while the SDK exposes no successor; remove it when it ships.
+- Add the issue to GitHub Project #2 and set both `Deprecated On` and `Migrate By`.
+- Close only when no call site reaches the deprecated method AND every SA1019
+  suppression for the surface is gone.
+-->
+
+## Status
+
+<!-- One paragraph: blocked upstream / ready to migrate / in flight in PR #NNN. Name the
+     SDK version and issue if the successor arrived through one. -->
+
+## What Jamf deprecated
+
+<!-- SDK version that introduced the Deprecated markers, the spec's deprecation-date,
+     how many methods, and which surfaces + versions. -->
+
+## Call sites in this provider
+
+| Call site | Deprecated method | Successor | Migration shape |
+|---|---|---|---|
+| `path/to/file.go:NN` |  |  | <!-- drop-in / signature change / type change — say which fields differ and whether this call site reads them --> |
+
+<!-- Include acceptance-tagged call sites; mark them as such. -->
+
+## Successor verification
+
+<!-- Wire-probe table (endpoint, status, Deprecation header) and/or the SDK-source
+     comparison that establishes the successor is usable: signatures, request/response
+     types, query-parameter contract, privilege names. State what was probed on which
+     Jamf Pro version and on what date. -->
+
+## Privileges
+
+<!-- Do the successors' scoped/legacy privilege names in the SDK privilege registry match
+     the predecessors'? If not, the rendered "Required Jamf privileges" table diffs and
+     `make generate` is required — list the old→new scoped names. -->
+
+## Work required
+
+- [ ] <!-- one item per package, each ending in "drop the suppression" -->
+- [ ] Refresh the `crud.go` SDK-endpoints annotation (`Status:` line + `Last reviewed`).
+- [ ] `make fix fmt lint test`, then `make generate` if any description changed.
+- [ ] Re-run acceptance for the affected resources.
+
+## Deadlines
+
+Per [STYLE_GUIDE §Deprecation migration timeline](../blob/main/STYLE_GUIDE.md#deprecation-migration-timeline), with the deprecation announced YYYY-MM-DD:
+
+- **6-month soft target: YYYY-MM-DD** — migration should be merged.
+- **Hard floor: 3 months before Jamf's announced removal date.** <!-- State whether a removal
+  date has been published; if it has, give the computed hard floor and use it as the binding date. -->
+
+Being blocked upstream does not pause the clock.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -288,6 +288,8 @@ Use [conventional commit](https://www.conventionalcommits.org/) style messages:
 - `chore: update CI workflow action versions`
 - `docs: add TESTING.md`
 
+Endpoint-deprecation migrations use a fixed form — `refactor(<pkg-or-resource>): migrate <surface> <from>→<to>` — and their tracking issues have their own title, label and deadline conventions. See [STYLE_GUIDE.md §Tracking — the migration issue](STYLE_GUIDE.md#tracking--the-migration-issue).
+
 ## Pull Requests
 
 - Keep PRs focused — one feature or fix per PR.

--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -745,6 +745,40 @@ Maintainer call, documented in the migration PR description.
 
 When migration would require a **breaking Terraform schema change**, defer to the next provider major version. Document explicitly in the resource's `crud.go` annotation (see below) and in the major-version release planning.
 
+#### Tracking — the migration issue
+
+Every deprecation gets exactly one tracking issue, opened from the **Deprecation migration** issue template (`.github/ISSUE_TEMPLATE/deprecation_migration.md`). The conventions below are mandatory — they are what makes the set of open migrations greppable and their deadlines visible.
+
+**Label**: `deprecation-migration`, always. Add `blocked-upstream` while the SDK exposes no successor, and remove it when the successor ships. No other label substitutes: `grep`ping the label is how the quarterly audit finds outstanding migrations.
+
+**Title format**:
+
+```
+deprecation(<sdk-family>): <surface> <from>→<to> — migrate by YYYY-MM-DD
+```
+
+- `<sdk-family>` is `pro`, `proclassic` or `platform`.
+- `<surface>` is the API path segment, not the Terraform name (`computers-inventory`, not `jamfplatform_pro_computer`). Comma-separate multiple surfaces deprecated in the same announcement rather than opening one issue per surface.
+- The date is the **binding** date: the 6-month soft target until Jamf publishes a removal date, then the 3-month hard floor if that lands earlier. Edit the title when the binding date moves — a stale date in a title is worse than none.
+
+**Deadlines**: GitHub issues carry no due-date field, so the dates live on [GitHub Project #2](https://github.com/orgs/Jamf-Concepts/projects/2) in two Date fields — `Deprecated On` (Jamf's announcement date) and `Migrate By` (the binding date, matching the title). Every `deprecation-migration` issue must be on the project with both set. Milestones are reserved for releases and must not be used to carry migration deadlines.
+
+**PR title**: conventional-commit `refactor`, naming the same surfaces as the issue:
+
+```
+refactor(<pkg-or-resource>): migrate <surface> <from>→<to>
+```
+
+The PR body closes the issue (`Closes #NNN`) and records the fast-track or slow-track call if either applies. One PR per surface unless the surfaces are coupled (e.g. a shared side-channel that cannot move independently).
+
+**While a migration is outstanding**, every call to a deprecated symbol carries a suppression naming the issue, so the reason survives without reading the tracker:
+
+```go
+//nolint:staticcheck // SA1019: no v4 client generated yet — see #311
+```
+
+**Closing condition**: the issue closes only when no call site reaches the deprecated method *and* every `SA1019` suppression for that surface is gone — `grep -rn "SA1019" internal/` is the check. A migration that leaves suppressions behind is not finished, because the next audit cannot tell it from an un-started one.
+
 #### Tracking — in-code annotation (Pro resources only)
 
 Every Jamf Pro resource's `crud.go` carries an annotation block at the top of the file listing the SDK endpoints in use, their status, and the last maintainer review date. Platform Services resources do **not** carry this annotation.
@@ -781,8 +815,9 @@ Once per quarter, a maintainer:
 2. Greps the repo for endpoint annotations: `grep -rA5 "SDK endpoints used:" internal/resources/pro/`.
 3. Reconciles each annotation against current Jamf + SDK state.
 4. Updates `Last reviewed YYYY-MM-DD` on every annotation that's still current.
-5. Opens migration tracking issues for any newly-deprecated Pro endpoints.
-6. Flags any annotation whose `Last reviewed` date is older than 120 days (means a prior audit was skipped).
+5. Opens migration tracking issues for any newly-deprecated Pro endpoints, following [§Tracking — the migration issue](#tracking--the-migration-issue).
+6. Reviews every open `deprecation-migration` issue — `gh issue list --label deprecation-migration` — and checks each one's `Migrate By` date on Project #2 against the current window, recomputing it if Jamf has since published a removal date.
+7. Flags any annotation whose `Last reviewed` date is older than 120 days (means a prior audit was skipped).
 
 The `Last reviewed` date is the drift detector — any annotation more than a quarter stale signals the audit hasn't happened.
 


### PR DESCRIPTION
Docs-only. Gives endpoint-deprecation work a fixed process, prompted by #311 sitting untitled by any pattern, unlabelled, and with no visible deadline.

## What changes

**STYLE_GUIDE.md** — new `§Tracking — the migration issue` under the existing deprecation timeline:

- **Label**: `deprecation-migration` always (created on the repo), plus `blocked-upstream` while the SDK exposes no successor. One greppable marker, so the quarterly audit can find every outstanding migration.
- **Issue title**: `deprecation(<sdk-family>): <surface> <from>→<to> — migrate by YYYY-MM-DD`. Surface is the API path segment, not the Terraform name; the date is the *binding* date and gets edited when it moves.
- **PR title**: `refactor(<pkg-or-resource>): migrate <surface> <from>→<to>`, closing the issue.
- **Deadlines**: GitHub issues have no due-date field, so the dates live on [Project #2](https://github.com/orgs/Jamf-Concepts/projects/2) in two new Date fields — `Deprecated On` and `Migrate By`. Milestones stay reserved for releases rather than being repurposed to carry migration dates.
- **Suppressions**: every `//nolint:staticcheck // SA1019` must name its tracking issue, and the closing condition is that no suppression for the surface remains (`grep -rn "SA1019" internal/`). Without that, a half-finished migration reads identically to one never started.

**Quarterly audit** gains a step: sweep open `deprecation-migration` issues and recompute `Migrate By` if Jamf has since published a removal date.

**`.github/ISSUE_TEMPLATE/deprecation_migration.md`** — new template mirroring the sections #311 actually needed: status, call-site table with a migration-shape column, successor verification (wire probe and/or SDK-source comparison), privilege-name diff, work checklist, deadlines.

**CONTRIBUTING.md** — one cross-reference from §Commit Messages, where someone looking for the PR-title form would start.

## Already applied

#311 is retitled, labelled `deprecation-migration`, and on Project #2 with `Deprecated On` = 2026-07-14 and `Migrate By` = 2027-01-14. Its body was also rewritten now that SDK v0.14.0 clears the blocker — the SDK-side work is gone from it, and the successor mapping is verified against the v0.14.0 source.

## Testing

No Go changes, so `make test` is unaffected. Markdown only; anchor links checked against GitHub's slug rules (`#tracking--the-migration-issue`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)