### PR TITLE
fix(payloadhelpers): tolerate Jamf Pro reordering PayloadContent entries

### DIFF
--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -510,6 +510,29 @@ Mask drops (or empty-normalises) from **both** sides:
 
 Cost: CR-vs-LF drift fidelity everywhere. Accepted over a per-`PayloadType` model of the server's line-break handling, which is empirical and drifts each release. U+2028/U+2029/U+0085 are deliberately **not** normalised — they round-trip byte-exact, render as line breaks on-device, and keep full drift detection.
 
+**`PayloadContent` entry order is not preserved on store — canonicalise it, do not compare it.** Jamf Pro **stably partitions** the top-level `PayloadContent` array into the entries it stores *verbatim* followed by the entries it *re-renders* (the same two categories as §"Payload storage categories" below), keeping relative order within each block. Wire-probed 2026-08-11 against Jamf Pro 11.30.x across 18 profile shapes, no exceptions:
+
+| Authored order | Stored order |
+|---|---|
+| `[MCX, certificate]` | `[certificate, MCX]` |
+| `[certificate, MCX]` | unchanged — already canonical |
+| `[MCX, certificate, MCX]` | `[certificate, MCX, MCX]` |
+| `[notificationsettings, MCX]` | unchanged — both re-rendered |
+| `[loginwindow, certificate]` | unchanged — both verbatim |
+| `[MCX, loginwindow, certificate]` | `[loginwindow, certificate, MCX]` |
+| `[MCX-a, certificate, MCX-b, certificate-b, MCX-c]` | `[certificate, certificate-b, MCX-a, MCX-b, MCX-c]` |
+
+A positional array compare therefore pairs unrelated entries and reports cascading false drift on every key of both — which reached a user as a bogus `"Jamf Pro cannot store this payload faithfully"` error plus a create-time rollback for a payload the server had stored perfectly. `maskPayloadContent` closes this by **stable-sorting the array by `PayloadType`** (`canonicalisePayloadContentOrder`), so both sides reach the comparator in the same order and every comparator built on `MaskPayload` — the lenient `LenientEqualPlist` and the strict `structuralEqual` behind `ThreeWayCompare` — inherits the fix.
+
+Two properties make this a canonicalisation rather than a tolerance:
+
+- **Entry order carries no meaning.** Apple treats each `PayloadContent` entry as an independent payload, so an order-insensitive comparison is the correct one.
+- **The sort is stable and keyed only on `PayloadType`**, so same-type siblings keep their authored order relative to each other and an edit to one of them still surfaces as drift. That granularity is exactly what the wire law needs: same `PayloadType` implies the same partition, so Jamf Pro *cannot* reorder same-type siblings.
+
+Do not reach for `PayloadIdentifier` as a pairing key — it is masked (server-assignable) and already gone by compare time.
+
+The same reorder breaks the **read-back diagnostic**, which quotes indexed paths (`PayloadContent[1].Foo`) and so needs both sides to agree on which entry index 1 is. `PayloadFidelityErrorDetail` permutes the stored array back into the *authored* order (`alignPayloadContentOrder`) rather than sorting both, so the indices it prints match the payload the operator wrote.
+
 If `inp_masked == srv_masked` the modifier suppresses the diff by setting `plan.payloads = state.payloads`. Otherwise the plan keeps the raw user input and Terraform plans the change.
 
 **Trade-off accepted**: if the user authors a meaningful change to one of the masked keys (e.g. a hand-tuned `PayloadOrganization`), the provider will not detect drift — the server overwrites that value on the next write anyway, so a permanent diff would be the alternative. Document this in the `payloads` attribute `MarkdownDescription`.

--- a/internal/common/payloadhelpers/fidelity.go
+++ b/internal/common/payloadhelpers/fidelity.go
@@ -196,7 +196,7 @@ func diffPayloadTrees(authoredTree, storedTree map[string]any) []fidelityFinding
 	authoredFlat := map[string]string{}
 	storedFlat := map[string]string{}
 	flattenStringLeaves("", authoredTree, authoredFlat)
-	flattenStringLeaves("", storedTree, storedFlat)
+	flattenStringLeaves("", alignPayloadContentOrder(authoredTree, storedTree), storedFlat)
 
 	findings := make([]fidelityFinding, 0, 4)
 	for _, path := range sortedKeys(authoredFlat) {
@@ -217,6 +217,69 @@ func diffPayloadTrees(authoredTree, storedTree map[string]any) []fidelityFinding
 		})
 	}
 	return findings
+}
+
+// alignPayloadContentOrder returns storedTree with its top-level PayloadContent
+// array permuted back into the order authoredTree used, pairing entries by
+// PayloadType in order of appearance. Entries with no counterpart keep their
+// relative order at the end.
+//
+// The paths this diagnostic quotes are indexed (`PayloadContent[1].Foo`), so both
+// sides have to agree on which entry index 1 is. Jamf Pro reorders the array on
+// store — it stably partitions verbatim-stored entries ahead of re-rendered ones
+// (see canonicalisePayloadContentOrder for the wire law) — so without this step
+// every leaf below a moved entry is diffed against an unrelated payload: values
+// that stored perfectly get reported as "not stored at all", a phantom
+// PayloadType mismatch appears, and the one real defect is pushed past
+// maxReportedFindings. Wire-confirmed 2026-08-11 on an authored
+// [MCX, loginwindow] profile carrying a single line feed: four findings reported,
+// none of them the line feed.
+//
+// Aligning to the *authored* order rather than sorting both sides keeps the
+// reported indices matching the payload the operator wrote, which is the whole
+// point of naming a path in the message.
+//
+// The returned tree shares everything except the PayloadContent slice with
+// storedTree — nothing here mutates the caller's trees, so the import gate's
+// predicted tree (which is already in authored order, making this a no-op)
+// continues to diff through exactly the comparison the post-write checks use.
+func alignPayloadContentOrder(authoredTree, storedTree map[string]any) map[string]any {
+	authored, aOK := authoredTree["PayloadContent"].([]any)
+	stored, sOK := storedTree["PayloadContent"].([]any)
+	if !aOK || !sOK || len(authored) < 2 || len(stored) < 2 {
+		return storedTree
+	}
+
+	remaining := make(map[string][]any, len(stored))
+	var order []string
+	for _, entry := range stored {
+		pt := payloadTypeOf(entry)
+		if _, seen := remaining[pt]; !seen {
+			order = append(order, pt)
+		}
+		remaining[pt] = append(remaining[pt], entry)
+	}
+
+	aligned := make([]any, 0, len(stored))
+	for _, entry := range authored {
+		pt := payloadTypeOf(entry)
+		if queue := remaining[pt]; len(queue) > 0 {
+			aligned = append(aligned, queue[0])
+			remaining[pt] = queue[1:]
+		}
+	}
+	// Anything the authored side had no slot for — an entry Jamf Pro injected, or
+	// a type whose count grew — keeps its stored relative order at the end.
+	for _, pt := range order {
+		aligned = append(aligned, remaining[pt]...)
+	}
+
+	out := make(map[string]any, len(storedTree))
+	for k, v := range storedTree {
+		out[k] = v
+	}
+	out["PayloadContent"] = aligned
+	return out
 }
 
 // classify picks the wire law that explains one divergence. Order is

--- a/internal/common/payloadhelpers/fidelity_test.go
+++ b/internal/common/payloadhelpers/fidelity_test.go
@@ -189,3 +189,114 @@ func mustNotContain(t *testing.T, got, unwanted string) {
 		t.Errorf("detail unexpectedly contains %q:\n%s", unwanted, got)
 	}
 }
