### PR TITLE
chore(payloadhelpers): use maps.Copy in alignPayloadContentOrder

### DIFF
--- a/internal/common/payloadhelpers/fidelity.go
+++ b/internal/common/payloadhelpers/fidelity.go
@@ -6,6 +6,7 @@ package payloadhelpers
 import (
 	"fmt"
 	"html"
+	"maps"
 	"slices"
 	"strings"
 
@@ -275,9 +276,7 @@ func alignPayloadContentOrder(authoredTree, storedTree map[string]any) map[strin
 	}
 
 	out := make(map[string]any, len(storedTree))
-	for k, v := range storedTree {
-		out[k] = v
-	}
+	maps.Copy(out, storedTree)
 	out["PayloadContent"] = aligned
 	return out
 }


### PR DESCRIPTION
## What

Replaces a hand-rolled map copy loop in `alignPayloadContentOrder` with `maps.Copy`.

```diff
-	for k, v := range storedTree {
-		out[k] = v
-	}
+	maps.Copy(out, storedTree)
```

## Why separately

This is what `make fix` (`go fix ./...`, part of the repo's documented pre-commit sequence) rewrites on its own. It surfaced while working on an unrelated impact-alerts change, and is split out so that PR stays scoped to its own feature rather than carrying a drive-by edit to `payloadhelpers`.

Behaviour is identical — `maps.Copy` is the stdlib spelling of exactly this loop, and the pre-sized `make(map[string]any, len(storedTree))` above it is unchanged.

## Testing

`make fmt lint test` clean; `payloadhelpers` unit tests pass unchanged. No behaviour change, so no new tests — the existing `PayloadContent` ordering tests already cover this function.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
