### PR TITLE
fix(pro): mobile prestage device naming payload and default_prestage

### DIFF
--- a/docs/resources/pro_mobile_device_prestage_enrollment.md
+++ b/docs/resources/pro_mobile_device_prestage_enrollment.md
@@ -125,7 +125,7 @@ resource "jamfplatform_pro_mobile_device_prestage_enrollment" "example" {
 - `authentication_prompt` (String) **"Authentication Prompt"** message shown when `require_authentication = true`.
 - `auto_advance_setup` (Boolean) **"Auto Advance Setup"** (tvOS) in the Jamf Pro admin UI.
 - `configure_device_before_setup_assistant` (Boolean) **"Configure device before Setup Assistant"** in the Jamf Pro admin UI.
-- `default_prestage` (Boolean) When true, this PreStage becomes the tenant default for new devices. Jamf Pro allows at most one default PreStage: if another PreStage is already the default, Jamf Pro keeps this `false` rather than reassigning. Clear the existing default first to take it over.
+- `default_prestage` (Boolean) When true, this PreStage becomes the tenant default for new devices. Jamf Pro allows at most one default PreStage and will not move the default automatically: if another PreStage already holds it, the apply fails. Set `default_prestage = false` on the current holder first — and where both are managed by Terraform, make the release land before the claim (apply it on its own, or add a `depends_on` from this resource to the one giving up the default).
 - `department` (String) **"Department"** label shown during Setup Assistant. Free-form text; *not* the department ID (`location_information.department_id`).
 - `do_not_use_profile_from_backup` (Boolean) **"Do not use profile from backup"** in the Jamf Pro admin UI.
 - `enable_device_based_activation_lock` (Boolean) **"Enable Device-Based Activation Lock"** in the Jamf Pro admin UI.

--- a/docs/resources/pro_mobile_device_prestage_enrollment.md
+++ b/docs/resources/pro_mobile_device_prestage_enrollment.md
@@ -144,7 +144,7 @@ resource "jamfplatform_pro_mobile_device_prestage_enrollment" "example" {
 - `minimum_os_specific_version_ios` (String) Specific minimum iOS version (e.g. `"17.1"`). Used only when `prestage_minimum_os_target_version_type_ios = "MINIMUM_OS_SPECIFIC_VERSION"`.
 - `minimum_os_specific_version_ipad` (String) Specific minimum iPadOS version (e.g. `"17.1"`). Used only when `prestage_minimum_os_target_version_type_ipad = "MINIMUM_OS_SPECIFIC_VERSION"`.
 - `multi_user` (Boolean) **"Enable Shared iPad"** in the Jamf Pro admin UI. Requires both `supervised = true` and `prevent_activation_lock = true` — Jamf Pro rejects Shared iPad otherwise (`prevent_activation_lock` with a hard error; `supervised` by silently disabling Shared iPad).
-- `names` (Attributes) **"Mobile device names"** in the Jamf Pro admin UI. Supply the block (even empty: `names = {}`) to manage device naming — omitting it produces drift on the next refresh because Jamf Pro always returns a populated block. (see [below for nested schema](#nestedatt--names))
+- `names` (Attributes) **"Mobile device names"** in the Jamf Pro admin UI. Supply the block (even empty: `names = {}`) to manage device naming — omitting it produces drift on the next refresh because Jamf Pro always returns a populated block. A bare `names = {}` leaves device naming *unconfigured*, which is how Jamf Pro's admin UI decides not to show the naming payload at all: set at least one field below for naming to take effect. (see [below for nested schema](#nestedatt--names))
 - `preserve_managed_apps` (Boolean) **"Preserve Managed Apps"** in the Jamf Pro admin UI.
 - `prestage_minimum_os_target_version_type_ios` (String) Minimum-iOS enforcement mode. One of `NO_ENFORCEMENT`, `MINIMUM_OS_LATEST_VERSION`, `MINIMUM_OS_LATEST_MAJOR_VERSION`, `MINIMUM_OS_LATEST_MINOR_VERSION`, `MINIMUM_OS_SPECIFIC_VERSION`. Pair `MINIMUM_OS_SPECIFIC_VERSION` with `minimum_os_specific_version_ios`.
 - `prestage_minimum_os_target_version_type_ipad` (String) Minimum-iPadOS enforcement mode. One of `NO_ENFORCEMENT`, `MINIMUM_OS_LATEST_VERSION`, `MINIMUM_OS_LATEST_MAJOR_VERSION`, `MINIMUM_OS_LATEST_MINOR_VERSION`, `MINIMUM_OS_SPECIFIC_VERSION`. Pair `MINIMUM_OS_SPECIFIC_VERSION` with `minimum_os_specific_version_ipad`.
@@ -199,10 +199,6 @@ Optional:
 - `manage_names` (Boolean) **"Enforce Mobile Device Names"** in the Jamf Pro admin UI.
 - `prestage_device_names` (Attributes List) Ordered list of device names (used in `"List of Names"` mode). Jamf Pro assigns each entry an `id` and consumes them in order as devices enrol. The framework reconciles entries by list position; append new names to the end to avoid churn. (see [below for nested schema](#nestedatt--names--prestage_device_names))
 - `single_device_name` (String) Single device name (used in `"Single Name"` mode). Required when `assign_names_using = "Single Name"`.
-
-Read-Only:
-
-- `device_naming_configured` (Boolean) Whether device naming has been configured. Server-managed; not user-settable.
 
 <a id="nestedatt--names--prestage_device_names"></a>
 ### Nested Schema for `names.prestage_device_names`

--- a/internal/resources/pro/mobile_device_prestage_enrollment/crud.go
+++ b/internal/resources/pro/mobile_device_prestage_enrollment/crud.go
@@ -134,6 +134,31 @@ func warnDefaultPrestageRefused(diags *diag.Diagnostics, cfg MobileDevicePrestag
 	}
 }
 
+// warnNamingNotConfigured flags a record whose stored deviceNamingConfigured is
+// false despite a names block that asks for naming. Because that wire field is
+// unmodelled (see namesSchema), Terraform sees no drift and reports "No
+// changes", so the admin UI would go on hiding the naming payload silently. Any
+// apply that touches this resource rewrites the flag correctly; this warning is
+// what tells the user one is needed. Reachable for records written by provider
+// releases before the flag was sent at all, or edited outside Terraform.
+func warnNamingNotConfigured(diags *diag.Diagnostics, state MobileDevicePrestageEnrollmentResourceModel, got *pro.GetMobileDevicePrestageV3) {
+	if got.Names == nil || !namingIntentBesidesMode(state.Names) {
+		return
+	}
+	if got.Names.DeviceNamingConfigured != nil && *got.Names.DeviceNamingConfigured {
+		return
+	}
+	diags.AddAttributeWarning(
+		path.Root("names"),
+		"device naming not applied in Jamf Pro",
+		"This PreStage has a names block, but Jamf Pro has device naming marked unconfigured, so the "+
+			"\"Mobile device names\" payload is hidden in the admin UI and the names are not applied to enrolling devices. "+
+			"Re-apply this resource to correct it — for example `terraform apply -replace=<address>`, or any change to the "+
+			"resource. Terraform reports no drift on its own because Jamf Pro's naming-configured flag is not a "+
+			"Terraform-managed attribute.",
+	)
+}
+
 func resolveIntentBool(planV, cfgV, stateV types.Bool) types.Bool {
 	if !planV.IsUnknown() {
 		return planV
@@ -170,7 +195,7 @@ func (r *MobileDevicePrestageEnrollmentResource) Create(ctx context.Context, req
 	createCtx, cancel := context.WithTimeout(ctx, createTimeout)
 	defer cancel()
 
-	post, d := buildPostInput(createCtx, plan)
+	post, d := buildPostInput(createCtx, plan, cfg)
 	resp.Diagnostics.Append(d...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -292,6 +317,7 @@ func (r *MobileDevicePrestageEnrollmentResource) Read(ctx context.Context, req r
 	if resp.Diagnostics.HasError() {
 		return
 	}
+	warnNamingNotConfigured(&resp.Diagnostics, state, got)
 
 	scope, err := r.client.GetMobileDevicePrestageScopeV2(readCtx, state.ID.ValueString())
 	if err != nil {
@@ -351,7 +377,7 @@ func (r *MobileDevicePrestageEnrollmentResource) Update(ctx context.Context, req
 		return
 	}
 
-	put, d := buildPutInput(updateCtx, plan)
+	put, d := buildPutInput(updateCtx, plan, cfg)
 	resp.Diagnostics.Append(d...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/resources/pro/mobile_device_prestage_enrollment/crud.go
+++ b/internal/resources/pro/mobile_device_prestage_enrollment/crud.go
@@ -21,14 +21,14 @@
 //     purchasingInformation); no accountSettings (spike §5/§7).
 //   - PUT-500-with-commit bug reproduces; the GET-diff verifier SKIPS the
 //     §9.1 server-authoritative exclusion set (storage_quota_size_megabytes,
-//     default_prestage, use_storage_quota_size, temporary_session_only,
-//     temporary_session_timeout) — their post-PUT drift is expected, not a
-//     silent rollback. anchor_certificates + names stay IN the check.
+//     use_storage_quota_size, temporary_session_only, temporary_session_timeout)
+//     — their post-PUT drift is expected, not a silent rollback.
+//     anchor_certificates, names and default_prestage stay IN the check.
 //   - Mobile scope errors: ALREADY_SCOPED (serial on another prestage),
 //     DEVICE_DOES_NOT_EXIST_ON_TOKEN (serial not on the ADE token).
 //   - DELETE → GET returns a clean 404 (no computer 400 INVALID_ID quirk).
 //
-// Status: current. Last reviewed 2026-05-30.
+// Status: current. Last reviewed 2026-08-07.
 
 package mobile_device_prestage_enrollment
 
@@ -53,16 +53,15 @@ import (
 // erroring with "Provider produced inconsistent result after apply". Runs on
 // create and update (skipped on destroy).
 //
-//   - default_prestage: Jamf Pro refuses `true` when another PreStage already
-//     holds the default (§F10) — it can't be detected at plan time, so a
-//     planned `true` is rendered Unknown.
 //   - use_storage_quota_size / temporary_session_only: mutually exclusive
 //     Shared-iPad storage modes — when both resolve `true` the server forces
 //     one to `false` (§F9), so both are rendered Unknown and the server picks.
 //
+// default_prestage is NOT in this set — see the note in the body.
+//
 // The user's intent is preserved for the wire body by restoreServerArbitrated
 // in Create/Update (a bare Unknown would serialise as `false` and corrupt the
-// write). diffPlanAgainstGet additionally excludes these fields (§9.1).
+// write). diffPlanAgainstGet additionally excludes those two fields (§9.1).
 func (r *MobileDevicePrestageEnrollmentResource) ModifyPlan(ctx context.Context, req resource.ModifyPlanRequest, resp *resource.ModifyPlanResponse) {
 	if req.Plan.Raw.IsNull() {
 		return // destroy
@@ -81,14 +80,16 @@ func (r *MobileDevicePrestageEnrollmentResource) ModifyPlan(ctx context.Context,
 		}
 	}
 
-	// default_prestage: only the false→true TRANSITION (and create-with-true)
-	// is server-arbitrated — Jamf Pro may refuse it when another PreStage holds
-	// the default (§F10). Steady-state true→true is honored and MUST round-trip
-	// cleanly, so leave it known there (rendering it Unknown would manufacture a
-	// perpetual diff on the prestage that legitimately is the default).
-	if isKnownTrue(plan.DefaultPrestage) && !isKnownTrue(state.DefaultPrestage) {
-		resp.Diagnostics.Append(resp.Plan.SetAttribute(ctx, path.Root("default_prestage"), types.BoolUnknown())...)
-	}
+	// default_prestage is deliberately NOT rendered Unknown here. It is not
+	// server-arbitrated: Jamf Pro never silently keeps it false. Claiming a
+	// default another PreStage already holds is rejected outright —
+	// 400 ALREADY_DEFAULT "Another prestage is already the default prestage" —
+	// on both create and update, with nothing written. Wire-probed 2026-08-07
+	// against Jamf Pro 11.30; see the transition table on
+	// diagnoseAlreadyDefault. Stamping Unknown over a known config value is also
+	// illegal for an Optional+Computed attribute: Terraform Core rejects the plan
+	// with "planned value cty.UnknownVal(cty.Bool) does not match config value
+	// cty.True", which made `default_prestage = true` impossible to set at all.
 
 	// use_storage_quota_size ⊻ temporary_session_only: the server stores at most
 	// one as true (§F9), so a resolved both-true is always a transition into the
@@ -115,23 +116,41 @@ func isKnownTrue(b types.Bool) bool {
 // comes from the post-write GET via assignGetToResource, which is what keeps
 // the result consistent with the Unknown plan. On create pass a zero-value
 // state.
+//
+// default_prestage is absent because ModifyPlan no longer stamps it Unknown —
+// its planned value is already the user's intent.
 func restoreServerArbitrated(plan *MobileDevicePrestageEnrollmentResourceModel, cfg, state MobileDevicePrestageEnrollmentResourceModel) {
-	plan.DefaultPrestage = resolveIntentBool(plan.DefaultPrestage, cfg.DefaultPrestage, state.DefaultPrestage)
 	plan.UseStorageQuotaSize = resolveIntentBool(plan.UseStorageQuotaSize, cfg.UseStorageQuotaSize, state.UseStorageQuotaSize)
 	plan.TemporarySessionOnly = resolveIntentBool(plan.TemporarySessionOnly, cfg.TemporarySessionOnly, state.TemporarySessionOnly)
 }
 
-// warnDefaultPrestageRefused emits a warning when the user asked for
-// default_prestage = true but Jamf Pro kept it false because another PreStage
-// already holds the tenant default (§F10). Without this the refusal is silent.
-func warnDefaultPrestageRefused(diags *diag.Diagnostics, cfg MobileDevicePrestageEnrollmentResourceModel, gotDefault bool) {
-	if isKnownTrue(cfg.DefaultPrestage) && !gotDefault {
-		diags.AddAttributeWarning(
-			path.Root("default_prestage"),
-			"default PreStage not applied",
-			"You set default_prestage = true, but another PreStage currently holds the tenant default, so Jamf Pro kept this PreStage non-default. Clear the existing default PreStage first to take it over.",
-		)
+// diagnoseAlreadyDefault replaces the raw ALREADY_DEFAULT API error with one
+// that says which knob to turn. Jamf Pro allows exactly one default mobile
+// device PreStage per tenant and will not reassign it; the current holder has to
+// give it up first. Wire-probed 2026-08-07 against Jamf Pro 11.30:
+//
+//	create default_prestage = true, no current holder   → accepted
+//	create default_prestage = true, another holds it    → 400 ALREADY_DEFAULT, nothing created
+//	update default_prestage = true, no current holder   → accepted
+//	update default_prestage = true, this one holds it   → accepted (no-op)
+//	update default_prestage = true, another holds it    → 400 ALREADY_DEFAULT, nothing written
+//	update default_prestage = false (release)           → accepted, tenant left with no default
+//
+// Returns true when it recognised and reported the error.
+func diagnoseAlreadyDefault(diags *diag.Diagnostics, cfg MobileDevicePrestageEnrollmentResourceModel, err error) bool {
+	if err == nil || !strings.Contains(err.Error(), "ALREADY_DEFAULT") {
+		return false
 	}
+	detail := "Jamf Pro allows only one default mobile device PreStage per tenant and will not move the default automatically: " +
+		"another PreStage already holds it, so this write was rejected and nothing changed. Set default_prestage = false on the " +
+		"PreStage that currently holds it, then apply again."
+	if isKnownTrue(cfg.DefaultPrestage) {
+		detail += " When both PreStages are managed by Terraform, the release has to land before the claim — Terraform does not " +
+			"order the two updates on its own, so either apply the release on its own first, or add a depends_on from this " +
+			"resource to the one giving up the default."
+	}
+	diags.AddAttributeError(path.Root("default_prestage"), "another PreStage is already the tenant default", detail)
+	return true
 }
 
 // warnNamingNotConfigured flags a record whose stored deviceNamingConfigured is
@@ -203,7 +222,9 @@ func (r *MobileDevicePrestageEnrollmentResource) Create(ctx context.Context, req
 
 	postResp, err := r.client.CreateMobileDevicePrestageV3(createCtx, post)
 	if err != nil {
-		resp.Diagnostics.AddError("Error creating Jamf Pro mobile device prestage enrollment", err.Error())
+		if !diagnoseAlreadyDefault(&resp.Diagnostics, cfg, err) {
+			resp.Diagnostics.AddError("Error creating Jamf Pro mobile device prestage enrollment", err.Error())
+		}
 		return
 	}
 	if postResp == nil || postResp.ID == "" {
@@ -226,7 +247,6 @@ func (r *MobileDevicePrestageEnrollmentResource) Create(ctx context.Context, req
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	warnDefaultPrestageRefused(&resp.Diagnostics, cfg, got.DefaultPrestage)
 
 	// Apply scope if user supplied any serial numbers. Mobile does not gate
 	// on profile_uuid readiness (§F13) — apply immediately.
@@ -388,7 +408,9 @@ func (r *MobileDevicePrestageEnrollmentResource) Update(ctx context.Context, req
 	putHitServerBug := false
 	if putErr != nil {
 		if !isPutSerializerBug(putErr) {
-			resp.Diagnostics.AddError("Error updating Jamf Pro mobile device prestage enrollment", putErr.Error())
+			if !diagnoseAlreadyDefault(&resp.Diagnostics, cfg, putErr) {
+				resp.Diagnostics.AddError("Error updating Jamf Pro mobile device prestage enrollment", putErr.Error())
+			}
 			return
 		}
 		putHitServerBug = true
@@ -423,7 +445,6 @@ func (r *MobileDevicePrestageEnrollmentResource) Update(ctx context.Context, req
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	warnDefaultPrestageRefused(&resp.Diagnostics, cfg, postGet.DefaultPrestage)
 
 	// Scope reconciliation: replace the entire serial-number set if the plan
 	// differs from the prior state.

--- a/internal/resources/pro/mobile_device_prestage_enrollment/input_builders.go
+++ b/internal/resources/pro/mobile_device_prestage_enrollment/input_builders.go
@@ -19,7 +19,7 @@ import (
 // purchasingInformation must be FULLY populated (id="-1", versionLock=0, every
 // scalar); `names` must be a populated object (empty names:{} → server 500);
 // storageQuotaSizeMegabytes >= 1024 even when useStorageQuotaSize is false.
-func buildPostInput(ctx context.Context, plan MobileDevicePrestageEnrollmentResourceModel) (*pro.MobileDevicePrestageV3, diag.Diagnostics) {
+func buildPostInput(ctx context.Context, plan, cfg MobileDevicePrestageEnrollmentResourceModel) (*pro.MobileDevicePrestageV3, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
 	post := &pro.MobileDevicePrestageV3{
@@ -90,7 +90,7 @@ func buildPostInput(ctx context.Context, plan MobileDevicePrestageEnrollmentReso
 	// `names` must ALWAYS be a populated object on POST — an empty names:{}
 	// triggers a server 500 (§F2). buildNames synthesizes a default block
 	// when the user omitted it. id="-1" on every element (§F4b).
-	post.Names = buildNames(plan.Names, true)
+	post.Names = buildNames(plan.Names, namingIntended(cfg.Names), true)
 
 	return post, diags
 }
@@ -98,7 +98,7 @@ func buildPostInput(ctx context.Context, plan MobileDevicePrestageEnrollmentReso
 // buildPutInput translates the plan + GET-derived state into the PUT body.
 // versionLocks are NOT set here — caller invokes injectVersionLocks. PUT is
 // full-replace, so every managed field is emitted (§F6).
-func buildPutInput(ctx context.Context, plan MobileDevicePrestageEnrollmentResourceModel) (*pro.PutMobileDevicePrestageV3, diag.Diagnostics) {
+func buildPutInput(ctx context.Context, plan, cfg MobileDevicePrestageEnrollmentResourceModel) (*pro.PutMobileDevicePrestageV3, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
 	put := &pro.PutMobileDevicePrestageV3{
@@ -173,7 +173,7 @@ func buildPutInput(ctx context.Context, plan MobileDevicePrestageEnrollmentResou
 	// On update, prestage_device_names elements echo their state-derived id
 	// (carried in via UseNonNullStateForUnknown) — omitting id silently rolls
 	// the whole names mutation back (§F4b).
-	put.Names = buildNames(plan.Names, false)
+	put.Names = buildNames(plan.Names, namingIntended(cfg.Names), false)
 
 	return put, diags
 }
@@ -199,8 +199,16 @@ func createStorageQuota(v types.Int64) int {
 // element serialises with id (state value, else "-1") AND used (§F4b).
 //
 // isCreate forces id="-1" for every element (no server ids exist yet).
-func buildNames(m *NamesModel, isCreate bool) *pro.MobileDevicePrestageNamesV3 {
+//
+// namingConfigured is the caller-derived deviceNamingConfigured value. It MUST
+// come from the CONFIG (namingIntended(cfg.Names)), never from the plan: the
+// Optional+Computed siblings carry UseStateForUnknown, so on update the plan's
+// assign_names_using holds the server's echoed default even for a bare
+// `names = {}`, which would flip an unconfigured PreStage to configured on any
+// unrelated edit.
+func buildNames(m *NamesModel, namingConfigured, isCreate bool) *pro.MobileDevicePrestageNamesV3 {
 	out := &pro.MobileDevicePrestageNamesV3{}
+	out.DeviceNamingConfigured = new(namingConfigured)
 
 	if m == nil {
 		// Synthesized default — empty names:{} would 500 the server.
@@ -412,6 +420,42 @@ func stringPtrOrSentinel(v types.String, sentinel string) *string {
 		s = v.ValueString()
 	}
 	return &s
+}
+
+// namingIntended reports whether a names block expresses any device-naming
+// intent, and so what deviceNamingConfigured is written as. A bare `names = {}`
+// expresses none. Call it on the CONFIG — see buildNames.
+func namingIntended(m *NamesModel) bool {
+	if m == nil {
+		return false
+	}
+	return knownNonEmpty(m.AssignNamesUsing) || namingIntentBesidesMode(m)
+}
+
+// namingIntentBesidesMode is namingIntended minus assign_names_using, for the
+// one caller that has only post-GET state to work from (warnNamingNotConfigured).
+// Jamf Pro always echoes an assign_names_using — it is populated even on a
+// PreStage where nothing was ever configured — so state cannot distinguish a
+// user-set mode from that echo. Every other field here is only non-zero because
+// somebody set it, so it is safe evidence of real naming intent.
+func namingIntentBesidesMode(m *NamesModel) bool {
+	if m == nil {
+		return false
+	}
+	switch {
+	case knownNonEmpty(m.DeviceNamePrefix),
+		knownNonEmpty(m.DeviceNameSuffix),
+		knownNonEmpty(m.SingleDeviceName):
+		return true
+	case !m.ManageNames.IsNull() && !m.ManageNames.IsUnknown() && m.ManageNames.ValueBool():
+		return true
+	default:
+		return len(m.PrestageDeviceNames) > 0
+	}
+}
+
+func knownNonEmpty(v types.String) bool {
+	return !v.IsNull() && !v.IsUnknown() && v.ValueString() != ""
 }
 
 // boolPtrOrFalse returns the value as a *bool, defaulting to false when

--- a/internal/resources/pro/mobile_device_prestage_enrollment/input_builders_test.go
+++ b/internal/resources/pro/mobile_device_prestage_enrollment/input_builders_test.go
@@ -133,7 +133,7 @@ func TestBuildPurchasingInformation_DateDefaults(t *testing.T) {
 }
 
 func TestBuildNames_NilSynthesizesDefault(t *testing.T) {
-	out := buildNames(nil, true)
+	out := buildNames(nil, false, true)
 	if out == nil {
 		t.Fatalf("buildNames(nil) must synthesize a populated object (empty names:{} 500s the server)")
 	}
@@ -148,6 +148,171 @@ func TestBuildNames_NilSynthesizesDefault(t *testing.T) {
 	} else if len(*out.PrestageDeviceNames) != 0 {
 		t.Errorf("synthesized prestage_device_names must be empty, got %d", len(*out.PrestageDeviceNames))
 	}
+	if out.DeviceNamingConfigured == nil || *out.DeviceNamingConfigured {
+		t.Errorf("synthesized device_naming_configured must be an explicit false, got %v", out.DeviceNamingConfigured)
+	}
+}
+
+// namingIntended decides deviceNamingConfigured, which the server stores
+// verbatim rather than deriving — and which the admin UI keys the whole "Mobile
+// device names" payload off.
+func TestNamingIntended(t *testing.T) {
+	tests := []struct {
+		name  string
+		names *NamesModel
+		want  bool
+		// wantBesidesMode is namingIntentBesidesMode's answer, which differs only
+		// where assign_names_using is the sole evidence.
+		wantBesidesMode bool
+	}{
+		{
+			name:  "nil block",
+			names: nil,
+			want:  false,
+		},
+		{
+			name:  "bare names = {} expresses no naming intent",
+			names: &NamesModel{},
+			want:  false,
+		},
+		{
+			name:  "assign_names_using set",
+			names: &NamesModel{AssignNamesUsing: types.StringValue("Serial Numbers")},
+			want:  true,
+			// Indistinguishable from the server's echo once in state.
+			wantBesidesMode: false,
+		},
+		{
+			name:            "assign_names_using set to Default Names is still a choice",
+			names:           &NamesModel{AssignNamesUsing: types.StringValue("Default Names")},
+			want:            true,
+			wantBesidesMode: false,
+		},
+		{
+			name:            "manage_names true",
+			names:           &NamesModel{ManageNames: types.BoolValue(true)},
+			want:            true,
+			wantBesidesMode: true,
+		},
+		{
+			name:  "manage_names explicitly false is not intent on its own",
+			names: &NamesModel{ManageNames: types.BoolValue(false)},
+			want:  false,
+		},
+		{
+			name:            "device_name_prefix set",
+			names:           &NamesModel{DeviceNamePrefix: types.StringValue("SSC-")},
+			want:            true,
+			wantBesidesMode: true,
+		},
+		{
+			name:            "device_name_suffix set",
+			names:           &NamesModel{DeviceNameSuffix: types.StringValue("-lab")},
+			want:            true,
+			wantBesidesMode: true,
+		},
+		{
+			name:            "single_device_name set",
+			names:           &NamesModel{SingleDeviceName: types.StringValue("Shared-iPad")},
+			want:            true,
+			wantBesidesMode: true,
+		},
+		{
+			name: "prestage_device_names populated",
+			names: &NamesModel{PrestageDeviceNames: []PrestageDeviceNameModel{
+				{DeviceName: types.StringValue("iPad-1")},
+			}},
+			want:            true,
+			wantBesidesMode: true,
+		},
+		{
+			name:  "empty-string prefix is not intent",
+			names: &NamesModel{DeviceNamePrefix: types.StringValue("")},
+			want:  false,
+		},
+		{
+			name:  "unknown sibling awaiting the post-apply GET is not intent",
+			names: &NamesModel{AssignNamesUsing: types.StringUnknown()},
+			want:  false,
+		},
+		{
+			name: "the reported config: Serial Numbers + prefix + manage_names",
+			names: &NamesModel{
+				AssignNamesUsing: types.StringValue("Serial Numbers"),
+				DeviceNamePrefix: types.StringValue("SSC-"),
+				ManageNames:      types.BoolValue(true),
+			},
+			want:            true,
+			wantBesidesMode: true,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := namingIntended(tc.names); got != tc.want {
+				t.Errorf("namingIntended = %v, want %v", got, tc.want)
+			}
+			if got := namingIntentBesidesMode(tc.names); got != tc.wantBesidesMode {
+				t.Errorf("namingIntentBesidesMode = %v, want %v", got, tc.wantBesidesMode)
+			}
+		})
+	}
+}
+
+// buildNames must put deviceNamingConfigured on the wire unconditionally —
+// omitting it is what made the naming payload invisible in the admin UI.
+func TestBuildNames_AlwaysSerialisesDeviceNamingConfigured(t *testing.T) {
+	for _, configured := range []bool{true, false} {
+		for _, isCreate := range []bool{true, false} {
+			for _, m := range []*NamesModel{nil, {}, {DeviceNamePrefix: types.StringValue("SSC-")}} {
+				out := buildNames(m, configured, isCreate)
+				if out.DeviceNamingConfigured == nil {
+					t.Fatalf("configured=%v isCreate=%v names=%+v: must always serialise, got nil", configured, isCreate, m)
+				}
+				if *out.DeviceNamingConfigured != configured {
+					t.Errorf("configured=%v isCreate=%v names=%+v: got %v", configured, isCreate, m, *out.DeviceNamingConfigured)
+				}
+			}
+		}
+	}
+}
+
+// Regression: deviceNamingConfigured must be derived from the CONFIG, not the
+// plan. assign_names_using is Optional+Computed with UseStateForUnknown, so on
+// update the plan carries the server's echoed mode even for a bare
+// `names = {}` — deriving from the plan flipped an unconfigured PreStage to
+// configured on any unrelated edit.
+func TestBuildPutInput_NamingConfiguredComesFromConfigNotPlan(t *testing.T) {
+	base := MobileDevicePrestageEnrollmentResourceModel{
+		DisplayName:                       types.StringValue("bare names block"),
+		DeviceEnrollmentProgramInstanceID: types.StringValue("1"),
+	}
+
+	// Config said `names = {}`; the plan holds the server's echoed mode.
+	plan := base
+	plan.Names = &NamesModel{AssignNamesUsing: types.StringValue("Serial Numbers")}
+	cfg := base
+	cfg.Names = &NamesModel{}
+
+	put, d := buildPutInput(context.Background(), plan, cfg)
+	if d.HasError() {
+		t.Fatalf("put build diags: %v", d)
+	}
+	if put.Names == nil || put.Names.DeviceNamingConfigured == nil {
+		t.Fatalf("names.deviceNamingConfigured must always serialise")
+	}
+	if *put.Names.DeviceNamingConfigured {
+		t.Errorf("a bare `names = {}` config must stay unconfigured; the plan's echoed assign_names_using leaked through")
+	}
+
+	// Same plan, but the config really does ask for naming.
+	cfg.Names = &NamesModel{AssignNamesUsing: types.StringValue("Serial Numbers")}
+	put, d = buildPutInput(context.Background(), plan, cfg)
+	if d.HasError() {
+		t.Fatalf("put build diags: %v", d)
+	}
+	if !*put.Names.DeviceNamingConfigured {
+		t.Errorf("config-declared naming must write deviceNamingConfigured=true")
+	}
 }
 
 func TestBuildNames_CreateForcesSentinelID(t *testing.T) {
@@ -159,7 +324,7 @@ func TestBuildNames_CreateForcesSentinelID(t *testing.T) {
 			{DeviceName: types.StringValue("iPad-2"), ID: types.StringNull(), Used: types.BoolNull()},
 		},
 	}
-	out := buildNames(plan, true)
+	out := buildNames(plan, true, true)
 	if out.AssignNamesUsing == nil || *out.AssignNamesUsing != "List of Names" {
 		t.Errorf("assign_names_using not copied")
 	}
@@ -191,7 +356,7 @@ func TestBuildNames_UpdateEchoesModelID(t *testing.T) {
 			{DeviceName: types.StringValue("iPad-2"), ID: types.StringNull()},
 		},
 	}
-	out := buildNames(plan, false)
+	out := buildNames(plan, true, false)
 	if out.PrestageDeviceNames == nil || len(*out.PrestageDeviceNames) != 2 {
 		t.Fatalf("expected 2 prestage device names")
 	}
@@ -210,7 +375,7 @@ func TestBuildPostInput_NamesAndNestedDefaults(t *testing.T) {
 		DeviceEnrollmentProgramInstanceID: types.StringValue("1"),
 		// Names omitted, storage unset, skip omitted.
 	}
-	post, d := buildPostInput(context.Background(), plan)
+	post, d := buildPostInput(context.Background(), plan, plan)
 	if d.HasError() {
 		t.Fatalf("post build diags: %v", d)
 	}
@@ -257,7 +422,7 @@ func TestBuildPostInput_SkipSetupItemsPopulated(t *testing.T) {
 			Biometric: types.BoolValue(true),
 		},
 	}
-	post, d := buildPostInput(context.Background(), plan)
+	post, d := buildPostInput(context.Background(), plan, plan)
 	if d.HasError() {
 		t.Fatalf("post build diags: %v", d)
 	}
@@ -277,7 +442,7 @@ func TestBuildPutInput_Smoke(t *testing.T) {
 		DisplayName:                       types.StringValue("put"),
 		DeviceEnrollmentProgramInstanceID: types.StringValue("1"),
 	}
-	put, d := buildPutInput(context.Background(), plan)
+	put, d := buildPutInput(context.Background(), plan, plan)
 	if d.HasError() {
 		t.Fatalf("put build diags: %v", d)
 	}

--- a/internal/resources/pro/mobile_device_prestage_enrollment/model_types.go
+++ b/internal/resources/pro/mobile_device_prestage_enrollment/model_types.go
@@ -80,17 +80,17 @@ type MobileDevicePrestageEnrollmentResourceModel struct {
 	Timeouts resourceTimeouts.Value `tfsdk:"timeouts"`
 }
 
-// NamesModel is the device-naming nested block (spike §4.2). The server
-// assigns `device_naming_configured`; the `prestage_device_names` list element
-// `id`/`used` are server-managed but echoed on the wire so the PUT round-trips.
+// NamesModel is the device-naming nested block (spike §4.2). The
+// `prestage_device_names` list element `id`/`used` are server-managed but echoed
+// on the wire so the PUT round-trips. The wire block's deviceNamingConfigured is
+// unmodelled and derived at write time — see namingIntended.
 type NamesModel struct {
-	AssignNamesUsing       types.String              `tfsdk:"assign_names_using"`
-	ManageNames            types.Bool                `tfsdk:"manage_names"`
-	DeviceNamingConfigured types.Bool                `tfsdk:"device_naming_configured"`
-	DeviceNamePrefix       types.String              `tfsdk:"device_name_prefix"`
-	DeviceNameSuffix       types.String              `tfsdk:"device_name_suffix"`
-	SingleDeviceName       types.String              `tfsdk:"single_device_name"`
-	PrestageDeviceNames    []PrestageDeviceNameModel `tfsdk:"prestage_device_names"`
+	AssignNamesUsing    types.String              `tfsdk:"assign_names_using"`
+	ManageNames         types.Bool                `tfsdk:"manage_names"`
+	DeviceNamePrefix    types.String              `tfsdk:"device_name_prefix"`
+	DeviceNameSuffix    types.String              `tfsdk:"device_name_suffix"`
+	SingleDeviceName    types.String              `tfsdk:"single_device_name"`
+	PrestageDeviceNames []PrestageDeviceNameModel `tfsdk:"prestage_device_names"`
 }
 
 // PrestageDeviceNameModel is one element of the `prestage_device_names` list.

--- a/internal/resources/pro/mobile_device_prestage_enrollment/resource.go
+++ b/internal/resources/pro/mobile_device_prestage_enrollment/resource.go
@@ -114,10 +114,13 @@ func (r *MobileDevicePrestageEnrollmentResource) Schema(ctx context.Context, req
 			"configure_device_before_setup_assistant": optBool("**\"Configure device before Setup Assistant\"** in the Jamf Pro admin UI."),
 			// Jamf Pro allows at most one default PreStage per device type.
 			// Setting this to true is honored only when no other PreStage is
-			// currently the default; if another already holds it, Jamf Pro
-			// silently keeps this false rather than stealing the flag (§F10).
+			// currently the default; if another already holds it the write is
+			// REJECTED with 400 ALREADY_DEFAULT and nothing is stored — it is NOT
+			// silently kept false. diagnoseAlreadyDefault turns that into an
+			// actionable diagnostic, and ModifyPlan deliberately leaves this
+			// attribute alone (see the note there).
 			"default_prestage": schema.BoolAttribute{
-				MarkdownDescription: "When true, this PreStage becomes the tenant default for new devices. Jamf Pro allows at most one default PreStage: if another PreStage is already the default, Jamf Pro keeps this `false` rather than reassigning. Clear the existing default first to take it over.",
+				MarkdownDescription: "When true, this PreStage becomes the tenant default for new devices. Jamf Pro allows at most one default PreStage and will not move the default automatically: if another PreStage already holds it, the apply fails. Set `default_prestage = false` on the current holder first — and where both are managed by Terraform, make the release land before the claim (apply it on its own, or add a `depends_on` from this resource to the one giving up the default).",
 				Optional:            true,
 				Computed:            true,
 				PlanModifiers: []planmodifier.Bool{

--- a/internal/resources/pro/mobile_device_prestage_enrollment/resource.go
+++ b/internal/resources/pro/mobile_device_prestage_enrollment/resource.go
@@ -414,7 +414,7 @@ func skipSetupItemsSchema() schema.SingleNestedAttribute {
 // with no computer analog.
 func namesSchema() schema.SingleNestedAttribute {
 	return schema.SingleNestedAttribute{
-		MarkdownDescription: "**\"Mobile device names\"** in the Jamf Pro admin UI. Supply the block (even empty: `names = {}`) to manage device naming — omitting it produces drift on the next refresh because Jamf Pro always returns a populated block.",
+		MarkdownDescription: "**\"Mobile device names\"** in the Jamf Pro admin UI. Supply the block (even empty: `names = {}`) to manage device naming — omitting it produces drift on the next refresh because Jamf Pro always returns a populated block. A bare `names = {}` leaves device naming *unconfigured*, which is how Jamf Pro's admin UI decides not to show the naming payload at all: set at least one field below for naming to take effect.",
 		Optional:            true,
 		Attributes: map[string]schema.Attribute{
 			"assign_names_using": schema.StringAttribute{
@@ -433,13 +433,13 @@ func namesSchema() schema.SingleNestedAttribute {
 			"device_name_prefix": optString("Device name prefix (used in `\"Serial Numbers\"` mode)."),
 			"device_name_suffix": optString("Device name suffix (used in `\"Serial Numbers\"` mode)."),
 			"single_device_name": optString("Single device name (used in `\"Single Name\"` mode). Required when `assign_names_using = \"Single Name\"`."),
-			"device_naming_configured": schema.BoolAttribute{
-				MarkdownDescription: "Whether device naming has been configured. Server-managed; not user-settable.",
-				Computed:            true,
-				PlanModifiers: []planmodifier.Bool{
-					boolplanmodifier.UseStateForUnknown(),
-				},
-			},
+			// deviceNamingConfigured is not exposed: it adds nothing the sibling
+			// attributes don't already say. It is still WRITTEN — buildNames
+			// derives it via namingIntended. Do not drop it from the wire body:
+			// the Jamf Pro admin UI hides the whole "Mobile device names" payload
+			// when it is false, and the server stores exactly what the write
+			// sends rather than deriving it (wire-probed 2026-08-07, Jamf Pro
+			// 11.30). Omitting it is what made naming invisible in the UI.
 			// Deliberately plain Optional, NOT Optional+Computed — an explicit
 			// carve-out from the provider-wide "full-replace ⇒ omit=preserve"
 			// standard (STYLE_GUIDE §Full-replace endpoints). prestage_device_names

--- a/internal/resources/pro/mobile_device_prestage_enrollment/server_arbitrated_test.go
+++ b/internal/resources/pro/mobile_device_prestage_enrollment/server_arbitrated_test.go
@@ -4,6 +4,10 @@
 package mobile_device_prestage_enrollment
 
 import (
+	"errors"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -57,7 +61,7 @@ func TestResolveIntentBool(t *testing.T) {
 // would serialise as false and silently disable the user's intent.
 func TestRestoreServerArbitrated_StateCarryPath(t *testing.T) {
 	plan := MobileDevicePrestageEnrollmentResourceModel{
-		DefaultPrestage:      types.BoolUnknown(),
+		DefaultPrestage:      types.BoolValue(true),
 		UseStorageQuotaSize:  types.BoolUnknown(),
 		TemporarySessionOnly: types.BoolUnknown(),
 	}
@@ -72,8 +76,10 @@ func TestRestoreServerArbitrated_StateCarryPath(t *testing.T) {
 
 	restoreServerArbitrated(&plan, cfg, state)
 
+	// default_prestage is not server-arbitrated and is never stamped Unknown, so
+	// restore must pass it through untouched.
 	if !plan.DefaultPrestage.Equal(types.BoolValue(true)) {
-		t.Errorf("default_prestage intent lost: %v", plan.DefaultPrestage)
+		t.Errorf("default_prestage should pass through untouched: %v", plan.DefaultPrestage)
 	}
 	if !plan.UseStorageQuotaSize.Equal(types.BoolValue(true)) {
 		t.Errorf("use_storage_quota_size intent lost (state-carry): %v", plan.UseStorageQuotaSize)
@@ -88,7 +94,7 @@ func TestRestoreServerArbitrated_StateCarryPath(t *testing.T) {
 // rather than leaking Unknown into the POST body.
 func TestRestoreServerArbitrated_CreateNoState(t *testing.T) {
 	plan := MobileDevicePrestageEnrollmentResourceModel{
-		DefaultPrestage:      types.BoolUnknown(),
+		DefaultPrestage:      types.BoolValue(true),
 		UseStorageQuotaSize:  types.BoolValue(false),
 		TemporarySessionOnly: types.BoolUnknown(),
 	}
@@ -101,9 +107,58 @@ func TestRestoreServerArbitrated_CreateNoState(t *testing.T) {
 	restoreServerArbitrated(&plan, cfg, MobileDevicePrestageEnrollmentResourceModel{})
 
 	if !plan.DefaultPrestage.Equal(types.BoolValue(true)) {
-		t.Errorf("default_prestage = %v, want true (from config)", plan.DefaultPrestage)
+		t.Errorf("default_prestage = %v, want true (passed through)", plan.DefaultPrestage)
 	}
 	if !plan.TemporarySessionOnly.Equal(types.BoolValue(false)) {
 		t.Errorf("temporary_session_only = %v, want false (no config/state)", plan.TemporarySessionOnly)
 	}
+}
+
+// TestDiagnoseAlreadyDefault covers the ALREADY_DEFAULT mapping. Jamf Pro
+// rejects a claim on a default another PreStage holds with 400 ALREADY_DEFAULT
+// and writes nothing, so the error must be surfaced (not swallowed as a
+// warning) and must name the fix.
+func TestDiagnoseAlreadyDefault(t *testing.T) {
+	apiErr := errors.New(`CreateMobileDevicePrestageV3: 400 {"httpStatus":400,"errors":[{"code":"ALREADY_DEFAULT","description":"Another prestage is already the default prestage","id":"0","field":"defaultPrestage"}]}`)
+
+	t.Run("recognised, with config intent", func(t *testing.T) {
+		var diags diag.Diagnostics
+		cfg := MobileDevicePrestageEnrollmentResourceModel{DefaultPrestage: types.BoolValue(true)}
+		if !diagnoseAlreadyDefault(&diags, cfg, apiErr) {
+			t.Fatalf("must recognise ALREADY_DEFAULT")
+		}
+		if !diags.HasError() {
+			t.Fatalf("must raise an ERROR, not a warning — the write did not happen")
+		}
+		detail := diags.Errors()[0].Detail()
+		if !strings.Contains(detail, "default_prestage = false") {
+			t.Errorf("detail should name the fix, got: %s", detail)
+		}
+		// The ordering hazard only applies when this resource is the claimant.
+		if !strings.Contains(detail, "depends_on") {
+			t.Errorf("detail should cover the release-before-claim ordering, got: %s", detail)
+		}
+	})
+
+	t.Run("recognised, no config intent", func(t *testing.T) {
+		var diags diag.Diagnostics
+		if !diagnoseAlreadyDefault(&diags, MobileDevicePrestageEnrollmentResourceModel{}, apiErr) {
+			t.Fatalf("must recognise ALREADY_DEFAULT regardless of config")
+		}
+		if strings.Contains(diags.Errors()[0].Detail(), "depends_on") {
+			t.Errorf("ordering advice is noise when the user did not ask for the default")
+		}
+	})
+
+	t.Run("passes other errors through", func(t *testing.T) {
+		var diags diag.Diagnostics
+		for _, err := range []error{nil, errors.New("500 internal server error"), errors.New("ALREADY_SCOPED")} {
+			if diagnoseAlreadyDefault(&diags, MobileDevicePrestageEnrollmentResourceModel{}, err) {
+				t.Errorf("must not claim unrelated error: %v", err)
+			}
+		}
+		if diags.HasError() {
+			t.Errorf("must not add diagnostics for unrelated errors")
+		}
+	})
 }

--- a/internal/resources/pro/mobile_device_prestage_enrollment/state_builders.go
+++ b/internal/resources/pro/mobile_device_prestage_enrollment/state_builders.go
@@ -178,12 +178,11 @@ func flattenNames(n *pro.MobileDevicePrestageNamesV3) *NamesModel {
 		return nil
 	}
 	out := &NamesModel{
-		AssignNamesUsing:       helpers.StringPointerValueOrNull(n.AssignNamesUsing),
-		ManageNames:            helpers.BoolPointerValueOrNull(n.ManageNames),
-		DeviceNamingConfigured: helpers.BoolPointerValueOrNull(n.DeviceNamingConfigured),
-		DeviceNamePrefix:       helpers.StringPointerValueOrNull(n.DeviceNamePrefix),
-		DeviceNameSuffix:       helpers.StringPointerValueOrNull(n.DeviceNameSuffix),
-		SingleDeviceName:       helpers.StringPointerValueOrNull(n.SingleDeviceName),
+		AssignNamesUsing: helpers.StringPointerValueOrNull(n.AssignNamesUsing),
+		ManageNames:      helpers.BoolPointerValueOrNull(n.ManageNames),
+		DeviceNamePrefix: helpers.StringPointerValueOrNull(n.DeviceNamePrefix),
+		DeviceNameSuffix: helpers.StringPointerValueOrNull(n.DeviceNameSuffix),
+		SingleDeviceName: helpers.StringPointerValueOrNull(n.SingleDeviceName),
 	}
 	// prestage_device_names is Optional-only (no Computed) — mirror the
 	// enrollment_customization text_panes pattern: leave the slice nil when

--- a/internal/resources/pro/mobile_device_prestage_enrollment/state_builders.go
+++ b/internal/resources/pro/mobile_device_prestage_enrollment/state_builders.go
@@ -273,13 +273,15 @@ func stringSliceToList(in []string) types.List {
 // expected, NOT a silent rollback, so they are omitted from this check:
 //
 //	storage_quota_size_megabytes  (recalculated to a device floor, §F8)
-//	default_prestage              (conditional singleton, §F10)
 //	use_storage_quota_size        (forced false when temp-session wins, §F9)
 //	temporary_session_only        (symmetric to above, §F9)
 //	temporary_session_timeout     (nulled below min / not enforced, §F11)
 //
 // anchor_certificates and names/prestage_device_names stay IN the check —
-// their mismatch IS a real failure (§F4b).
+// their mismatch IS a real failure (§F4b). So does default_prestage: it was
+// previously excluded as a "conditional singleton" on the assumption Jamf Pro
+// silently keeps it false, but a refused claim is a hard 400 ALREADY_DEFAULT
+// (wire-probed 2026-08-07), so a mismatch here really is a rollback.
 func diffPlanAgainstGet(ctx context.Context, plan MobileDevicePrestageEnrollmentResourceModel, got *pro.GetMobileDevicePrestageV3) []string {
 	var mismatched []string
 
@@ -309,7 +311,7 @@ func diffPlanAgainstGet(ctx context.Context, plan MobileDevicePrestageEnrollment
 	checkBool("allow_pairing", plan.AllowPairing, got.AllowPairing)
 	checkBool("auto_advance_setup", plan.AutoAdvanceSetup, got.AutoAdvanceSetup)
 	checkBool("configure_device_before_setup_assistant", plan.ConfigureDeviceBeforeSetupAssistant, got.ConfigureDeviceBeforeSetupAssistant)
-	// default_prestage — EXCLUDED (§9.1).
+	checkBool("default_prestage", plan.DefaultPrestage, got.DefaultPrestage)
 	checkBool("send_timezone", plan.SendTimezone, got.SendTimezone)
 	checkBool("prevent_activation_lock", plan.PreventActivationLock, got.PreventActivationLock)
 	checkBool("enable_device_based_activation_lock", plan.EnableDeviceBasedActivationLock, got.EnableDeviceBasedActivationLock)

--- a/internal/resources/pro/mobile_device_prestage_enrollment/state_builders_test.go
+++ b/internal/resources/pro/mobile_device_prestage_enrollment/state_builders_test.go
@@ -174,24 +174,26 @@ func TestScopeSerialsToSet(t *testing.T) {
 
 // TestDiffPlanAgainstGet_ExclusionSet is the single most important unit test in
 // the package. The §9.1 server-authoritative exclusion set
-// (storage_quota_size_megabytes, default_prestage, use_storage_quota_size,
-// temporary_session_only, temporary_session_timeout) MUST NOT appear in the
-// rollback-detection diff even when every one of them differs between plan and
-// GET — their post-PUT drift is server-intentional, not a silent rollback.
+// (storage_quota_size_megabytes, use_storage_quota_size, temporary_session_only,
+// temporary_session_timeout) MUST NOT appear in the rollback-detection diff even
+// when every one of them differs between plan and GET — their post-PUT drift is
+// server-intentional, not a silent rollback.
 //
-// Only those five fields are set on the plan; everything else is left null
+// default_prestage is NOT in the set: it was excluded on the belief Jamf Pro
+// silently keeps it false, but a refused claim is a hard 400 ALREADY_DEFAULT, so
+// a plan/GET mismatch there is a real rollback and must be reported.
+//
+// Only those four fields are set on the plan; everything else is left null
 // (zero-value types.*), which the per-field early-return guards skip.
 func TestDiffPlanAgainstGet_ExclusionSet(t *testing.T) {
 	plan := MobileDevicePrestageEnrollmentResourceModel{
 		StorageQuotaSizeMegabytes: types.Int64Value(8192),
-		DefaultPrestage:           types.BoolValue(true),
 		UseStorageQuotaSize:       types.BoolValue(true),
 		TemporarySessionOnly:      types.BoolValue(true),
 		TemporarySessionTimeout:   types.Int64Value(120),
 	}
 	got := &pro.GetMobileDevicePrestageV3{
 		StorageQuotaSizeMegabytes: 1024,  // differs
-		DefaultPrestage:           false, // differs
 		UseStorageQuotaSize:       false, // differs
 		TemporarySessionOnly:      false, // differs
 		TemporarySessionTimeout:   0,     // differs
@@ -199,6 +201,17 @@ func TestDiffPlanAgainstGet_ExclusionSet(t *testing.T) {
 	diff := diffPlanAgainstGet(context.Background(), plan, got)
 	if len(diff) != 0 {
 		t.Fatalf("excluded fields must NEVER appear in the rollback diff; got %v", diff)
+	}
+}
+
+// TestDiffPlanAgainstGet_DefaultPrestageIsChecked pins the counterpart: a
+// planned default_prestage that the GET contradicts is a genuine rollback.
+func TestDiffPlanAgainstGet_DefaultPrestageIsChecked(t *testing.T) {
+	plan := MobileDevicePrestageEnrollmentResourceModel{DefaultPrestage: types.BoolValue(true)}
+	got := &pro.GetMobileDevicePrestageV3{DefaultPrestage: false}
+	diff := diffPlanAgainstGet(context.Background(), plan, got)
+	if len(diff) != 1 || diff[0] != "default_prestage" {
+		t.Fatalf("default_prestage mismatch must be reported, got %v", diff)
 	}
 }
 


### PR DESCRIPTION
Two independent bugs in `jamfplatform_pro_mobile_device_prestage_enrollment`, both present since `0472b55` (the commit that introduced the resource) and therefore in every release. Both found from a user report, both root-caused by wire-probing Jamf Pro 11.30 and verified end to end against a live tenant.

Each commit stands alone and they touch mostly disjoint code, but they share a root pattern worth naming: **a field was assumed server-managed, and that assumption was never wire-checked.** In both cases the server turned out to behave differently, and the provider was built around the wrong contract.

## 1. `names` applied but the naming payload was invisible in the UI

A prestage configured with a `names` block stored its naming values, yet the Jamf Pro admin UI showed no **Mobile device names** payload at all.

The UI keys that payload off `names.deviceNamingConfigured`. The provider never sent the field, so Jamf Pro stored `false` and hid the payload however complete the rest of the block was. It was modelled `Computed` — *"Whether device naming has been configured. Server-managed; not user-settable."* — on the assumption Jamf Pro derives it. It does not:

- The API spec types it as a plain writable `boolean` (`"example": true`) on both `MobileDevicePrestageNamesV2` and `V3`.
- Wire probe: the server stores verbatim whatever the write sends, and stores `false` when the write omits it.
- Two prestages POSTed byte-identically except that one flag: the one with `true` showed the payload in the UI, the one with `false` did not. Confirmed visually by the reporter.

**Fix.** `buildNames` now always emits `deviceNamingConfigured`, derived by `namingIntended` — `true` when the block expresses naming intent (`assign_names_using`, `manage_names = true`, a prefix/suffix/single name, or a non-empty `prestage_device_names`), `false` for a bare `names = {}`.

Derived from the **config**, not the plan. `assign_names_using` is `Optional+Computed` with `UseStateForUnknown`, so on update the plan carries the server's echoed mode even for a bare `names = {}`. Deriving from the plan flipped an unconfigured PreStage to configured on any unrelated edit — caught in live testing, pinned by a regression test. `buildPostInput`/`buildPutInput` therefore take `cfg` alongside `plan`.

Records written by earlier releases stay unconfigured, and Terraform sees no drift because the field is no longer a managed attribute. `Read` emits a warning naming the fix via `warnNamingNotConfigured`. That uses a deliberately stricter predicate (`namingIntentBesidesMode`) which ignores `assign_names_using`: post-GET state cannot distinguish a user-set mode from Jamf Pro's echo, and including it false-positived on `names = {}`.

### Breaking change

`names.device_naming_configured` is removed. It exposed provider bookkeeping rather than a user setting, and the only state it let a user reach that they cannot reach without it is the broken one — a fully populated naming block the UI refuses to show. No state upgrader, per repo policy; existing state decodes cleanly (verified against real state written by the old provider: the framework drops the key and `plan` reports no changes).

## 2. `default_prestage = true` was impossible to set

Any plan resolving `default_prestage` to `true` from a known config value failed outright:

```
Error: Provider produced invalid plan
...planned an invalid value for ...default_prestage: planned value
cty.UnknownVal(cty.Bool) does not match config value cty.True
```

`ModifyPlan` stamped the attribute `Unknown` on the `false -> true` transition and on create-with-`true`. For an `Optional+Computed` attribute whose config value is known and non-null, Terraform Core requires the planned value to equal the config value, so the plan was rejected before any request was made:

| config | prior state | result |
|---|---|---|
| `true` | none (create) | invalid plan |
| `true` | `false` | invalid plan |
| `true` | `true` | worked (guard skipped this case) |
| omitted | any | worked |

The flag could be observed but never set.

The guard was also unnecessary. It existed to absorb a silent server override — *"Jamf Pro silently keeps this false rather than stealing the flag"* — that does not happen. Wire-probed, no provider involved:

| transition | server |
|---|---|
| create `true`, no current holder | accepted |
| create `true`, another holds it | **400 `ALREADY_DEFAULT`**, nothing created |
| update `true`, no current holder | accepted |
| update `true`, this one holds it | accepted (no-op) |
| update `true`, another holds it | **400 `ALREADY_DEFAULT`**, nothing written |
| update `false` (release) | accepted, tenant left with no default |

`Another prestage is already the default prestage`, `field: defaultPrestage`. A hard reject, never a silent `false`.

**Fix.** The `default_prestage` branch is dropped from `ModifyPlan` and its entry from `restoreServerArbitrated`. `warnDefaultPrestageRefused` is deleted: it was unreachable (a refusal is a 400, so Create/Update returns on the error long before the post-write GET the warning read) and it described behaviour the server does not have. `diagnoseAlreadyDefault` replaces it, mapping `ALREADY_DEFAULT` to an error that names the fix.

`default_prestage` also returns to the `diffPlanAgainstGet` rollback check. It sat in the §9.1 server-authoritative exclusion set on the same wrong premise; since the server never silently overrides it, a plan/GET mismatch there is a real rollback.

### Known API limitation, documented not worked around

Moving the default between two Terraform-managed prestages in a single apply **reliably fails**. Terraform updates both in parallel and the claim consistently reaches the server before the release commits, so the claim is refused — and the release still lands, leaving the tenant with no default at all.

`depends_on` from the claimant to the releaser serialises the two and the move succeeds (verified rather than assumed, since the diagnostic recommends it). Both the diagnostic and the attribute description spell this out.

## Verification

Live tenant, fixed provider, sandbox left clean afterwards.

`names`:

- fresh create writes `deviceNamingConfigured = true`
- bare `names = {}` holds `false` across two unrelated applies
- a stale record warns on refresh, and heals on re-apply
- pre-existing state decodes without an upgrader

`default_prestage`:

- create-with-`true` — the original error, gone
- update-to-`true`
- steady-state `true` is a clean no-op
- `plan -refresh=false` (`UseStateForUnknown` sanity)
- refusal on **both** create and update paths, nothing written either time
- the parallel-move race, and the `depends_on` fix

`go build`, full `go test ./...`, `go vet -tags acceptance`, `make generate` and `golangci-lint run ./internal/...` all clean. Docs regenerated.

## Not done

**Acceptance tests are unrun** and I have not added any. Worth noting that `resource_acceptance_test.go` has no `default_prestage` coverage at all, which is how a bug this total stayed invisible for the resource's entire life; `device_naming_configured` was likewise only ever asserted as a state attribute, never against the wire. Neither gap is closeable by a state assertion alone — the naming flag is no longer in state, and the default-prestage refusal needs a second prestage holding the default — so both want a check that reads the API directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