+
+// Wire-observed 2026-08-11 against Jamf Pro 11.30.x: an authored
+// [MCX, loginwindow] profile comes back as [loginwindow, MCX], because a
+// loginwindow payload is stored verbatim while MCX is re-rendered and Jamf Pro
+// puts the verbatim block first. The loginwindow value also loses its line feed,
+// so this pair carries a reorder and exactly one real defect at the same time.
+const (
+	reorderedAuthored = `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0"><dict>
+<key>PayloadType</key><string>Configuration</string>
+<key>PayloadVersion</key><integer>1</integer>
+<key>PayloadIdentifier</key><string>top-id</string>
+<key>PayloadUUID</key><string>top-uuid</string>
+<key>PayloadContent</key><array>
+<dict>
+<key>PayloadType</key><string>com.apple.ManagedClient.preferences</string>
+<key>PayloadVersion</key><integer>1</integer>
+<key>PayloadContent</key><dict>
+<key>com.example.browser</key><dict>
+<key>Forced</key><array><dict>
+<key>mcx_preference_settings</key><dict>
+<key>HomepageLocation</key><string>https://example.com/start</string>
+</dict>
+</dict></array>
+</dict>
+</dict>
+</dict>
+<dict>
+<key>PayloadType</key><string>com.apple.loginwindow</string>
+<key>PayloadVersion</key><integer>1</integer>
+<key>LoginwindowText</key><string>FIRST LINE
+SECOND LINE</string>
+</dict>
+</array>
+</dict></plist>`
+
+	reorderedStored = `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0"><dict>
+<key>PayloadType</key><string>Configuration</string>
+<key>PayloadVersion</key><integer>1</integer>
+<key>PayloadIdentifier</key><string>top-id</string>
+<key>PayloadUUID</key><string>top-uuid</string>
+<key>PayloadContent</key><array>
+<dict>
+<key>PayloadType</key><string>com.apple.loginwindow</string>
+<key>PayloadVersion</key><integer>1</integer>
+<key>LoginwindowText</key><string>FIRST LINESECOND LINE</string>
+</dict>
+<dict>
+<key>PayloadType</key><string>com.apple.ManagedClient.preferences</string>
+<key>PayloadVersion</key><integer>1</integer>
+<key>PayloadContent</key><dict>
+<key>com.example.browser</key><dict>
+<key>Forced</key><array><dict>
+<key>mcx_preference_settings</key><dict>
+<key>HomepageLocation</key><string>https://example.com/start</string>
+</dict>
+</dict></array>
+</dict>
+</dict>
+</dict>
+</array>
+</dict></plist>`
+)
+
+// TestPayloadFidelityErrorDetail_ReorderedEntriesBlameOnlyTheRealValue is the
+// regression guard for the diagnostic half of the reorder bug. The paths this
+// message quotes are indexed, so when Jamf Pro moves an entry the authored and
+// stored sides disagree about which entry index 1 is. Without
+// alignPayloadContentOrder this pair produced four findings — a value that stored
+// perfectly reported as "not stored at all", a phantom PayloadType mismatch, the
+// real defect misclassified as absent, and the actual line-break finding pushed
+// past maxReportedFindings and never shown to the operator.
+func TestPayloadFidelityErrorDetail_ReorderedEntriesBlameOnlyTheRealValue(t *testing.T) {
+	got := PayloadFidelityErrorDetail([]byte(reorderedAuthored), []byte(reorderedStored), FidelityPhaseCreate)
+
+	// Exactly one value differs, and it is named at the index the operator wrote it at.
+	mustContain(t, got, "Jamf Pro stored a payload value differently")
+	mustContain(t, got, "PayloadContent[1].LoginwindowText")
+	mustContain(t, got, "line breaks removed")
+	mustContain(t, got, `"FIRST LINE\nSECOND LINE"`)
+
+	// None of the reorder artefacts may appear.
+	mustNotContain(t, got, "further value(s) also differ")
+	mustNotContain(t, got, "not stored at all")
+	mustNotContain(t, got, "HomepageLocation")
+	mustNotContain(t, got, "com.apple.ManagedClient.preferences")
+}
+
+// TestPayloadFidelityErrorDetail_ReorderAloneIsNotReported covers the case that
+// actually reached a user: the array was reordered and nothing else changed, so
+// the diff must be silent. The equality gate suppresses this before the
+// diagnostic is reached, but the two must not be able to disagree.
+func TestPayloadFidelityErrorDetail_ReorderAloneIsNotReported(t *testing.T) {
+	authored, stored := []byte(reorderedAuthored), []byte(reorderedStored)
+	// Same pair with the line feed left intact on the stored side.
+	stored = []byte(strings.Replace(string(stored), "FIRST LINESECOND LINE", "FIRST LINE\nSECOND LINE", 1))
+
+	findings, ok := diffPayloadStrings(authored, stored)
+	if !ok {
+		t.Fatal("pair did not parse")
+	}
+	if len(findings) != 0 {
+		for _, f := range findings {
+			t.Logf("unexpected finding: %s (present=%v)", f.path, f.present)
+		}
+		t.Errorf("a reorder with no value change must produce no findings, got %d", len(findings))
+	}
+}

--- a/internal/common/payloadhelpers/helpers.go
+++ b/internal/common/payloadhelpers/helpers.go
@@ -345,6 +345,9 @@ func LenientEqualPlist(a, b any) bool {
 		if !ok || len(av) != len(bv) {
 			return false
 		}
+		if isPayloadContentArray(av) && isPayloadContentArray(bv) {
+			return payloadContentArraysEqual(av, bv)
+		}
 		for i := range av {
 			if !LenientEqualPlist(av[i], bv[i]) {
 				return false
@@ -366,6 +369,74 @@ func LenientEqualPlist(a, b any) bool {
 	default:
 		return a == b
 	}
+}
+
+// isPayloadContentArray reports whether every element is a dict carrying a
+// non-empty PayloadType — the shape of a profile's top-level PayloadContent
+// array. Ordinary ordered arrays (SSIDMatch, OnDemandRules, …) never match
+// this shape, so they keep the strict positional compare below.
+func isPayloadContentArray(arr []any) bool {
+	if len(arr) == 0 {
+		return false
+	}
+	for _, item := range arr {
+		m, ok := item.(map[string]any)
+		if !ok {
+			return false
+		}
+		if pt, _ := m["PayloadType"].(string); pt == "" {
+			return false
+		}
+	}
+	return true
+}
+
+// payloadContentArraysEqual compares two PayloadContent arrays tolerating
+// reorder *between* PayloadType groups while still comparing strictly
+// *within* each group. Jamf Pro is free to move an entire entry elsewhere in
+// the array on store (wire-observed: a profile mixing an MCX
+// "Application & Custom Settings" entry with a Certificate entry comes back
+// with the certificate moved ahead of MCX) — a positional compare would pair
+// unrelated entries and report cascading false drift.
+//
+// PayloadIdentifier can't be used to pair same-type entries because it's in
+// maskedPayloadContentKeys (the server may assign it) and is already gone
+// from both trees by the time this runs. Instead, entries are grouped by
+// PayloadType and matched positionally *within* each group — Jamf Pro has
+// never been observed to reorder same-type siblings relative to each other
+// (e.g. six MCX "Application & Custom Settings" entries for six different
+// browsers keep their authored order), only to relocate an entire type
+// elsewhere among its differently-typed siblings.
+func payloadContentArraysEqual(av, bv []any) bool {
+	byTypeA := groupByPayloadType(av)
+	byTypeB := groupByPayloadType(bv)
+	if len(byTypeA) != len(byTypeB) {
+		return false
+	}
+	for pt, groupA := range byTypeA {
+		groupB, ok := byTypeB[pt]
+		if !ok || len(groupA) != len(groupB) {
+			return false
+		}
+		for i := range groupA {
+			if !LenientEqualPlist(groupA[i], groupB[i]) {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+// groupByPayloadType buckets PayloadContent entries by their PayloadType,
+// preserving each bucket's original relative order.
+func groupByPayloadType(arr []any) map[string][]map[string]any {
+	groups := make(map[string][]map[string]any)
+	for _, item := range arr {
+		m := item.(map[string]any) // isPayloadContentArray already checked
+		pt, _ := m["PayloadType"].(string)
+		groups[pt] = append(groups[pt], m)
+	}
+	return groups
 }
 
 // InjectTopLevelIdentifierValues overwrites the top-level PayloadUUID and

--- a/internal/common/payloadhelpers/helpers.go
+++ b/internal/common/payloadhelpers/helpers.go
@@ -12,6 +12,7 @@ import (
 	"encoding/base64"
 	"fmt"
 	"html"
+	"slices"
 	"strings"
 
 	"howett.net/plist"
@@ -152,7 +153,52 @@ func maskPayloadContent(items []any) []any {
 		}
 		out = append(out, masked)
 	}
-	return out
+	return canonicalisePayloadContentOrder(out)
+}
+
+// canonicalisePayloadContentOrder stable-sorts a top-level PayloadContent array
+// by PayloadType so two payloads that differ only in entry order compare equal
+// under the positional array walk in LenientEqualPlist and structuralEqual.
+//
+// Jamf Pro does not store the array as submitted: it stably partitions the
+// entries into the ones it stores verbatim followed by the ones it re-renders
+// (see the storage-category table in importgate.go), keeping relative order
+// within each block. Wire-probed 2026-08-11 against Jamf Pro 11.30.x over 18
+// profile shapes: an authored [MCX, certificate] comes back as
+// [certificate, MCX], while [loginwindow, certificate] — both verbatim slots —
+// comes back untouched. A positional compare therefore pairs unrelated entries
+// and reports cascading false drift on every key of both, which surfaced as a
+// bogus "Jamf Pro cannot store this payload faithfully" error and a create-time
+// rollback for a payload the server had stored perfectly.
+//
+// Sorting rather than special-casing the compare is safe because entry order in
+// PayloadContent carries no meaning: Apple treats each entry as an independent
+// payload, so an order-insensitive comparison is the correct one, not a
+// tolerance. The sort is *stable* and keyed only on PayloadType, so two entries
+// of the same type keep their authored order relative to each other and a real
+// change between same-type siblings still surfaces as drift. That is exactly the
+// granularity the wire law needs — same PayloadType implies the same partition,
+// so Jamf Pro cannot reorder same-type siblings.
+//
+// PayloadIdentifier would be the natural pairing key but it is in
+// maskedPayloadContentKeys (the server may assign it) and is already gone from
+// the masked tree by the time this runs.
+func canonicalisePayloadContentOrder(entries []any) []any {
+	slices.SortStableFunc(entries, func(a, b any) int {
+		return strings.Compare(payloadTypeOf(a), payloadTypeOf(b))
+	})
+	return entries
+}
+
+// payloadTypeOf returns a PayloadContent entry's PayloadType, or "" when the
+// entry is not a dict or carries no type.
+func payloadTypeOf(v any) string {
+	m, ok := v.(map[string]any)
+	if !ok {
+		return ""
+	}
+	pt, _ := m["PayloadType"].(string)
+	return pt
 }
 
 // isEmpty reports whether a plist value is equivalent to "user did not
@@ -282,8 +328,11 @@ func PayloadsSemanticallyEqual(a, b []byte) (bool, error) {
 
 // LenientEqualPlist compares two parsed-and-masked plist trees with
 // intersection semantics: dict keys present on only one side are ignored;
-// shared keys must compare equal. Arrays compare positionally. Scalars
-// compare via plisthelpers.NumericEqual for ints (howett.net/plist returns int64 or
+// shared keys must compare equal. Arrays compare positionally — the top-level
+// PayloadContent array, the one array Jamf Pro reorders on store, is put into a
+// canonical order by MaskPayload before it gets here (see
+// canonicalisePayloadContentOrder). Scalars compare via
+// plisthelpers.NumericEqual for ints (howett.net/plist returns int64 or
 // uint64 depending on sign).
 //
 // Exception: PayloadContent[i] entries whose PayloadType is in
@@ -345,9 +394,6 @@ func LenientEqualPlist(a, b any) bool {
 		if !ok || len(av) != len(bv) {
 			return false
 		}
-		if isPayloadContentArray(av) && isPayloadContentArray(bv) {
-			return payloadContentArraysEqual(av, bv)
-		}
 		for i := range av {
 			if !LenientEqualPlist(av[i], bv[i]) {
 				return false
@@ -369,74 +415,6 @@ func LenientEqualPlist(a, b any) bool {
 	default:
 		return a == b
 	}
-}
-
-// isPayloadContentArray reports whether every element is a dict carrying a
-// non-empty PayloadType — the shape of a profile's top-level PayloadContent
-// array. Ordinary ordered arrays (SSIDMatch, OnDemandRules, …) never match
-// this shape, so they keep the strict positional compare below.
-func isPayloadContentArray(arr []any) bool {
-	if len(arr) == 0 {
-		return false
-	}
-	for _, item := range arr {
-		m, ok := item.(map[string]any)
-		if !ok {
-			return false
-		}
-		if pt, _ := m["PayloadType"].(string); pt == "" {
-			return false
-		}
-	}
-	return true
-}
-
-// payloadContentArraysEqual compares two PayloadContent arrays tolerating
-// reorder *between* PayloadType groups while still comparing strictly
-// *within* each group. Jamf Pro is free to move an entire entry elsewhere in
-// the array on store (wire-observed: a profile mixing an MCX
-// "Application & Custom Settings" entry with a Certificate entry comes back
-// with the certificate moved ahead of MCX) — a positional compare would pair
-// unrelated entries and report cascading false drift.
-//
-// PayloadIdentifier can't be used to pair same-type entries because it's in
-// maskedPayloadContentKeys (the server may assign it) and is already gone
-// from both trees by the time this runs. Instead, entries are grouped by
-// PayloadType and matched positionally *within* each group — Jamf Pro has
-// never been observed to reorder same-type siblings relative to each other
-// (e.g. six MCX "Application & Custom Settings" entries for six different
-// browsers keep their authored order), only to relocate an entire type
-// elsewhere among its differently-typed siblings.
-func payloadContentArraysEqual(av, bv []any) bool {
-	byTypeA := groupByPayloadType(av)
-	byTypeB := groupByPayloadType(bv)
-	if len(byTypeA) != len(byTypeB) {
-		return false
-	}
-	for pt, groupA := range byTypeA {
-		groupB, ok := byTypeB[pt]
-		if !ok || len(groupA) != len(groupB) {
-			return false
-		}
-		for i := range groupA {
-			if !LenientEqualPlist(groupA[i], groupB[i]) {
-				return false
-			}
-		}
-	}
-	return true
-}
-
-// groupByPayloadType buckets PayloadContent entries by their PayloadType,
-// preserving each bucket's original relative order.
-func groupByPayloadType(arr []any) map[string][]map[string]any {
-	groups := make(map[string][]map[string]any)
-	for _, item := range arr {
-		m := item.(map[string]any) // isPayloadContentArray already checked
-		pt, _ := m["PayloadType"].(string)
-		groups[pt] = append(groups[pt], m)
-	}
-	return groups
 }
 
 // InjectTopLevelIdentifierValues overwrites the top-level PayloadUUID and

--- a/internal/common/payloadhelpers/helpers_test.go
+++ b/internal/common/payloadhelpers/helpers_test.go
@@ -5,6 +5,8 @@ package payloadhelpers
 
 import (
 	"bytes"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -809,3 +811,162 @@ func TestNormalizeLineEndings(t *testing.T) {
 		})
 	}
 }
+
+// payloadContentTypeOrder returns the PayloadType of each top-level
+// PayloadContent entry, in document order.
+func payloadContentTypeOrder(t *testing.T, raw []byte) []string {
+	t.Helper()
+	tree, _, err := plisthelpers.ParsePlist(raw)
+	if err != nil {
+		t.Fatalf("parsing payload: %v", err)
+	}
+	arr, ok := tree["PayloadContent"].([]any)
+	if !ok {
+		t.Fatal("payload has no PayloadContent array")
+	}
+	out := make([]string, 0, len(arr))
+	for _, entry := range arr {
+		out = append(out, payloadTypeOf(entry))
+	}
+	return out
+}
+
+// TestPayloadsSemanticallyEqual_RecordedReorderedResponse_Equal is the
+// wire-backed twin of the two hand-written reorder tests above: real authored
+// bytes and the real response a live Jamf Pro returned for them, so it guards
+// the actual server behaviour rather than our model of it.
+//
+// The fixture mixes an MCX "Application & Custom Settings" entry with a
+// certificate entry — a certificate is stored verbatim while MCX is re-rendered,
+// which is the condition that makes Jamf Pro reorder the array. Before the
+// canonical ordering in maskPayloadContent this pair reported drift on every key
+// of both entries, rolled back the freshly created profile, and told the operator
+// Jamf Pro could not store a payload it had in fact stored perfectly.
+func TestPayloadsSemanticallyEqual_RecordedReorderedResponse_Equal(t *testing.T) {
+	const (
+		fixtures = "../../resources/pro/macos_configuration_profile/testdata"
+		stem     = "GoogleChrome__mcx_with_certificate_profile"
+	)
+	authored, err := os.ReadFile(filepath.Join(fixtures, stem+".mobileconfig"))
+	if err != nil {
+		t.Fatalf("reading authored fixture: %v", err)
+	}
+	resp, err := os.ReadFile(filepath.Join(fixtures, stem+".create_response.xml"))
+	if err != nil {
+		t.Fatalf("reading recorded response: %v", err)
+	}
+	stored, err := ExtractServerPayloadFromGeneral(resp)
+	if err != nil {
+		t.Fatalf("extracting payload from recorded response: %v", err)
+	}
+
+	// Guard the guard: if this tenant ever stops reordering, the assertions below
+	// would pass for the wrong reason and quietly stop covering anything.
+	authoredOrder := payloadContentTypeOrder(t, authored)
+	storedOrder := payloadContentTypeOrder(t, stored)
+	if strings.Join(authoredOrder, ",") == strings.Join(storedOrder, ",") {
+		t.Fatalf("fixture no longer exhibits the reorder it exists to cover: %v", storedOrder)
+	}
+
+	eq, err := PayloadsSemanticallyEqual(authored, stored)
+	if err != nil {
+		t.Fatalf("compare: %v", err)
+	}
+	if !eq {
+		t.Errorf("recorded response reordered %v to %v and this must not read as drift", authoredOrder, storedOrder)
+	}
+
+	// The diagnostic path has to agree with the equality gate, or a profile that
+	// compares equal would still produce a findings list if anything else failed.
+	findings, ok := diffPayloadStrings(authored, stored)
+	if !ok {
+		t.Fatal("fixture pair did not parse for the fidelity diff")
+	}
+	if len(findings) != 0 {
+		for _, f := range findings {
+			t.Logf("unexpected finding: %s (present=%v) authored=%q stored=%q", f.path, f.present, f.authored, f.stored)
+		}
+		t.Errorf("recorded response stored every value faithfully, got %d fidelity finding(s)", len(findings))
+	}
+}
+
+// TestPayloadsSemanticallyEqual_SameTypeSiblingDrift_NotEqual pins the limit of
+// the canonical ordering: the sort is keyed only on PayloadType and is stable, so
+// two entries of the same type keep their authored positions relative to each
+// other and an edit to one of them is still drift. A non-stable sort, or one that
+// also ordered by content, would silently swallow this.
+func TestPayloadsSemanticallyEqual_SameTypeSiblingDrift_NotEqual(t *testing.T) {
+	eq, err := PayloadsSemanticallyEqual([]byte(twoMCXSiblings), []byte(twoMCXSiblingsSecondEdited))
+	if err != nil {
+		t.Fatalf("compare: %v", err)
+	}
+	if eq {
+		t.Fatal("an edit inside the second of two same-type siblings must surface as drift")
+	}
+}
+
+const twoMCXSiblings = `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0"><dict>
+<key>PayloadType</key><string>Configuration</string>
+<key>PayloadVersion</key><integer>1</integer>
+<key>PayloadIdentifier</key><string>top-id</string>
+<key>PayloadUUID</key><string>top-uuid</string>
+<key>PayloadContent</key><array>
+<dict>
+<key>PayloadType</key><string>com.apple.ManagedClient.preferences</string>
+<key>PayloadVersion</key><integer>1</integer>
+<key>PayloadContent</key><dict>
+<key>com.example.first</key><dict>
+<key>Forced</key><array><dict>
+<key>mcx_preference_settings</key><dict><key>Flag</key><true/></dict>
+</dict></array>
+</dict>
+</dict>
+</dict>
+<dict>
+<key>PayloadType</key><string>com.apple.ManagedClient.preferences</string>
+<key>PayloadVersion</key><integer>1</integer>
+<key>PayloadContent</key><dict>
+<key>com.example.second</key><dict>
+<key>Forced</key><array><dict>
+<key>mcx_preference_settings</key><dict><key>Flag</key><true/></dict>
+</dict></array>
+</dict>
+</dict>
+</dict>
+</array>
+</dict></plist>`
+
+const twoMCXSiblingsSecondEdited = `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0"><dict>
+<key>PayloadType</key><string>Configuration</string>
+<key>PayloadVersion</key><integer>1</integer>
+<key>PayloadIdentifier</key><string>top-id</string>
+<key>PayloadUUID</key><string>top-uuid</string>
+<key>PayloadContent</key><array>
+<dict>
+<key>PayloadType</key><string>com.apple.ManagedClient.preferences</string>
+<key>PayloadVersion</key><integer>1</integer>
+<key>PayloadContent</key><dict>
+<key>com.example.first</key><dict>
+<key>Forced</key><array><dict>
+<key>mcx_preference_settings</key><dict><key>Flag</key><true/></dict>
+</dict></array>
+</dict>
+</dict>
+</dict>
+<dict>
+<key>PayloadType</key><string>com.apple.ManagedClient.preferences</string>
+<key>PayloadVersion</key><integer>1</integer>
+<key>PayloadContent</key><dict>
+<key>com.example.second</key><dict>
+<key>Forced</key><array><dict>
+<key>mcx_preference_settings</key><dict><key>Flag</key><false/></dict>
+</dict></array>
+</dict>
+</dict>
+</dict>
+</array>
+</dict></plist>`

--- a/internal/common/payloadhelpers/helpers_test.go
+++ b/internal/common/payloadhelpers/helpers_test.go
@@ -343,6 +343,138 @@ const mcxChangedInnerValue = `<?xml version="1.0" encoding="UTF-8"?>
 </dict></array>
 </dict></plist>`
 
+// PayloadContent reorder fixtures: wire-observed 2026-08-11 against a live
+// Jamf Pro 11.30.x tenant, a profile mixing an MCX "Application & Custom
+// Settings" entry with a Certificate entry comes back with the certificate
+// moved ahead of MCX. A positional array compare pairs the wrong entries
+// (MCX vs certificate) and reports cascading false drift across every key —
+// this is the root cause of the original "Jamf Pro cannot store this payload
+// faithfully" false positive.
+const mcxThenCert = `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0"><dict>
+<key>PayloadType</key><string>Configuration</string>
+<key>PayloadVersion</key><integer>1</integer>
+<key>PayloadIdentifier</key><string>top-id</string>
+<key>PayloadUUID</key><string>top-uuid</string>
+<key>PayloadContent</key><array>
+<dict>
+<key>PayloadType</key><string>com.apple.ManagedClient.preferences</string>
+<key>PayloadVersion</key><integer>1</integer>
+<key>PayloadIdentifier</key><string>mcx-id</string>
+<key>PayloadUUID</key><string>mcx-uuid</string>
+<key>PayloadContent</key><dict>
+<key>com.example.app</key><dict>
+<key>Forced</key><array><dict>
+<key>mcx_preference_settings</key><dict>
+<key>FeatureEnabled</key><true/>
+<key>BannerMessage</key><string>hello</string>
+</dict>
+</dict></array>
+</dict>
+</dict>
+</dict>
+<dict>
+<key>PayloadType</key><string>com.apple.security.root</string>
+<key>PayloadVersion</key><integer>1</integer>
+<key>PayloadIdentifier</key><string>cert-id</string>
+<key>PayloadUUID</key><string>cert-uuid</string>
+<key>PayloadCertificateFileName</key><string>Test.crt</string>
+<key>PayloadContent</key><data>AAAA</data>
+</dict>
+</array>
+</dict></plist>`
+
+const certThenMCXSameContent = `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0"><dict>
+<key>PayloadType</key><string>Configuration</string>
+<key>PayloadVersion</key><integer>1</integer>
+<key>PayloadIdentifier</key><string>top-id</string>
+<key>PayloadUUID</key><string>top-uuid</string>
+<key>PayloadContent</key><array>
+<dict>
+<key>PayloadType</key><string>com.apple.security.root</string>
+<key>PayloadVersion</key><integer>1</integer>
+<key>PayloadIdentifier</key><string>cert-id</string>
+<key>PayloadUUID</key><string>cert-uuid</string>
+<key>PayloadCertificateFileName</key><string>Test.crt</string>
+<key>PayloadContent</key><data>AAAA</data>
+</dict>
+<dict>
+<key>PayloadType</key><string>com.apple.ManagedClient.preferences</string>
+<key>PayloadVersion</key><integer>1</integer>
+<key>PayloadIdentifier</key><string>mcx-id</string>
+<key>PayloadUUID</key><string>mcx-uuid</string>
+<key>PayloadContent</key><dict>
+<key>com.example.app</key><dict>
+<key>Forced</key><array><dict>
+<key>mcx_preference_settings</key><dict>
+<key>FeatureEnabled</key><true/>
+<key>BannerMessage</key><string>hello</string>
+</dict>
+</dict></array>
+</dict>
+</dict>
+</dict>
+</array>
+</dict></plist>`
+
+const certThenMCXChangedInnerValue = `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0"><dict>
+<key>PayloadType</key><string>Configuration</string>
+<key>PayloadVersion</key><integer>1</integer>
+<key>PayloadIdentifier</key><string>top-id</string>
+<key>PayloadUUID</key><string>top-uuid</string>
+<key>PayloadContent</key><array>
+<dict>
+<key>PayloadType</key><string>com.apple.security.root</string>
+<key>PayloadVersion</key><integer>1</integer>
+<key>PayloadIdentifier</key><string>cert-id</string>
+<key>PayloadUUID</key><string>cert-uuid</string>
+<key>PayloadCertificateFileName</key><string>Test.crt</string>
+<key>PayloadContent</key><data>AAAA</data>
+</dict>
+<dict>
+<key>PayloadType</key><string>com.apple.ManagedClient.preferences</string>
+<key>PayloadVersion</key><integer>1</integer>
+<key>PayloadIdentifier</key><string>mcx-id</string>
+<key>PayloadUUID</key><string>mcx-uuid</string>
+<key>PayloadContent</key><dict>
+<key>com.example.app</key><dict>
+<key>Forced</key><array><dict>
+<key>mcx_preference_settings</key><dict>
+<key>FeatureEnabled</key><false/>
+<key>BannerMessage</key><string>hello</string>
+</dict>
+</dict></array>
+</dict>
+</dict>
+</dict>
+</array>
+</dict></plist>`
+
+func TestPayloadsSemanticallyEqual_PayloadContentReordered_Equal(t *testing.T) {
+	eq, err := PayloadsSemanticallyEqual([]byte(mcxThenCert), []byte(certThenMCXSameContent))
+	if err != nil {
+		t.Fatalf("compare: %v", err)
+	}
+	if !eq {
+		t.Fatal("Jamf Pro reordering PayloadContent entries on store must not report drift")
+	}
+}
+
+func TestPayloadsSemanticallyEqual_PayloadContentReorderedWithRealDrift_NotEqual(t *testing.T) {
+	eq, err := PayloadsSemanticallyEqual([]byte(mcxThenCert), []byte(certThenMCXChangedInnerValue))
+	if err != nil {
+		t.Fatalf("compare: %v", err)
+	}
+	if eq {
+		t.Fatal("a real change inside the reordered MCX entry must still be reported as drift")
+	}
+}
+
 func TestPayloadsSemanticallyEqual_MCXIdentical_Equal(t *testing.T) {
 	eq, err := PayloadsSemanticallyEqual([]byte(mcxBaseline), []byte(mcxBaseline))
 	if err != nil {

--- a/internal/common/payloadhelpers/payload_content_order_probe_test.go
+++ b/internal/common/payloadhelpers/payload_content_order_probe_test.go
@@ -1,0 +1,384 @@
+// Copyright Jamf Software LLC 2026
+// SPDX-License-Identifier: MPL-2.0
+
+//go:build payload_probe
+
+// Wire-probe harness for the PayloadContent ordering law behind
+// canonicalisePayloadContentOrder, and for the drift detection that ordering
+// must not weaken. Not part of any normal build — it creates, updates and
+// deletes real profiles on a live tenant.
+//
+//	JAMFPLATFORM_BASE_URL=... JAMFPLATFORM_CLIENT_ID=... \
+//	JAMFPLATFORM_CLIENT_SECRET=... JAMFPLATFORM_TENANT_ID=... \
+//	go test -tags payload_probe ./internal/common/payloadhelpers/ -run TestProbePayloadContent -v
+//
+// TestProbePayloadContentOrder asserts the law itself: Jamf Pro stably partitions
+// the top-level PayloadContent array into the entries it stores verbatim followed
+// by the entries it re-renders, preserving relative order within each block. The
+// expected order is derived from faithfulPayloadTypes, so if the two ever
+// disagree this probe says which entry moved where.
+//
+// TestProbePayloadContentOrderDoesNotHideDrift is the other half: it applies the
+// admin-UI edits an operator can make to a stored profile and asserts each one is
+// still caught, by the plan-time gate (PayloadsSemanticallyEqual) or the
+// Read-side drift detector (PayloadsStructurallyEqual) or both. A canonical
+// ordering is only safe if the sole thing it hides is a pure permutation.
+package payloadhelpers
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Jamf-Concepts/jamfplatform-go-sdk/jamfplatform/proclassic"
+
+	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/common/plisthelpers"
+)
+
+// orderRoundTrip creates a profile, reads it back, and registers its deletion.
+// Unlike roundTripProbe in storage_category_probe_test.go it hands the ID back,
+// because the drift probe below has to update the profile before it is removed.
+func orderRoundTrip(t *testing.T, ctx context.Context, c *proclassic.Client, name string, authored []byte) (stored []byte, id string) {
+	t.Helper()
+	prepared, err := PrepareWirePayload(authored, "", "")
+	if err != nil {
+		t.Fatalf("prepare: %v", err)
+	}
+	pl := proclassic.PayloadsXMLText(prepared)
+	level := "System"
+	created, err := c.CreateOSXConfigurationProfileByID(ctx, "0",
+		&proclassic.OsXConfigurationProfile{General: &proclassic.OsXConfigurationProfileGeneral{
+			Name: &name, Payloads: &pl, Level: &level}})
+	if err != nil {
+		t.Fatalf("create %s: %v", name, err)
+	}
+	id = probeID(created.ID, func() *int {
+		if created.General != nil {
+			return created.General.ID
+		}
+		return nil
+	}())
+	if id == "" {
+		t.Fatal("create returned no id")
+	}
+	t.Cleanup(func() {
+		if err := c.DeleteOSXConfigurationProfileByID(ctx, id); err != nil {
+			t.Errorf("probe profile %s left behind: %v", id, err)
+		}
+	})
+	got, err := c.GetOSXConfigurationProfileByID(ctx, id)
+	if err != nil || got == nil || got.General == nil || got.General.Payloads == nil {
+		t.Fatalf("read back %s: %v", id, err)
+	}
+	return []byte(string(*got.General.Payloads)), id
+}
+
+// orderEntry is one PayloadContent entry: a payload type plus a marker that
+// makes two entries of the same type distinguishable in the probe output.
+type orderEntry struct {
+	ptype string
+	mark  string
+}
+
+func (e orderEntry) label() string {
+	return e.ptype[strings.LastIndexByte(e.ptype, '.')+1:] + "/" + e.mark
+}
+
+// xml renders a body the server actually keeps. A payload with no content keys
+// is silently discarded on store, which would make every assertion below vacuous.
+func (e orderEntry) xml() string {
+	switch e.ptype {
+	case "com.apple.ManagedClient.preferences":
+		return fmt.Sprintf(`<dict>
+<key>PayloadType</key><string>%s</string><key>PayloadVersion</key><integer>1</integer>
+<key>PayloadIdentifier</key><string>com.zz.order.%s</string>
+<key>PayloadUUID</key><string>ZZORDER-%s</string>
+<key>PayloadContent</key><dict><key>com.zz.probe.%s</key><dict><key>Forced</key><array>
+<dict><key>mcx_preference_settings</key><dict><key>ZZmark</key><string>%s</string></dict></dict>
+</array></dict></dict></dict>`, e.ptype, e.mark, e.mark, e.mark, e.mark)
+	case "com.apple.security.root":
+		return fmt.Sprintf(`<dict>
+<key>PayloadType</key><string>%s</string><key>PayloadVersion</key><integer>1</integer>
+<key>PayloadIdentifier</key><string>com.zz.order.%s</string>
+<key>PayloadUUID</key><string>ZZORDER-%s</string>
+<key>PayloadCertificateFileName</key><string>%s.cer</string>
+<key>PayloadContent</key><data>
+MIIBCgKCAQEAxGF3lQ0m6zvbNQ0dQKe9nJ6l0J1yQ4nFq0dYh2s5cWJ9Yz8mQ2pL
+</data></dict>`, e.ptype, e.mark, e.mark, e.mark)
+	case "com.apple.notificationsettings":
+		return fmt.Sprintf(`<dict>
+<key>PayloadType</key><string>%s</string><key>PayloadVersion</key><integer>1</integer>
+<key>PayloadIdentifier</key><string>com.zz.order.%s</string>
+<key>PayloadUUID</key><string>ZZORDER-%s</string>
+<key>NotificationSettings</key><array><dict>
+<key>AlertType</key><integer>1</integer>
+<key>BundleIdentifier</key><string>com.zz.probe.%s</string>
+<key>NotificationsEnabled</key><true/>
+</dict></array></dict>`, e.ptype, e.mark, e.mark, e.mark)
+	case "com.apple.loginwindow":
+		return fmt.Sprintf(`<dict>
+<key>PayloadType</key><string>%s</string><key>PayloadVersion</key><integer>1</integer>
+<key>PayloadIdentifier</key><string>com.zz.order.%s</string>
+<key>PayloadUUID</key><string>ZZORDER-%s</string>
+<key>LoginwindowText</key><string>%s</string></dict>`, e.ptype, e.mark, e.mark, e.mark)
+	default:
+		panic("orderEntry: no probe body for " + e.ptype)
+	}
+}
+
+func orderProfile(name string, entries ...orderEntry) []byte {
+	var b strings.Builder
+	fmt.Fprintf(&b, `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0"><dict>
+<key>PayloadType</key><string>Configuration</string><key>PayloadVersion</key><integer>1</integer>
+<key>PayloadScope</key><string>System</string>
+<key>PayloadDisplayName</key><string>%s</string>
+<key>PayloadIdentifier</key><string>com.zz.order.top</string>
+<key>PayloadUUID</key><string>ZZORDER-TOP</string>
+<key>PayloadContent</key><array>
+`, name)
+	for _, e := range entries {
+		b.WriteString(e.xml())
+		b.WriteString("\n")
+	}
+	b.WriteString("</array>\n</dict></plist>")
+	return []byte(b.String())
+}
+
+// expectedStoredOrder is the wire law as code: a stable partition putting the
+// verbatim-stored entries first, then the re-rendered ones.
+func expectedStoredOrder(platform ProfilePlatform, entries []orderEntry) []string {
+	var verbatim, rerendered []string
+	for _, e := range entries {
+		if isFaithfulPayloadType(platform, e.ptype) {
+			rerendered = append(rerendered, e.label())
+		} else {
+			verbatim = append(verbatim, e.label())
+		}
+	}
+	return append(verbatim, rerendered...)
+}
+
+// storedOrder labels each stored entry the same way, pairing it back to the
+// authored entry by the marker the body carries.
+func storedOrder(t *testing.T, raw []byte) []string {
+	t.Helper()
+	tree, _, err := plisthelpers.ParsePlist(raw)
+	if err != nil {
+		t.Fatalf("parsing stored payload: %v", err)
+	}
+	arr, _ := tree["PayloadContent"].([]any)
+	out := make([]string, 0, len(arr))
+	for _, item := range arr {
+		m, ok := item.(map[string]any)
+		if !ok {
+			out = append(out, "?/non-dict")
+			continue
+		}
+		pt := payloadTypeOf(item)
+		short := pt[strings.LastIndexByte(pt, '.')+1:]
+		out = append(out, short+"/"+storedMarker(m))
+	}
+	return out
+}
+
+// storedMarker digs the probe marker back out of whichever slot the payload type
+// keeps it in.
+func storedMarker(m map[string]any) string {
+	if s, ok := m["PayloadCertificateFileName"].(string); ok {
+		return strings.TrimSuffix(s, ".cer")
+	}
+	if s, ok := m["LoginwindowText"].(string); ok {
+		return s
+	}
+	if arr, ok := m["NotificationSettings"].([]any); ok && len(arr) > 0 {
+		if d, ok := arr[0].(map[string]any); ok {
+			if s, ok := d["BundleIdentifier"].(string); ok {
+				return strings.TrimPrefix(s, "com.zz.probe.")
+			}
+		}
+	}
+	if inner, ok := m["PayloadContent"].(map[string]any); ok {
+		for k := range inner {
+			return strings.TrimPrefix(k, "com.zz.probe.")
+		}
+	}
+	return "?"
+}
+
+func TestProbePayloadContentOrder(t *testing.T) {
+	pc := probeClient(t)
+	ctx := context.Background()
+
+	mcxA := orderEntry{"com.apple.ManagedClient.preferences", "mcxa"}
+	mcxB := orderEntry{"com.apple.ManagedClient.preferences", "mcxb"}
+	mcxC := orderEntry{"com.apple.ManagedClient.preferences", "mcxc"}
+	certA := orderEntry{"com.apple.security.root", "certa"}
+	certB := orderEntry{"com.apple.security.root", "certb"}
+	notif := orderEntry{"com.apple.notificationsettings", "notif"}
+	login := orderEntry{"com.apple.loginwindow", "login"}
+
+	shapes := []struct {
+		name    string
+		entries []orderEntry
+	}{
+		{"mcx_then_cert", []orderEntry{mcxA, certA}},
+		{"cert_then_mcx_already_canonical", []orderEntry{certA, mcxA}},
+		{"notif_then_cert", []orderEntry{notif, certA}},
+		{"both_verbatim_untouched", []orderEntry{login, certA}},
+		{"both_rerendered_untouched", []orderEntry{notif, mcxA}},
+		{"mcx_login_cert", []orderEntry{mcxA, login, certA}},
+		{"same_type_siblings_untouched", []orderEntry{mcxA, mcxB, mcxC}},
+		{"interleaved_two_of_each", []orderEntry{mcxA, certA, mcxB, certB, mcxC}},
+		{"two_verbatim_two_rerendered", []orderEntry{certA, notif, login, mcxA}},
+	}
+
+	suffix := strconv.FormatInt(time.Now().Unix(), 10)
+	for _, s := range shapes {
+		t.Run(s.name, func(t *testing.T) {
+			name := "zz-order-probe-" + s.name + "-" + suffix
+			authored := orderProfile(name, s.entries...)
+			stored, _ := orderRoundTrip(t, ctx, pc, name, authored)
+
+			want := expectedStoredOrder(PlatformMacOS, s.entries)
+			got := storedOrder(t, stored)
+			var authoredLabels []string
+			for _, e := range s.entries {
+				authoredLabels = append(authoredLabels, e.label())
+			}
+			t.Logf("authored %v", authoredLabels)
+			t.Logf("stored   %v", got)
+			if strings.Join(got, ",") != strings.Join(want, ",") {
+				t.Errorf("stored order does not match the verbatim-then-re-rendered partition\n  want %v\n  got  %v\n"+
+					"faithfulPayloadTypes and the server disagree — re-probe the storage categories before trusting the compare",
+					want, got)
+			}
+
+			// Whatever the server did with the order, the compare must be quiet:
+			// nothing about these payloads changed.
+			eq, err := PayloadsSemanticallyEqual(authored, stored)
+			if err != nil {
+				t.Fatalf("compare: %v", err)
+			}
+			if !eq {
+				t.Errorf("reorder alone must not read as drift")
+			}
+			if findings, ok := diffPayloadStrings(authored, stored); ok && len(findings) > 0 {
+				for _, f := range findings {
+					t.Logf("unexpected finding: %s (present=%v)", f.path, f.present)
+				}
+				t.Errorf("reorder alone must not produce fidelity findings, got %d", len(findings))
+			}
+		})
+	}
+}
+
+// TestProbePayloadContentOrderDoesNotHideDrift applies each admin-UI edit an
+// operator can make to a stored profile and asserts it is still detected. Pure
+// permutation is the one case that must NOT be reported: entry order carries no
+// meaning to Apple, and the server produces it unprompted on every write.
+func TestProbePayloadContentOrderDoesNotHideDrift(t *testing.T) {
+	pc := probeClient(t)
+	ctx := context.Background()
+
+	mcxA := orderEntry{"com.apple.ManagedClient.preferences", "mcxa"}
+	mcxB := orderEntry{"com.apple.ManagedClient.preferences", "mcxb"}
+	certA := orderEntry{"com.apple.security.root", "certa"}
+	notif := orderEntry{"com.apple.notificationsettings", "notif"}
+
+	base := []orderEntry{mcxA, certA}
+
+	cases := []struct {
+		name       string
+		edited     []orderEntry
+		mutate     func(string) string
+		wantDetect bool
+	}{
+		{name: "value changed inside a re-rendered payload", edited: base,
+			mutate: func(s string) string {
+				return strings.Replace(s, "<string>mcxa</string>", "<string>EDITED</string>", 1)
+			},
+			wantDetect: true},
+		{name: "key added inside a re-rendered payload", edited: base,
+			mutate: func(s string) string {
+				return strings.Replace(s, "<key>ZZmark</key>", "<key>ZZextra</key><string>added</string><key>ZZmark</key>", 1)
+			},
+			wantDetect: true},
+		{name: "key removed inside a re-rendered payload", edited: base,
+			mutate: func(s string) string {
+				return strings.Replace(s, "<key>ZZmark</key><string>mcxa</string>", "<key>ZZother</key><string>mcxa</string>", 1)
+			},
+			wantDetect: true},
+		{name: "value changed inside a verbatim payload", edited: base,
+			mutate:     func(s string) string { return strings.Replace(s, "certa.cer", "swapped.cer", 1) },
+			wantDetect: true},
+		{name: "payload added", edited: []orderEntry{mcxA, certA, notif}, wantDetect: true},
+		{name: "payload removed", edited: []orderEntry{mcxA}, wantDetect: true},
+		{name: "payload swapped, count unchanged", edited: []orderEntry{mcxA, notif}, wantDetect: true},
+		{name: "second of two same-type siblings edited",
+			edited: []orderEntry{mcxA, mcxB},
+			mutate: func(s string) string {
+				return strings.Replace(s, "<string>mcxb</string>", "<string>EDITED</string>", 1)
+			},
+			wantDetect: true},
+		{name: "pure permutation, nothing else changed", edited: []orderEntry{certA, mcxA}, wantDetect: false},
+	}
+
+	suffix := strconv.FormatInt(time.Now().Unix(), 10)
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			name := "zz-drift-probe-" + strconv.Itoa(len(tc.name)) + "-" + suffix
+			authoredEntries := base
+			if tc.mutate != nil {
+				authoredEntries = tc.edited
+			}
+			authored := orderProfile(name, authoredEntries...)
+
+			// Apply: the profile Terraform created, and the server form it saw back.
+			atApply, id := orderRoundTrip(t, ctx, pc, name, authored)
+
+			// Admin edit, via the same API a UI save goes through.
+			edited := string(orderProfile(name, tc.edited...))
+			if tc.mutate != nil {
+				edited = tc.mutate(edited)
+			}
+			if edited == string(authored) {
+				t.Fatal("edit was a no-op — the probe body moved and this case covers nothing")
+			}
+			wire, err := PrepareWirePayload([]byte(edited), "", "")
+			if err != nil {
+				t.Fatal(err)
+			}
+			pxt := proclassic.PayloadsXMLText(wire)
+			if err := pc.UpdateOSXConfigurationProfileByID(ctx, id, &proclassic.OsXConfigurationProfile{
+				General: &proclassic.OsXConfigurationProfileGeneral{Payloads: &pxt},
+			}); err != nil {
+				t.Fatalf("update: %v", err)
+			}
+			got, err := pc.GetOSXConfigurationProfileByID(ctx, id)
+			if err != nil {
+				t.Fatalf("read back: %v", err)
+			}
+			serverNow := []byte(string(*got.General.Payloads))
+
+			planEq, err := PayloadsSemanticallyEqual(authored, serverNow)
+			if err != nil {
+				t.Fatalf("plan-gate compare: %v", err)
+			}
+			readEq, err := PayloadsStructurallyEqual(atApply, serverNow)
+			if err != nil {
+				t.Fatalf("read-drift compare: %v", err)
+			}
+			detected := !planEq || !readEq
+			t.Logf("detected=%-5v (plan gate differs=%-5v, read-side drift differs=%-5v)", detected, !planEq, !readEq)
+			if detected != tc.wantDetect {
+				t.Errorf("%s: detected=%v want=%v — stored order %v",
+					tc.name, detected, tc.wantDetect, storedOrder(t, serverNow))
+			}
+		})
+	}
+}

--- a/internal/common/payloadhelpers/threeway_test.go
+++ b/internal/common/payloadhelpers/threeway_test.go
@@ -213,3 +213,37 @@ func TestStructuralEqual_NumericCrossType(t *testing.T) {
 		})
 	}
 }
+
+// TestPayloadsStructurallyEqual_ReorderedPayloadContent covers the strict
+// comparator's share of the reorder problem. structuralEqual walks arrays
+// positionally too, and both of its operands are usually server-canonical — so
+// both carry Jamf Pro's ordering and agree. The exception is the plan modifier's
+// fallback when payload_server_now is absent from private state: the drift arm
+// then compares the last-applied server canonical against state.General.Payloads,
+// which lenient self-healing keeps in the *user-authored* order. On a profile
+// mixing storage categories that is a guaranteed false DecisionDrift and a plan
+// that never converges.
+//
+// MaskPayload canonicalises PayloadContent order for both comparators, so this
+// holds without structuralEqual needing a special case of its own.
+func TestPayloadsStructurallyEqual_ReorderedPayloadContent(t *testing.T) {
+	equal, err := PayloadsStructurallyEqual([]byte(mcxThenCert), []byte(certThenMCXSameContent))
+	if err != nil {
+		t.Fatalf("compare: %v", err)
+	}
+	if !equal {
+		t.Fatal("entry order must not make two otherwise identical payloads structurally unequal")
+	}
+}
+
+// TestPayloadsStructurallyEqual_ReorderedWithRealDrift keeps the strict
+// comparator strict: order is ignored, values are not.
+func TestPayloadsStructurallyEqual_ReorderedWithRealDrift(t *testing.T) {
+	equal, err := PayloadsStructurallyEqual([]byte(mcxThenCert), []byte(certThenMCXChangedInnerValue))
+	if err != nil {
+		t.Fatalf("compare: %v", err)
+	}
+	if equal {
+		t.Fatal("a changed value inside a relocated entry must still compare unequal")
+	}
+}

--- a/internal/resources/pro/macos_configuration_profile/testdata/GoogleChrome__mcx_with_certificate_profile.create_response.xml
+++ b/internal/resources/pro/macos_configuration_profile/testdata/GoogleChrome__mcx_with_certificate_profile.create_response.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8"?><os_x_configuration_profile>
+<!--
+ Copyright Jamf Software LLC 2026
+ SPDX-License-Identifier: MPL-2.0
+-->
+
+  <general>
+    <id>7366</id>
+    <name>tf-acc-roundtrip-GoogleChrome--mcx-with-certificate-profile</name>
+    <description/>
+    <site>
+      <id>-1</id>
+      <name>NONE</name>
+    </site>
+    <category>
+      <id>-1</id>
+      <name>No category assigned</name>
+    </category>
+    <distribution_method>Install Automatically</distribution_method>
+    <user_removable>false</user_removable>
+    <level>System</level>
+    <uuid>9ded2aaa-39e0-46fe-b5bc-ba5f0f0f3a4d</uuid>
+    <redeploy_on_update>Newly Assigned</redeploy_on_update>
+    <payloads>&lt;?xml version="1.0" encoding="UTF-8"?&gt;&lt;!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd"&gt;
+&lt;plist version="1"&gt;&lt;dict&gt;&lt;key&gt;PayloadUUID&lt;/key&gt;&lt;string&gt;9ded2aaa-39e0-46fe-b5bc-ba5f0f0f3a4d&lt;/string&gt;&lt;key&gt;PayloadType&lt;/key&gt;&lt;string&gt;Configuration&lt;/string&gt;&lt;key&gt;PayloadOrganization&lt;/key&gt;&lt;string&gt;Example Org&lt;/string&gt;&lt;key&gt;PayloadIdentifier&lt;/key&gt;&lt;string&gt;9ded2aaa-39e0-46fe-b5bc-ba5f0f0f3a4d&lt;/string&gt;&lt;key&gt;PayloadDisplayName&lt;/key&gt;&lt;string&gt;tf-acc-roundtrip-GoogleChrome--mcx-with-certificate-profile&lt;/string&gt;&lt;key&gt;PayloadDescription&lt;/key&gt;&lt;string/&gt;&lt;key&gt;PayloadVersion&lt;/key&gt;&lt;integer&gt;1&lt;/integer&gt;&lt;key&gt;PayloadEnabled&lt;/key&gt;&lt;true/&gt;&lt;key&gt;PayloadRemovalDisallowed&lt;/key&gt;&lt;true/&gt;&lt;key&gt;PayloadScope&lt;/key&gt;&lt;string&gt;System&lt;/string&gt;&lt;key&gt;PayloadContent&lt;/key&gt;&lt;array&gt;&lt;dict&gt;&lt;key&gt;PayloadUUID&lt;/key&gt;&lt;string&gt;4A7D2E60-8B15-4C93-A2F6-1D3E5C9B7048&lt;/string&gt;&lt;key&gt;PayloadType&lt;/key&gt;&lt;string&gt;com.apple.security.root&lt;/string&gt;&lt;key&gt;PayloadOrganization&lt;/key&gt;&lt;string&gt;Terraform Acceptance Test Org&lt;/string&gt;&lt;key&gt;PayloadIdentifier&lt;/key&gt;&lt;string&gt;com.example.root.ca&lt;/string&gt;&lt;key&gt;PayloadDisplayName&lt;/key&gt;&lt;string&gt;Example Root CA&lt;/string&gt;&lt;key&gt;PayloadDescription&lt;/key&gt;&lt;string/&gt;&lt;key&gt;PayloadVersion&lt;/key&gt;&lt;integer&gt;1&lt;/integer&gt;&lt;key&gt;PayloadEnabled&lt;/key&gt;&lt;true/&gt;&lt;key&gt;PayloadCertificateFileName&lt;/key&gt;&lt;string&gt;example-root-ca.cer&lt;/string&gt;&lt;key&gt;PayloadContent&lt;/key&gt;&lt;data&gt;MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAxGF3lQ0m6zvbNQ0dQKe9nJ6l0J1yQ4nFq0dYh2s5cWJ9Yz8mQ2pLdE7vXhR4tS1uK0oB9wYcAaZmNpQrTfHl&lt;/data&gt;&lt;key&gt;AllowAllAppsAccess&lt;/key&gt;&lt;false/&gt;&lt;/dict&gt;&lt;dict&gt;&lt;key&gt;PayloadDisplayName&lt;/key&gt;&lt;string&gt;Custom Settings&lt;/string&gt;&lt;key&gt;PayloadIdentifier&lt;/key&gt;&lt;string&gt;com.example.chrome.managed.settings&lt;/string&gt;&lt;key&gt;PayloadOrganization&lt;/key&gt;&lt;string&gt;JAMF Software&lt;/string&gt;&lt;key&gt;PayloadType&lt;/key&gt;&lt;string&gt;com.apple.ManagedClient.preferences&lt;/string&gt;&lt;key&gt;PayloadUUID&lt;/key&gt;&lt;string&gt;9C1F5A24-3E7B-4D18-9F02-6B5A8C4E17D3&lt;/string&gt;&lt;key&gt;PayloadVersion&lt;/key&gt;&lt;integer&gt;1&lt;/integer&gt;&lt;key&gt;PayloadContent&lt;/key&gt;&lt;dict&gt;&lt;key&gt;com.google.Chrome&lt;/key&gt;&lt;dict&gt;&lt;key&gt;Forced&lt;/key&gt;&lt;array&gt;&lt;dict&gt;&lt;key&gt;mcx_preference_settings&lt;/key&gt;&lt;dict&gt;&lt;key&gt;HomepageLocation&lt;/key&gt;&lt;string&gt;https://example.com/start&lt;/string&gt;&lt;key&gt;NewTabPageLocation&lt;/key&gt;&lt;string&gt;https://example.com/newtab&lt;/string&gt;&lt;key&gt;PasswordManagerEnabled&lt;/key&gt;&lt;false/&gt;&lt;key&gt;URLBlocklist&lt;/key&gt;&lt;array&gt;&lt;string&gt;example-blocked.test&lt;/string&gt;&lt;/array&gt;&lt;/dict&gt;&lt;/dict&gt;&lt;/array&gt;&lt;/dict&gt;&lt;/dict&gt;&lt;/dict&gt;&lt;/array&gt;&lt;/dict&gt;&lt;/plist&gt;</payloads>
+  </general>
+  <scope>
+    <all_computers>false</all_computers>
+    <all_jss_users>false</all_jss_users>
+    <computers/>
+    <buildings/>
+    <departments/>
+    <computer_groups/>
+    <jss_users/>
+    <jss_user_groups/>
+    <limitations>
+      <users/>
+      <user_groups/>
+      <network_segments/>
+      <ibeacons/>
+    </limitations>
+    <exclusions>
+      <computers/>
+      <buildings/>
+      <departments/>
+      <computer_groups/>
+      <users/>
+      <user_groups/>
+      <network_segments/>
+      <ibeacons/>
+      <jss_users/>
+      <jss_user_groups/>
+    </exclusions>
+  </scope>
+  <self_service>
+    <self_service_display_name/>
+    <install_button_text>Install</install_button_text>
+    <self_service_description/>
+    <force_users_to_view_description>false</force_users_to_view_description>
+    <security>
+      <removal_disallowed>Never</removal_disallowed>
+    </security>
+    <self_service_icon/>
+    <feature_on_main_page>false</feature_on_main_page>
+    <self_service_categories/>
+    <notification>false</notification>
+    <notification>Self Service</notification>
+    <notification_subject/>
+    <notification_message/>
+  </self_service>
+</os_x_configuration_profile>

--- a/internal/resources/pro/macos_configuration_profile/testdata/GoogleChrome__mcx_with_certificate_profile.mobileconfig
+++ b/internal/resources/pro/macos_configuration_profile/testdata/GoogleChrome__mcx_with_certificate_profile.mobileconfig
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>PayloadContent</key>
+	<array>
+		<dict>
+			<key>PayloadContent</key>
+			<dict>
+				<key>com.google.Chrome</key>
+				<dict>
+					<key>Forced</key>
+					<array>
+						<dict>
+							<key>mcx_preference_settings</key>
+							<dict>
+								<key>HomepageLocation</key>
+								<string>https://example.com/start</string>
+								<key>NewTabPageLocation</key>
+								<string>https://example.com/newtab</string>
+								<key>PasswordManagerEnabled</key>
+								<false/>
+								<key>URLBlocklist</key>
+								<array>
+									<string>example-blocked.test</string>
+								</array>
+							</dict>
+						</dict>
+					</array>
+				</dict>
+			</dict>
+			<key>PayloadDisplayName</key>
+			<string>Google Chrome managed preferences</string>
+			<key>PayloadIdentifier</key>
+			<string>com.example.chrome.managed.settings</string>
+			<key>PayloadType</key>
+			<string>com.apple.ManagedClient.preferences</string>
+			<key>PayloadUUID</key>
+			<string>9C1F5A24-3E7B-4D18-9F02-6B5A8C4E17D3</string>
+			<key>PayloadVersion</key>
+			<integer>1</integer>
+		</dict>
+		<dict>
+			<key>PayloadCertificateFileName</key>
+			<string>example-root-ca.cer</string>
+			<key>PayloadContent</key>
+			<data>
+			MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAxGF3lQ0m6zvbNQ0dQKe9
+			nJ6l0J1yQ4nFq0dYh2s5cWJ9Yz8mQ2pLdE7vXhR4tS1uK0oB9wYcAaZmNpQrTfHl
+			</data>
+			<key>PayloadDisplayName</key>
+			<string>Example Root CA</string>
+			<key>PayloadIdentifier</key>
+			<string>com.example.root.ca</string>
+			<key>PayloadType</key>
+			<string>com.apple.security.root</string>
+			<key>PayloadUUID</key>
+			<string>4A7D2E60-8B15-4C93-A2F6-1D3E5C9B7048</string>
+			<key>PayloadVersion</key>
+			<integer>1</integer>
+		</dict>
+	</array>
+	<key>PayloadDisplayName</key>
+	<string>Chrome settings with root certificate</string>
+	<key>PayloadIdentifier</key>
+	<string>com.example.chrome.with.certificate</string>
+	<key>PayloadOrganization</key>
+	<string>Example Org</string>
+	<key>PayloadScope</key>
+	<string>System</string>
+	<key>PayloadType</key>
+	<string>Configuration</string>
+	<key>PayloadUUID</key>
+	<string>2F8C6B31-7A4E-4D52-B9C8-0E1A3F7D6B92</string>
+	<key>PayloadVersion</key>
+	<integer>1</integer>
+</dict>
+</plist>


### PR DESCRIPTION
## Summary
- `LenientEqualPlist` compared top-level `PayloadContent` arrays strictly by index. Jamf Pro is free to relocate an entire entry elsewhere in the array on store — wire-observed with a profile mixing an MCX "Application & Custom Settings" entry with a Certificate entry, which comes back with the certificate moved ahead of MCX.
- The positional compare paired unrelated entries (MCX vs certificate), cascading into a false `"Jamf Pro cannot store this payload faithfully"` diagnostic and a create-time rollback — even though the server had stored every value correctly.
- Fixed by grouping `PayloadContent` entries by `PayloadType` and comparing positionally *within* each group instead of across the whole array. `PayloadIdentifier` can't be used to pair entries directly because it's already masked out (server-assignable) by the time this comparison runs — same-type siblings have never been observed to reorder relative to each other, only entire types relative to their differently-typed siblings.

## How this was found
Traced from a live apply failure in a downstream onboarder config combining an MCX activation-profile payload with a certificate payload in the same `jamfplatform_pro_macos_configuration_profile`. Ruled out Jamf Pro, the Classic API, and the SDK one at a time by:
1. Reproducing the same combination via the Jamf Pro admin UI directly — round-tripped fine.
2. POSTing the same payload via the raw Classic API (OAuth2 client-credentials) — round-tripped fine.
3. Calling the real `jamfplatform-go-sdk` client with the provider's exact `PrepareWirePayload` transform — round-tripped fine.
4. Calling `payloadhelpers.PayloadsSemanticallyEqual` directly on the authored-vs-server bytes from that successful round-trip — returned `false`. That pinpointed the bug to the comparator itself, not any wire/storage layer.
5. Confirmed the array reorder by parsing both sides and diffing `PayloadContent` order.

## Test plan
- [x] `go build ./...`, `go vet ./...`, `go test ./...` all pass
- [x] Added two new tests: `TestPayloadsSemanticallyEqual_PayloadContentReordered_Equal` (reorder alone is tolerated) and `TestPayloadsSemanticallyEqual_PayloadContentReorderedWithRealDrift_NotEqual` (a real change inside a reordered entry still surfaces)
- [x] Verified live against a real Jamf Pro tenant: the original failing module (11 `PayloadContent` entries including 6 same-type MCX siblings for different browsers) now applies clean for both the macOS and mobile-device configuration profile resources — no fidelity error, no rollback.