### PR TITLE
fix(security): close OSS pre-release audit follow-ups

### DIFF
--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -6,5 +6,10 @@
 # certificate-filename attribute (and its generated doc). That value is a p12
 # FILENAME, not a credential — the real secret is the filebase64(...) keystore
 # reference, which has no literal value. Safe to ignore.
-e79e5aeb580a053c71d4b09de7dfc0f00c168085:docs/resources/pro_gsx_connection_settings.md:generic-api-key:37
-e79e5aeb580a053c71d4b09de7dfc0f00c168085:examples/resources/jamfplatform_pro_gsx_connection_settings/resource.tf:generic-api-key:22
+#
+# The SHA must be the commit that INTRODUCED the line, as gitleaks reports it in
+# the finding fingerprint — not the commit that added this file. If history is
+# rebased the SHA changes and the entry silently stops matching, so re-derive it
+# with `gitleaks git --log-opts="--all" -v` after any history rewrite.
+1335078e2bbab1ddd5aec36e4e3e34fdcd3e2a58:docs/resources/pro_gsx_connection_settings.md:generic-api-key:37
+1335078e2bbab1ddd5aec36e4e3e34fdcd3e2a58:examples/resources/jamfplatform_pro_gsx_connection_settings/resource.tf:generic-api-key:22

--- a/README.md
+++ b/README.md
@@ -56,6 +56,37 @@ Refer to the [documentation](https://registry.terraform.io/providers/Jamf-Concep
 
 ---
 
+## Troubleshooting
+
+### Debug logging
+
+Terraform's log level is set with `TF_LOG`. At `DEBUG` the provider logs every HTTP request and response it makes to the Jamf Platform API — method, URL, status code, response headers, and the request and response bodies:
+
+```shell
+TF_LOG=DEBUG terraform apply
+TF_LOG=DEBUG terraform apply 2> debug.log   # capture to a file
+```
+
+`TF_LOG=TRACE` adds Terraform core's own plan/apply internals on top. Use `TF_LOG_PROVIDER=DEBUG` to raise the level for providers only and leave Terraform core quieter.
+
+### Debug logs and secrets
+
+Debug logs are the fastest way to see what the provider actually sent, which means they are also the most likely place for a credential to end up. The provider therefore redacts before it logs:
+
+- **Headers** — `Authorization`, `Proxy-Authorization`, `Cookie`, `Set-Cookie` and `X-Api-Key` are logged as `REDACTED`.
+- **Request and response bodies** — values of known credential-bearing fields are replaced with `REDACTED`. This covers plaintext passwords and their `_sha256` echoes, recovery and encryption keys, client secrets, bearer and enrolment tokens, keystore blobs, and secret values inside configuration profile payloads (including plist `<key>`/`<string>` pairs, which sit inside the `payloads` element).
+- **Unparseable bodies** — a body that is neither JSON nor XML cannot be checked for credentials, so it is withheld from the log rather than written out raw.
+- **File uploads** — multipart bodies are never rendered; the log records `<multipart body>`.
+
+Redaction is matched against known field names, so treat it as a strong safety net rather than a guarantee. Two things follow from that:
+
+- Review a debug log before you attach it to a support ticket, paste it into an issue, or leave it in CI output. CI logs in particular are often readable by more people than the person who triggered the run.
+- If you find a credential in a debug log that should have been redacted, please report it — see [SECURITY.md](./SECURITY.md).
+
+Redaction applies to what the provider logs. It does not change what Terraform itself writes: values marked sensitive are masked in Terraform's plan and apply output, but a `write-only` argument's value still exists in your configuration and in any variable file or environment variable that supplies it.
+
+---
+
 ## Contributing
 
 Contributions are welcome. See [CONTRIBUTING.md](./CONTRIBUTING.md) and [TESTING.md](./TESTING.md) for the full workflow. In short, for changes that add or modify resources, data sources, list resources, actions, or functions:

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,45 +1,11 @@
-# Security Policy
+# Security
 
-## Reporting a vulnerability
+## Reporting a Vulnerability
 
-Please report security vulnerabilities in this provider through either of these channels:
+Information security is a team effort. If you discover a security vulnerability in this project, please report it to us so we can fix it. For these reports, there is Jamf's Vulnerability Disclosure Program:
 
-- **[Jamf's Vulnerability Disclosure Program](https://www.jamf.com/trust-center/vulnerability-disclosure/)** — Jamf's monitored intake, triaged by the Jamf Application Security team.
-- **[GitHub private vulnerability reporting](https://github.com/Jamf-Concepts/terraform-provider-jamfplatform/security/advisories/new)** — private to the maintainers, and the route we use to publish an advisory once a fix ships.
+https://www.jamf.com/security/vulnerability-disclosure/
 
-Please do **not** open a public GitHub issue for a suspected vulnerability, and do not include credentials, tenant identifiers, or customer data in a report.
+For more information about Jamf's broader security program, see:
 
-A useful report includes the provider version, the Terraform version, the resource or data source involved, and clear steps that demonstrate the issue.
-
-## What to expect
-
-We will acknowledge receipt of your report within **5 business days**. That acknowledgement confirms the report has been received and entered into triage — it is not a commitment to a remediation timeline, which depends on the severity and complexity of the issue.
-
-We will keep you informed as triage progresses, and we will credit reporters who wish to be credited when we publish an advisory.
-
-## Scope
-
-**In scope:**
-
-- The provider's own source code in this repository.
-- The provider's dependencies, where the issue is reachable through this provider.
-- This repository's build and release pipeline.
-
-**Out of scope:**
-
-- The Jamf Platform API, Jamf Pro, and other Jamf products and hosted services. Report these through [Jamf's Vulnerability Disclosure Program](https://www.jamf.com/trust-center/vulnerability-disclosure/) so they reach the right team.
-- Third-party services and infrastructure Jamf does not operate.
-- Social engineering, physical attacks, and denial of service.
-- Findings that require an attacker to already control the machine running Terraform, or to already hold valid Jamf API credentials with the privileges the reported action needs.
-
-## Coordinated disclosure
-
-Please give us a reasonable opportunity to assess and address an issue before disclosing it publicly. We will work with you on timing and will publish a [GitHub Security Advisory](https://github.com/Jamf-Concepts/terraform-provider-jamfplatform/security/advisories) when a fix is released.
-
-## Supported versions
-
-This provider is pre-1.0 and released from `main`. Security fixes ship in a new release rather than being backported to earlier minor versions, so please upgrade to the latest release before reporting, and expect fixes to require an upgrade.
-
-## Handling secrets when reporting
-
-Terraform debug logging (`TF_LOG=DEBUG`) records the provider's HTTP traffic. The provider redacts credential-bearing headers and body fields before they reach the log, but please still review any log excerpt before attaching it to a report, and never share an unredacted log publicly. See the Troubleshooting section of the [README](README.md#troubleshooting) for details.
+https://security.jamf.com/

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,45 @@
+# Security Policy
+
+## Reporting a vulnerability
+
+Please report security vulnerabilities in this provider through either of these channels:
+
+- **[Jamf's Vulnerability Disclosure Program](https://www.jamf.com/trust-center/vulnerability-disclosure/)** — Jamf's monitored intake, triaged by the Jamf Application Security team.
+- **[GitHub private vulnerability reporting](https://github.com/Jamf-Concepts/terraform-provider-jamfplatform/security/advisories/new)** — private to the maintainers, and the route we use to publish an advisory once a fix ships.
+
+Please do **not** open a public GitHub issue for a suspected vulnerability, and do not include credentials, tenant identifiers, or customer data in a report.
+
+A useful report includes the provider version, the Terraform version, the resource or data source involved, and clear steps that demonstrate the issue.
+
+## What to expect
+
+We will acknowledge receipt of your report within **5 business days**. That acknowledgement confirms the report has been received and entered into triage — it is not a commitment to a remediation timeline, which depends on the severity and complexity of the issue.
+
+We will keep you informed as triage progresses, and we will credit reporters who wish to be credited when we publish an advisory.
+
+## Scope
+
+**In scope:**
+
+- The provider's own source code in this repository.
+- The provider's dependencies, where the issue is reachable through this provider.
+- This repository's build and release pipeline.
+
+**Out of scope:**
+
+- The Jamf Platform API, Jamf Pro, and other Jamf products and hosted services. Report these through [Jamf's Vulnerability Disclosure Program](https://www.jamf.com/trust-center/vulnerability-disclosure/) so they reach the right team.
+- Third-party services and infrastructure Jamf does not operate.
+- Social engineering, physical attacks, and denial of service.
+- Findings that require an attacker to already control the machine running Terraform, or to already hold valid Jamf API credentials with the privileges the reported action needs.
+
+## Coordinated disclosure
+
+Please give us a reasonable opportunity to assess and address an issue before disclosing it publicly. We will work with you on timing and will publish a [GitHub Security Advisory](https://github.com/Jamf-Concepts/terraform-provider-jamfplatform/security/advisories) when a fix is released.
+
+## Supported versions
+
+This provider is pre-1.0 and released from `main`. Security fixes ship in a new release rather than being backported to earlier minor versions, so please upgrade to the latest release before reporting, and expect fixes to require an upgrade.
+
+## Handling secrets when reporting
+
+Terraform debug logging (`TF_LOG=DEBUG`) records the provider's HTTP traffic. The provider redacts credential-bearing headers and body fields before they reach the log, but please still review any log excerpt before attaching it to a report, and never share an unredacted log publicly. See the Troubleshooting section of the [README](README.md#troubleshooting) for details.

--- a/go.mod
+++ b/go.mod
@@ -62,6 +62,6 @@ require (
 	golang.org/x/tools v0.47.0 // indirect
 	google.golang.org/appengine v1.6.8 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260519071638-aa98bba5eb94 // indirect
-	google.golang.org/grpc v1.81.1 // indirect
+	google.golang.org/grpc v1.82.1 // indirect
 	google.golang.org/protobuf v1.36.11 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,11 +1,5 @@
 dario.cat/mergo v1.0.0 h1:AGCNq9Evsj31mOgNPcLyXc+4PNABt905YmuqPYYpBWk=
 dario.cat/mergo v1.0.0/go.mod h1:uNxQE+84aUszobStD9th8a29P2fMDhsBdgRYvZOxGmk=
-github.com/Jamf-Concepts/jamfplatform-go-sdk v0.15.1-0.20260816172136-2e67e67111aa h1:jiA5BZiIIdqqLlgqkWfVfLRc9oxL4VSgur/2ehlYdhk=
-github.com/Jamf-Concepts/jamfplatform-go-sdk v0.15.1-0.20260816172136-2e67e67111aa/go.mod h1:PY6rrlON3zFpNyhXRr5AIlt3VOxgdlKomSJXefkAXi4=
-github.com/Jamf-Concepts/jamfplatform-go-sdk v0.16.0 h1:75dxPtw2CTP9uB8KeBkVb/pvcbEJntQ4HRkodg6hP20=
-github.com/Jamf-Concepts/jamfplatform-go-sdk v0.16.0/go.mod h1:PY6rrlON3zFpNyhXRr5AIlt3VOxgdlKomSJXefkAXi4=
-github.com/Jamf-Concepts/jamfplatform-go-sdk v0.16.1-0.20260818120018-fb2c38e93981 h1:w6Rn+VRRNlq2bTH5ialzyyCUPqwOaT9WfjvQ8hA0O40=
-github.com/Jamf-Concepts/jamfplatform-go-sdk v0.16.1-0.20260818120018-fb2c38e93981/go.mod h1:PY6rrlON3zFpNyhXRr5AIlt3VOxgdlKomSJXefkAXi4=
 github.com/Jamf-Concepts/jamfplatform-go-sdk v0.16.1 h1:RZrdaOZkzF+nqzTVkwHG7xup74RUaON3XoXy/Kx917k=
 github.com/Jamf-Concepts/jamfplatform-go-sdk v0.16.1/go.mod h1:PY6rrlON3zFpNyhXRr5AIlt3VOxgdlKomSJXefkAXi4=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
@@ -240,8 +234,8 @@ google.golang.org/appengine v1.6.8 h1:IhEN5q69dyKagZPYMSdIjS2HqprW324FRQZJcGqPAs
 google.golang.org/appengine v1.6.8/go.mod h1:1jJ3jBArFh5pcgW8gCtRJnepW8FzD1V44FJffLiz/Ds=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20260519071638-aa98bba5eb94 h1:eZCjr/aAF8c5ccm5pb6T4EXgIei5MlAAPWPJk+5ArfY=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20260519071638-aa98bba5eb94/go.mod h1:4Hqkh8ycfw05ld/3BWL7rJOSfebL2Q+DVDeRgYgxUU8=
-google.golang.org/grpc v1.81.1 h1:VnnIIZ88UzOOKLukQi+ImGz8O1Wdp8nAGGnvOfEIWQQ=
-google.golang.org/grpc v1.81.1/go.mod h1:xGH9GfzOyMTGIOXBJmXt+BX/V0kcdQbdcuwQ/zNw42I=
+google.golang.org/grpc v1.82.1 h1:NnAxzGRA0677vCa4BUkOAnO5+FfQqVl9iUXeD0IqcGE=
+google.golang.org/grpc v1.82.1/go.mod h1:yzTZ1TB1Z3SG+LIYaI+WiE8D5+PZ3ArnrSp8zF3+/ZA=
 google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
 google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
 google.golang.org/protobuf v1.36.11 h1:fV6ZwhNocDyBLK0dj+fg8ektcVegBBuEolpbTQyBNVE=

--- a/internal/provider/tflogger.go
+++ b/internal/provider/tflogger.go
@@ -8,12 +8,15 @@ import (
 	"context"
 	"encoding/json"
 	"encoding/xml"
+	"fmt"
 	"io"
 	"net/http"
 	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/Jamf-Concepts/jamfplatform-go-sdk/jamfplatform"
+	"github.com/Jamf-Concepts/terraform-provider-jamfplatform/internal/common/plisthelpers"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
 
@@ -29,11 +32,24 @@ func NewTerraformLogger() *TerraformLogger {
 }
 
 // maxLoggedBodyBytes caps the rendered body length before truncation. Applied
-// to the pretty-printed string so truncation never lands mid-token.
+// to the redacted, pretty-printed string so truncation never lands mid-token
+// and never exposes content that redaction would otherwise have removed.
 const maxLoggedBodyBytes = 5000
 
-// LogRequest logs HTTP request details using tflog at DEBUG level. Bodies
-// are pretty-printed by content sniff (JSON / XML / opaque).
+// redactedPlaceholder replaces every value the body redactor treats as
+// credential material.
+const redactedPlaceholder = "REDACTED"
+
+// multipartSentinel is the literal stand-in the SDK passes to LogRequest in
+// place of a multipart body, so file and package uploads are never rendered.
+// Recognised by formatBody so it survives the fail-closed path rather than
+// being reported as an unparseable body.
+const multipartSentinel = "<multipart body>"
+
+// LogRequest logs HTTP request details using tflog at DEBUG level. Bodies are
+// redacted, then pretty-printed by content sniff (JSON / XML). The SDK's Logger
+// interface passes no request headers, so there is nothing to redact there —
+// the bearer token never reaches this function.
 func (l *TerraformLogger) LogRequest(ctx context.Context, method, url string, body []byte) {
 	fields := map[string]any{
 		"method": method,
@@ -47,8 +63,8 @@ func (l *TerraformLogger) LogRequest(ctx context.Context, method, url string, bo
 	tflog.Debug(ctx, "HTTP Request", fields)
 }
 
-// LogResponse logs HTTP response details using tflog at DEBUG level. Bodies
-// are pretty-printed by content sniff (JSON / XML / opaque).
+// LogResponse logs HTTP response details using tflog at DEBUG level. Bodies are
+// redacted, then pretty-printed by content sniff (JSON / XML).
 func (l *TerraformLogger) LogResponse(ctx context.Context, statusCode int, headers http.Header, body []byte) {
 	fields := map[string]any{
 		"status_code": statusCode,
@@ -65,51 +81,54 @@ func (l *TerraformLogger) LogResponse(ctx context.Context, statusCode int, heade
 	tflog.Debug(ctx, "HTTP Response", fields)
 }
 
-// formatBody pretty-prints JSON and XML payloads and truncates to keep
-// debug logs readable. Falls back to the raw string when sniffing fails or
-// the body is neither JSON nor XML.
+// formatBody renders a request or response body for a debug log: credential
+// values are replaced with redactedPlaceholder, the remainder is pretty-printed,
+// and the result is truncated to keep logs readable. Redaction runs before
+// truncation, so a secret early in a long body is removed rather than merely
+// pushed past the cut.
+//
+// The renderer FAILS CLOSED. Redaction can only find secrets in a body it can
+// parse, so a body that is neither JSON nor XML is withheld entirely rather than
+// logged raw — logging it would silently bypass every rule below. The multipart
+// sentinel is the one recognised exception.
 func formatBody(body []byte) string {
-	pretty := prettyPrint(body)
-	if len(pretty) > maxLoggedBodyBytes {
-		return pretty[:maxLoggedBodyBytes] + "... (truncated)"
+	if string(bytes.TrimSpace(body)) == multipartSentinel {
+		return multipartSentinel
 	}
-	return pretty
+
+	rendered, ok := redactAndFormat(body)
+	if !ok {
+		return fmt.Sprintf("<body withheld: %d bytes, not parseable as JSON or XML so it cannot be redaction-checked>", len(body))
+	}
+
+	if len(rendered) > maxLoggedBodyBytes {
+		return rendered[:maxLoggedBodyBytes] + "... (truncated)"
+	}
+	return rendered
 }
 
-// prettyPrint sniffs the first non-whitespace byte to pick a formatter.
-// '{' or '[' → JSON. '<' → XML. Anything else → raw string.
-func prettyPrint(body []byte) string {
-	leading := body
-	for len(leading) > 0 {
-		switch leading[0] {
-		case ' ', '\t', '\r', '\n':
-			leading = leading[1:]
-			continue
-		}
-		break
-	}
+// redactAndFormat sniffs the first non-whitespace byte to pick a renderer.
+// '{' or '[' selects JSON, '<' selects XML. Anything else is unsupported and
+// reports false so the caller withholds the body.
+func redactAndFormat(body []byte) (string, bool) {
+	leading := bytes.TrimLeft(body, " \t\r\n")
 	if len(leading) == 0 {
-		return string(body)
+		return string(body), true
 	}
 
 	switch leading[0] {
 	case '{', '[':
-		var buf bytes.Buffer
-		if err := json.Indent(&buf, body, "", "  "); err == nil {
-			return buf.String()
-		}
+		return redactJSON(body)
 	case '<':
-		if out, err := indentXML(body); err == nil {
-			return out
-		}
+		return redactXML(body)
 	}
-	return string(body)
+	return "", false
 }
 
-// sensitiveHeaders are response/request headers whose values may carry
-// credentials or session state. Logged as REDACTED to avoid leaks in
-// tflog output. Compared case-insensitively against canonical MIME keys
-// (http.Header normalises to canonical form).
+// sensitiveHeaders are response headers whose values may carry credentials or
+// session state. Logged as redactedPlaceholder to avoid leaks in tflog output.
+// Compared case-insensitively against canonical MIME keys (http.Header
+// normalises to canonical form).
 var sensitiveHeaders = map[string]struct{}{
 	"Authorization":       {},
 	"Proxy-Authorization": {},
@@ -118,9 +137,139 @@ var sensitiveHeaders = map[string]struct{}{
 	"X-Api-Key":           {},
 }
 
+// sensitiveBodyFields are JSON and XML wire field names whose values are
+// credential material: plaintext passwords and their _sha256 echoes, recovery
+// and encryption keys, client secrets and credential bundles, bearer and
+// enrolment tokens, keystore blobs, and licence keys.
+//
+// Keys are lower-cased and matching is EXACT after lower-casing, never by
+// substring. Exact matching is deliberate. The Jamf Platform and Jamf Pro
+// schemas carry many non-secret fields whose names contain "password", "key" or
+// "token" — passwordMinLength, passwordMaxAge, passwordHistoryDepth,
+// passcodePresent, passed, passPercentage, keyUsage, groupRdnKey, triggerKey,
+// tokenExpiration, bootstrapTokenEscrowed, vppTokenEnabled among them. Those are
+// frequently the very values an operator enabled DEBUG to inspect, so a
+// substring rule would redact the log into uselessness while adding no safety.
+//
+// Bare "key" and "keys" are deliberately absent: they hold key material in
+// SsoKeystore but are plain identifiers in StatusItem, UserPreferencesSettings
+// and ComputerContentCachingDataMigrationErrorUserInfo. The blob-bearing
+// siblings below cover the material without hiding those identifiers.
+//
+// Both camelCase (Jamf Pro JSON) and snake_case (ProClassic XML) spellings are
+// listed because they are distinct strings; case variants are not, since
+// matching lower-cases first.
+var sensitiveBodyFields = map[string]struct{}{
+	"accesskeyid":                {},
+	"access_token":               {},
+	"adminpassword":              {},
+	"airplaypassword":            {},
+	"airplay_password":           {},
+	"applecaretoken":             {},
+	"basicauthcredentials":       {},
+	"bootstraptoken":             {},
+	"cached_credentials":         {},
+	"clientsecret":               {},
+	"currentpassword":            {},
+	"encodedtoken":               {},
+	"encryption_key":             {},
+	"googlemailcredentials":      {},
+	"graphapicredentials":        {},
+	"gsxkeystore":                {},
+	"httpspassword":              {},
+	"http_password":              {},
+	"http_password_sha256":       {},
+	"identitykeystore":           {},
+	"institutional_recovery_key": {},
+	"keystore":                   {},
+	"keystorebytes":              {},
+	"keystorefile":               {},
+	"keystorepassword":           {},
+	"lapsuserpasswordlist":       {},
+	"managed_password":           {},
+	"newpassword":                {},
+	"of_password":                {},
+	"of_password_sha256":         {},
+	"open_firmware_efi_password": {},
+	"password":                   {},
+	"password_sha256":            {},
+	"personalrecoverykey":        {},
+	"pin":                        {},
+	"plainpassword":              {},
+	"privatekey":                 {},
+	"productkey":                 {},
+	"readonlypassword":           {},
+	"readwritepassword":          {},
+	"read_only_password":         {},
+	"read_only_password_sha256":  {},
+	"read_write_password":        {},
+	"read_write_password_sha256": {},
+	"recoverylockpassword":       {},
+	"refreshtoken":               {},
+	"secretaccesskey":            {},
+	"servertoken":                {},
+	"servicetoken":               {},
+	"service_token":              {},
+	"sessiontoken":               {},
+	"sshpassword":                {},
+	"ssh_password":               {},
+	"ssh_password_sha256":        {},
+	"token":                      {},
+	"unlocktoken":                {},
+}
+
+// sensitivePlistKeys are Apple configuration-profile payload keys whose values
+// are credential material. Lower-cased and matched exactly, for the same reason
+// as sensitiveBodyFields. PayloadContent is absent because it needs its value to
+// decide — see isSensitivePlistKey.
+var sensitivePlistKeys = map[string]struct{}{
+	"authpassword":     {},
+	"clientsecret":     {},
+	"otpsecret":        {},
+	"outgoingpassword": {},
+	"passphrase":       {},
+	"password":         {},
+	"privatekey":       {},
+	"proxypassword":    {},
+	"psk":              {},
+	"routingpassword":  {},
+	"secret":           {},
+	"sharedsecret":     {},
+	"token":            {},
+}
+
+// isSensitiveField reports whether a JSON or XML wire field name carries
+// credential material.
+func isSensitiveField(name string) bool {
+	_, ok := sensitiveBodyFields[strings.ToLower(name)]
+	return ok
+}
+
+// isSensitivePlistKey reports whether a plist key carries credential material.
+//
+// PayloadContent needs its value to decide. At the top level of a .mobileconfig
+// it is the array of payload dictionaries, and redacting it would blank the
+// entire profile; inside a certificate payload the same key holds the raw
+// PKCS#12 or DER bytes, which must be redacted. Container values are therefore
+// walked and scalar values are redacted.
+func isSensitivePlistKey(key string, value any) bool {
+	lower := strings.ToLower(key)
+
+	if lower == "payloadcontent" {
+		switch value.(type) {
+		case []any, map[string]any:
+			return false
+		}
+		return true
+	}
+
+	_, ok := sensitivePlistKeys[lower]
+	return ok
+}
+
 // formatHeaders renders an http.Header as a sorted multi-line block of
-// "Key: value" pairs. Multi-value headers are comma-joined. Sensitive
-// headers (Authorization, Set-Cookie, etc.) are redacted.
+// "Key: value" pairs. Multi-value headers are comma-joined. Sensitive headers
+// (Authorization, Set-Cookie, etc.) are redacted.
 func formatHeaders(h http.Header) string {
 	if len(h) == 0 {
 		return ""
@@ -139,7 +288,7 @@ func formatHeaders(h http.Header) string {
 		sb.WriteString(k)
 		sb.WriteString(": ")
 		if _, redact := sensitiveHeaders[http.CanonicalHeaderKey(k)]; redact {
-			sb.WriteString("REDACTED")
+			sb.WriteString(redactedPlaceholder)
 			continue
 		}
 		sb.WriteString(strings.Join(h[k], ", "))
@@ -147,15 +296,171 @@ func formatHeaders(h http.Header) string {
 	return sb.String()
 }
 
-// indentXML re-encodes an XML payload with two-space indentation by streaming
-// tokens through xml.Decoder → xml.Encoder. Whitespace-only CharData tokens
-// are dropped so the existing wire whitespace does not double up against the
-// new indentation.
-func indentXML(body []byte) (string, error) {
+// redactJSON re-emits a JSON body with sensitive values replaced and two-space
+// indentation applied. Reports false if the body is not a single well-formed
+// JSON value, so the caller withholds it.
+//
+// It streams tokens rather than unmarshalling into map[string]any and
+// re-marshalling, because Go maps do not preserve object member order. Wire
+// field order has been load-bearing in this provider before — Jamf Pro rejects
+// some classic payloads whose members arrive out of order — so a debug log that
+// silently re-sorted members would misdirect that exact investigation.
+// UseNumber preserves numeric literals, which the default float64 decode would
+// rewrite for large integers and trailing zeros.
+func redactJSON(body []byte) (string, bool) {
+	dec := json.NewDecoder(bytes.NewReader(body))
+	dec.UseNumber()
+
+	var buf bytes.Buffer
+	if err := writeJSONValue(dec, &buf, 0); err != nil {
+		return "", false
+	}
+
+	if _, err := dec.Token(); err != io.EOF {
+		return "", false
+	}
+
+	return buf.String(), true
+}
+
+// writeJSONValue reads exactly one JSON value from dec and writes its redacted,
+// indented rendering to buf.
+func writeJSONValue(dec *json.Decoder, buf *bytes.Buffer, depth int) error {
+	tok, err := dec.Token()
+	if err != nil {
+		return err
+	}
+
+	delim, isDelim := tok.(json.Delim)
+	if !isDelim {
+		writeJSONScalar(buf, tok)
+		return nil
+	}
+
+	switch delim {
+	case '{':
+		return writeJSONObject(dec, buf, depth)
+	case '[':
+		return writeJSONArray(dec, buf, depth)
+	}
+	return fmt.Errorf("unexpected JSON delimiter %v", delim)
+}
+
+// writeJSONObject renders an object whose opening brace has already been read.
+// A member whose name is sensitive has its entire value consumed and replaced,
+// so a credential nested under a sensitive key cannot survive.
+func writeJSONObject(dec *json.Decoder, buf *bytes.Buffer, depth int) error {
+	buf.WriteByte('{')
+	empty := true
+
+	for dec.More() {
+		keyTok, err := dec.Token()
+		if err != nil {
+			return err
+		}
+		key, ok := keyTok.(string)
+		if !ok {
+			return fmt.Errorf("non-string JSON object key %v", keyTok)
+		}
+
+		if !empty {
+			buf.WriteByte(',')
+		}
+		empty = false
+		writeJSONIndent(buf, depth+1)
+		buf.WriteString(strconv.Quote(key))
+		buf.WriteString(": ")
+
+		if isSensitiveField(key) {
+			var discard json.RawMessage
+			if err := dec.Decode(&discard); err != nil {
+				return err
+			}
+			buf.WriteString(strconv.Quote(redactedPlaceholder))
+			continue
+		}
+
+		if err := writeJSONValue(dec, buf, depth+1); err != nil {
+			return err
+		}
+	}
+
+	if _, err := dec.Token(); err != nil {
+		return err
+	}
+	if !empty {
+		writeJSONIndent(buf, depth)
+	}
+	buf.WriteByte('}')
+	return nil
+}
+
+// writeJSONArray renders an array whose opening bracket has already been read.
+func writeJSONArray(dec *json.Decoder, buf *bytes.Buffer, depth int) error {
+	buf.WriteByte('[')
+	empty := true
+
+	for dec.More() {
+		if !empty {
+			buf.WriteByte(',')
+		}
+		empty = false
+		writeJSONIndent(buf, depth+1)
+		if err := writeJSONValue(dec, buf, depth+1); err != nil {
+			return err
+		}
+	}
+
+	if _, err := dec.Token(); err != nil {
+		return err
+	}
+	if !empty {
+		writeJSONIndent(buf, depth)
+	}
+	buf.WriteByte(']')
+	return nil
+}
+
+// writeJSONIndent writes a newline plus two spaces per depth level.
+func writeJSONIndent(buf *bytes.Buffer, depth int) {
+	buf.WriteByte('\n')
+	buf.WriteString(strings.Repeat("  ", depth))
+}
+
+// writeJSONScalar writes a non-container JSON token.
+func writeJSONScalar(buf *bytes.Buffer, tok json.Token) {
+	switch v := tok.(type) {
+	case nil:
+		buf.WriteString("null")
+	case string:
+		buf.WriteString(strconv.Quote(v))
+	case bool:
+		buf.WriteString(strconv.FormatBool(v))
+	case json.Number:
+		buf.WriteString(v.String())
+	default:
+		buf.WriteString(strconv.Quote(fmt.Sprint(v)))
+	}
+}
+
+// redactXML re-encodes an XML payload with two-space indentation, replacing the
+// character data of any element whose name is a sensitive field. Reports false
+// if the body is not well-formed XML, so the caller withholds it.
+//
+// Whitespace-only CharData tokens are dropped so existing wire whitespace does
+// not double up against the new indentation.
+//
+// Character data that is itself a plist — how Jamf Pro carries configuration
+// profile payloads inside <payloads> — is handed to redactPlist, because plist
+// stores values as sibling <key>/<string> pairs that element-name matching
+// cannot see.
+func redactXML(body []byte) (string, bool) {
 	dec := xml.NewDecoder(bytes.NewReader(body))
 	var buf bytes.Buffer
 	enc := xml.NewEncoder(&buf)
 	enc.Indent("", "  ")
+
+	var stack []string
 
 	for {
 		tok, err := dec.Token()
@@ -163,19 +468,91 @@ func indentXML(body []byte) (string, error) {
 			break
 		}
 		if err != nil {
-			return "", err
+			return "", false
 		}
-		if cd, ok := tok.(xml.CharData); ok {
-			if strings.TrimSpace(string(cd)) == "" {
+
+		switch t := tok.(type) {
+		case xml.StartElement:
+			stack = append(stack, t.Name.Local)
+		case xml.EndElement:
+			if len(stack) > 0 {
+				stack = stack[:len(stack)-1]
+			}
+		case xml.CharData:
+			if strings.TrimSpace(string(t)) == "" {
 				continue
 			}
+			var parent string
+			if len(stack) > 0 {
+				parent = stack[len(stack)-1]
+			}
+			switch {
+			case isSensitiveField(parent):
+				tok = xml.CharData(redactedPlaceholder)
+			case looksLikePlist(t):
+				tok = xml.CharData(redactPlist(t))
+			}
 		}
+
 		if err := enc.EncodeToken(tok); err != nil {
-			return "", err
+			return "", false
 		}
 	}
+
 	if err := enc.Flush(); err != nil {
-		return "", err
+		return "", false
 	}
-	return buf.String(), nil
+	return buf.String(), true
+}
+
+// looksLikePlist reports whether character data is an Apple property list, by
+// sniffing for a plist or bare dict root with or without an XML prolog.
+func looksLikePlist(data []byte) bool {
+	trimmed := strings.TrimSpace(string(data))
+	if !strings.HasPrefix(trimmed, "<") {
+		return false
+	}
+	return strings.Contains(trimmed, "<plist") ||
+		strings.Contains(trimmed, "<!DOCTYPE plist") ||
+		strings.HasPrefix(trimmed, "<dict")
+}
+
+// redactPlist parses embedded plist content, replaces credential values, and
+// re-emits it. A plist that will not parse is replaced wholesale, keeping the
+// fail-closed contract of formatBody: unparsed content is never logged.
+func redactPlist(raw []byte) string {
+	parsed, _, err := plisthelpers.ParsePlist(raw)
+	if err != nil {
+		return redactedPlaceholder
+	}
+
+	redactPlistValue(parsed)
+
+	out, err := plisthelpers.MarshalPlist(parsed)
+	if err != nil {
+		return redactedPlaceholder
+	}
+	return string(out)
+}
+
+// redactPlistValue walks a decoded plist in place, redacting sensitive keys, and
+// returns the value it was given.
+func redactPlistValue(value any) any {
+	switch typed := value.(type) {
+	case map[string]any:
+		for k, v := range typed {
+			if isSensitivePlistKey(k, v) {
+				typed[k] = redactedPlaceholder
+				continue
+			}
+			typed[k] = redactPlistValue(v)
+		}
+		return typed
+	case []any:
+		for i, v := range typed {
+			typed[i] = redactPlistValue(v)
+		}
+		return typed
+	}
+	return value
 }

--- a/internal/provider/tflogger_test.go
+++ b/internal/provider/tflogger_test.go
@@ -4,14 +4,38 @@
 package provider
 
 import (
+	"bytes"
+	"encoding/xml"
 	"net/http"
 	"strings"
 	"testing"
 )
 
-func TestPrettyPrint_JSONObject(t *testing.T) {
-	in := []byte(`{"name":"foo","id":1,"tags":["a","b"]}`)
-	got := prettyPrint(in)
+// render is a test helper: renders a body and fails if it was withheld.
+func render(t *testing.T, in []byte) string {
+	t.Helper()
+	got, ok := redactAndFormat(in)
+	if !ok {
+		t.Fatalf("body unexpectedly withheld: %q", in)
+	}
+	return got
+}
+
+// escapeXMLText escapes a string the way it would appear as XML character data,
+// so tests can embed a plist inside an element the same way Jamf Pro does.
+func escapeXMLText(t *testing.T, s string) string {
+	t.Helper()
+	var buf bytes.Buffer
+	if err := xml.EscapeText(&buf, []byte(s)); err != nil {
+		t.Fatalf("escaping test fixture: %v", err)
+	}
+	return buf.String()
+}
+
+// --- formatting ------------------------------------------------------------
+
+func TestRedactAndFormat_JSONObject(t *testing.T) {
+	got := render(t, []byte(`{"name":"foo","id":1,"tags":["a","b"]}`))
 	if !strings.Contains(got, "\n  \"name\": \"foo\"") {
 		t.Errorf("JSON not indented:\n%s", got)
 	}
@@ -20,18 +44,16 @@ func TestPrettyPrint_JSONObject(t *testing.T) {
 	}
 }
 
-func TestPrettyPrint_JSONArray(t *testing.T) {
-	in := []byte(`[{"a":1},{"a":2}]`)
-	got := prettyPrint(in)
+func TestRedactAndFormat_JSONArray(t *testing.T) {
+	got := render(t, []byte(`[{"a":1},{"a":2}]`))
 	if !strings.HasPrefix(got, "[\n  {") {
 		t.Errorf("JSON array root not indented:\n%s", got)
 	}
 }
 
-func TestPrettyPrint_XMLBasic(t *testing.T) {
+func TestRedactAndFormat_XMLBasic(t *testing.T) {
 	in := []byte(`<user_group><id>3</id><name>Excluded Users</name><is_smart>false</is_smart></user_group>`)
-	got := prettyPrint(in)
-	// Each child element must land on its own indented line.
+	got := render(t, in)
 	for _, want := range []string{
 		"<user_group>\n  <id>3</id>",
 		"  <name>Excluded Users</name>",
@@ -44,55 +66,259 @@ func TestPrettyPrint_XMLBasic(t *testing.T) {
 	}
 }
 
-func TestPrettyPrint_XMLNested(t *testing.T) {
+func TestRedactAndFormat_XMLNested(t *testing.T) {
 	in := []byte(`<user_group><criteria><size>1</size><criterion><name>User Group</name><value>x</value></criterion></criteria></user_group>`)
-	got := prettyPrint(in)
-	// Nested criterion gets two-step indent.
+	got := render(t, in)
 	if !strings.Contains(got, "    <criterion>\n      <name>User Group</name>") {
 		t.Errorf("XML nesting not indented to 4 spaces:\n%s", got)
 	}
 }
 
-func TestPrettyPrint_LeadingWhitespace(t *testing.T) {
-	in := []byte("\n\t  <foo><bar/></foo>")
-	got := prettyPrint(in)
+func TestRedactAndFormat_LeadingWhitespace(t *testing.T) {
+	got := render(t, []byte("\n\t  <foo><bar/></foo>"))
 	if !strings.Contains(got, "<foo>\n  <bar></bar>") {
 		t.Errorf("leading whitespace tripped XML sniff:\n%s", got)
 	}
 }
 
-func TestPrettyPrint_Opaque_PassesThrough(t *testing.T) {
-	in := []byte("plain text, not JSON, not XML")
-	got := prettyPrint(in)
-	if got != string(in) {
-		t.Errorf("opaque body mutated: %q", got)
+// TestRedactJSON_PreservesMemberOrder guards the reason redaction streams tokens
+// instead of round-tripping through map[string]any: Jamf Pro rejects some
+// classic payloads whose members arrive out of order, so a debug log that
+// silently re-sorted them would misdirect that exact investigation.
+func TestRedactJSON_PreservesMemberOrder(t *testing.T) {
+	got := render(t, []byte(`{"zebra":1,"apple":2,"mango":3}`))
+	zebra := strings.Index(got, "zebra")
+	apple := strings.Index(got, "apple")
+	mango := strings.Index(got, "mango")
+	if zebra >= apple || apple >= mango {
+		t.Errorf("member order not preserved (zebra=%d apple=%d mango=%d):\n%s", zebra, apple, mango, got)
 	}
 }
 
-func TestPrettyPrint_InvalidJSON_PassesThrough(t *testing.T) {
-	in := []byte(`{not valid json`)
-	got := prettyPrint(in)
-	if got != string(in) {
-		t.Errorf("invalid JSON should fall through to raw: %q", got)
+// TestRedactJSON_PreservesNumberLiterals guards dec.UseNumber(): the default
+// float64 decode would rewrite a large ID and drop a trailing zero.
+func TestRedactJSON_PreservesNumberLiterals(t *testing.T) {
+	got := render(t, []byte(`{"big":12345678901234567890,"exact":1.10}`))
+	for _, want := range []string{"12345678901234567890", "1.10"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("number literal %q not preserved:\n%s", want, got)
+		}
 	}
 }
 
-func TestPrettyPrint_InvalidXML_PassesThrough(t *testing.T) {
-	in := []byte(`<unclosed`)
-	got := prettyPrint(in)
-	if got != string(in) {
-		t.Errorf("invalid XML should fall through to raw: %q", got)
+// --- JSON redaction --------------------------------------------------------
+
+func TestRedactJSON_RedactsSecretScalars(t *testing.T) {
+	in := []byte(`{"username":"svc-bind","password":"hunter2","clientSecret":"cs-abc","token":"tok-xyz"}`)
+	got := render(t, in)
+
+	for _, leak := range []string{"hunter2", "cs-abc", "tok-xyz"} {
+		if strings.Contains(got, leak) {
+			t.Errorf("secret %q leaked:\n%s", leak, got)
+		}
+	}
+	if !strings.Contains(got, `"username": "svc-bind"`) {
+		t.Errorf("non-secret username should survive:\n%s", got)
+	}
+	if n := strings.Count(got, redactedPlaceholder); n != 3 {
+		t.Errorf("expected 3 redactions, got %d:\n%s", n, got)
 	}
 }
 
-func TestPrettyPrint_Empty(t *testing.T) {
-	if got := prettyPrint(nil); got != "" {
-		t.Errorf("nil body: expected empty, got %q", got)
+// TestRedactJSON_KeepsNonSecretLookalikes is the point of exact-match matching:
+// every field here contains "password", "key" or "token" but none is a secret,
+// and several are exactly what DEBUG was enabled to inspect.
+func TestRedactJSON_KeepsNonSecretLookalikes(t *testing.T) {
+	in := []byte(`{
+	  "passwordMinLength": 12,
+	  "passwordMaxAge": 90,
+	  "passwordHistoryDepth": 5,
+	  "passcodePresent": true,
+	  "passed": false,
+	  "passPercentage": 80,
+	  "keyUsage": "digitalSignature",
+	  "groupRdnKey": "cn",
+	  "triggerKey": "startup",
+	  "tokenExpiration": "2026-01-01",
+	  "bootstrapTokenEscrowed": true,
+	  "vppTokenEnabled": false,
+	  "keystoreFileName": "sso.jks"
+	}`)
+	got := render(t, in)
+	if strings.Contains(got, redactedPlaceholder) {
+		t.Errorf("non-secret lookalike field was redacted:\n%s", got)
 	}
-	if got := prettyPrint([]byte("   ")); got != "   " {
+}
+
+func TestRedactJSON_RedactsWholeSubtreeUnderSecretKey(t *testing.T) {
+	in := []byte(`{"keystore":{"bytes":"MIIKk...","alias":"jamf"},"name":"sso"}`)
+	got := render(t, in)
+
+	for _, leak := range []string{"MIIKk", "alias", "jamf"} {
+		if strings.Contains(got, leak) {
+			t.Errorf("nested value %q survived under a secret key:\n%s", leak, got)
+		}
+	}
+	if !strings.Contains(got, `"keystore": "REDACTED"`) {
+		t.Errorf("expected whole keystore subtree redacted:\n%s", got)
+	}
+	if !strings.Contains(got, `"name": "sso"`) {
+		t.Errorf("sibling should survive:\n%s", got)
+	}
+}
+
+func TestRedactJSON_CaseInsensitiveFieldMatch(t *testing.T) {
+	in := []byte(`{"Password":"a","PASSWORD":"b","password":"c"}`)
+	got := render(t, in)
+	for _, leak := range []string{`"a"`, `"b"`, `"c"`} {
+		if strings.Contains(got, leak) {
+			t.Errorf("value %s leaked despite case-insensitive match:\n%s", leak, got)
+		}
+	}
+}
+
+func TestRedactJSON_RedactsInsideArrays(t *testing.T) {
+	in := []byte(`{"accounts":[{"username":"a","password":"p1"},{"username":"b","password":"p2"}]}`)
+	got := render(t, in)
+	for _, leak := range []string{"p1", "p2"} {
+		if strings.Contains(got, leak) {
+			t.Errorf("secret %q inside array leaked:\n%s", leak, got)
+		}
+	}
+	if n := strings.Count(got, redactedPlaceholder); n != 2 {
+		t.Errorf("expected 2 redactions, got %d:\n%s", n, got)
+	}
+}
+
+// --- XML redaction ---------------------------------------------------------
+
+func TestRedactXML_RedactsSensitiveElements(t *testing.T) {
+	in := []byte(`<directory_binding><name>AD</name><username>svc</username><password>hunter2</password><password_sha256>deadbeef</password_sha256></directory_binding>`)
+	got := render(t, in)
+
+	for _, leak := range []string{"hunter2", "deadbeef"} {
+		if strings.Contains(got, leak) {
+			t.Errorf("secret %q leaked:\n%s", leak, got)
+		}
+	}
+	if !strings.Contains(got, "<name>AD</name>") || !strings.Contains(got, "<username>svc</username>") {
+		t.Errorf("non-secret elements should survive:\n%s", got)
+	}
+	if !strings.Contains(got, "<password>REDACTED</password>") {
+		t.Errorf("expected redacted password element:\n%s", got)
+	}
+}
+
+// --- plist-in-XML redaction ------------------------------------------------
+
+func TestRedactXML_RedactsPlistPayloadSecrets(t *testing.T) {
+	inner := `<?xml version="1.0" encoding="UTF-8"?><plist version="1.0"><dict>` +
+		`<key>PayloadIdentifier</key><string>com.jamf.wifi</string>` +
+		`<key>SSID_STR</key><string>CorpWiFi</string>` +
+		`<key>Password</key><string>hunter2</string>` +
+		`</dict></plist>`
+	in := []byte(`<configuration_profile><general><name>WiFi</name><payloads>` +
+		escapeXMLText(t, inner) + `</payloads></general></configuration_profile>`)
+
+	got := render(t, in)
+
+	if strings.Contains(got, "hunter2") {
+		t.Errorf("plist payload password leaked:\n%s", got)
+	}
+	if !strings.Contains(got, redactedPlaceholder) {
+		t.Errorf("expected a redaction inside the payload:\n%s", got)
+	}
+	for _, want := range []string{"PayloadIdentifier", "com.jamf.wifi", "SSID_STR", "CorpWiFi"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("non-secret payload key %q was lost:\n%s", want, got)
+		}
+	}
+}
+
+// TestRedactPlist_PayloadContentArrayVsBlob covers the one key that means two
+// different things: at the top level PayloadContent is the ARRAY of payloads
+// (must be walked, not blanked); inside a certificate payload it is the raw
+// PKCS#12 bytes (must be redacted).
+func TestRedactPlist_PayloadContentArrayVsBlob(t *testing.T) {
+	inner := `<plist version="1.0"><dict>` +
+		`<key>PayloadContent</key><array><dict>` +
+		`<key>PayloadType</key><string>com.apple.security.pkcs12</string>` +
+		`<key>PayloadContent</key><data>TUlJS2t3SUJBekNDQ2s4</data>` +
+		`</dict></array>` +
+		`</dict></plist>`
+
+	got := redactPlist([]byte(inner))
+
+	if strings.Contains(got, "TUlJS2t3SUJBekNDQ2s4") {
+		t.Errorf("certificate blob leaked:\n%s", got)
+	}
+	if !strings.Contains(got, "com.apple.security.pkcs12") {
+		t.Errorf("top-level PayloadContent array was blanked, losing the profile:\n%s", got)
+	}
+	if !strings.Contains(got, redactedPlaceholder) {
+		t.Errorf("expected the blob to be redacted:\n%s", got)
+	}
+}
+
+func TestRedactPlist_UnparseableFailsClosed(t *testing.T) {
+	got := redactPlist([]byte(`<plist version="1.0"><dict><key>oops`))
+	if got != redactedPlaceholder {
+		t.Errorf("unparseable plist must be withheld wholesale, got: %q", got)
+	}
+}
+
+// --- fail-closed behaviour -------------------------------------------------
+
+func TestFormatBody_WithholdsOpaqueBody(t *testing.T) {
+	got := formatBody([]byte("user=admin&password=hunter2"))
+	if strings.Contains(got, "hunter2") {
+		t.Errorf("form-encoded secret leaked: %q", got)
+	}
+	if !strings.Contains(got, "body withheld") {
+		t.Errorf("expected withheld notice, got: %q", got)
+	}
+}
+
+func TestFormatBody_WithholdsInvalidJSON(t *testing.T) {
+	got := formatBody([]byte(`{"password":"hunter2",`))
+	if strings.Contains(got, "hunter2") {
+		t.Errorf("secret in truncated JSON leaked: %q", got)
+	}
+	if !strings.Contains(got, "body withheld") {
+		t.Errorf("expected withheld notice, got: %q", got)
+	}
+}
+
+func TestFormatBody_WithholdsInvalidXML(t *testing.T) {
+	got := formatBody([]byte(`<binding><password>hunter2</password`))
+	if strings.Contains(got, "hunter2") {
+		t.Errorf("secret in malformed XML leaked: %q", got)
+	}
+	if !strings.Contains(got, "body withheld") {
+		t.Errorf("expected withheld notice, got: %q", got)
+	}
+}
+
+func TestFormatBody_WithholdsTrailingGarbageAfterJSON(t *testing.T) {
+	got := formatBody([]byte(`{"a":1} then some raw text with password=hunter2`))
+	if strings.Contains(got, "hunter2") {
+		t.Errorf("trailing raw content leaked: %q", got)
+	}
+}
+
+func TestFormatBody_KeepsMultipartSentinel(t *testing.T) {
+	if got := formatBody([]byte(multipartSentinel)); got != multipartSentinel {
+		t.Errorf("multipart sentinel should pass through, got %q", got)
+	}
+}
+
+func TestFormatBody_Empty(t *testing.T) {
+	if got := formatBody([]byte("   ")); got != "   " {
 		t.Errorf("whitespace-only: expected unchanged, got %q", got)
 	}
 }
+
+// --- headers ---------------------------------------------------------------
 
 func TestFormatHeaders_SortedAndJoined(t *testing.T) {
 	h := http.Header{
@@ -137,8 +363,11 @@ func TestFormatHeaders_Empty(t *testing.T) {
 	}
 }
 
-func TestFormatBody_TruncatesAfterPretty(t *testing.T) {
-	// Build a JSON object large enough to exceed maxLoggedBodyBytes after indent.
+// --- truncation ------------------------------------------------------------
+
+// TestFormatBody_TruncatesAfterRedaction builds a JSON object large enough to
+// exceed maxLoggedBodyBytes once indented, and asserts the truncation marker.
+func TestFormatBody_TruncatesAfterRedaction(t *testing.T) {
 	var sb strings.Builder
 	sb.WriteString(`{"items":[`)
 	for i := range 200 {
@@ -157,5 +386,27 @@ func TestFormatBody_TruncatesAfterPretty(t *testing.T) {
 	}
 	if len(got) > maxLoggedBodyBytes+len("... (truncated)") {
 		t.Errorf("truncated string too long: %d", len(got))
+	}
+}
+
+// TestFormatBody_RedactsBeforeTruncating proves ordering: a secret early in a
+// long body must be gone even though truncation only removes the tail.
+func TestFormatBody_RedactsBeforeTruncating(t *testing.T) {
+	var sb strings.Builder
+	sb.WriteString(`{"password":"hunter2","items":[`)
+	for i := range 300 {
+		if i > 0 {
+			sb.WriteString(",")
+		}
+		sb.WriteString(`"padding-value-to-push-past-the-truncation-limit"`)
+	}
+	sb.WriteString("]}")
+
+	got := formatBody([]byte(sb.String()))
+	if strings.Contains(got, "hunter2") {
+		t.Errorf("secret survived in a truncated body:\n%s", got[:200])
+	}
+	if !strings.HasSuffix(got, "... (truncated)") {
+		t.Errorf("expected truncation to still apply")
 	}
 }

--- a/tools/tools.go
+++ b/tools/tools.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2021, 2025
+// Copyright Jamf Software LLC 2026
 // SPDX-License-Identifier: MPL-2.0
 
 //go:build generate


### PR DESCRIPTION
Closes the follow-up items from the Jamf OSS §9.2.4 Developer Pre-Release Checklist run of 2026-08-13, ahead of AppSec review for **ASKAS-447** (transfer of this repo into the `jamf` GitHub org).

## 1. Redact secrets in debug-level HTTP bodies

`TerraformLogger` redacted sensitive *headers* but pretty-printed request and response **bodies** verbatim. 24 resources carry `WriteOnly` secret attributes whose plaintext values transit those bodies on Create/Update, so `TF_LOG=DEBUG` — a routine, HashiCorp-documented troubleshooting step — wrote them into logs that commonly end up in support tickets and CI output.

Bodies are now redacted before rendering, and **before truncation**, so a secret early in a long body is removed rather than merely pushed past the cut.

Three mechanisms, one per body shape:

| Shape | Approach |
|---|---|
| JSON | Token-streamed, **not** round-tripped through `map[string]any` — Go maps don't preserve member order, and wire field order has been load-bearing here before (Jamf Pro rejects some classic payloads whose members arrive out of order). `UseNumber` keeps numeric literals intact. A sensitive key has its **entire** value consumed, so a credential nested under one can't survive. |
| XML | Element-name matching layered onto the existing indent token stream. |
| plist inside XML | Configuration profile payloads ride as escaped plist inside `<payloads>`, where secrets sit in sibling `<key>`/`<string>` pairs that element-name matching structurally cannot see. Parsed via `plisthelpers`, walked, redacted, re-emitted — so payload diffs stay readable. |

**Field matching is exact, never substring.** The Jamf schemas carry many non-secret fields whose names contain `password`, `key` or `token` — `passwordMinLength`, `passwordMaxAge`, `passcodePresent`, `passed`, `keyUsage`, `groupRdnKey`, `tokenExpiration`, `bootstrapTokenEscrowed`, `vppTokenEnabled` — and those are frequently the very values an operator enabled DEBUG to inspect. A substring rule would redact the log into uselessness while adding no safety. Bare `key`/`keys` are excluded for the same reason: key material in `SsoKeystore`, but plain identifiers in `StatusItem`, `UserPreferencesSettings` and `ComputerContentCachingDataMigrationErrorUserInfo`; the blob-bearing siblings (`keystore`, `keystoreBytes`, `keystoreFile`, `privateKey`) cover the material instead.

`PayloadContent` is the one key needing its value to decide: at the top level of a `.mobileconfig` it's the **array** of payloads (walk it, or the whole profile blanks); inside a certificate payload it's the raw PKCS#12 bytes (redact it).

**Rendering now fails closed.** Redaction can only find secrets in a body it can parse, so a body that is neither JSON nor XML is withheld rather than logged raw — logging it would have silently bypassed every rule above. The SDK's `<multipart body>` sentinel is the one recognised exception, so file and package uploads still log recognisably.

### Scope narrowed while investigating

Two parts of the original finding turned out not to apply:

- **Request headers were never at risk** — the SDK's `Logger` interface passes none to `LogRequest`, so the bearer token never reaches the logger.
- **Provider credentials are unaffected** — the OAuth token exchange runs through `golang.org/x/oauth2/clientcredentials` on its own `http.Client`, outside the SDK's logged request path. This closes the "open question" the audit left about the token-exchange body.

## 2. Dependency CVE

`google.golang.org/grpc` v1.81.1 → v1.82.1 — GO-2026-6061 / GHSA-hrxh-6v49-42gf (HIGH), reachable via `terraform-plugin-go`'s `tf5server`. `govulncheck ./...` now reports no vulnerabilities. Closes Dependabot alert #16.

## 3. SECURITY.md

Added per OSS Policy §9.1.6, written to Engineering Guidance §2.5(a)–(d): monitored-team intake (public VDP page + GitHub private vulnerability reporting, which is already enabled), stated acknowledgement time, explicit in/out scope, coordinated-disclosure request. None of §2.5's prohibited contents (PGP keys, bug-bounty commitments, remediation-time guarantees).

⚠️ **One item needs AppSec sign-off.** The 5-business-day acknowledgement comes from §2.5(b) — but that page self-declares as a working *draft*, and the in-force policy (KB0215395 §9.1.6) states no timeframe. It's therefore a public commitment on AppSec's behalf sourced from a draft. Flagged for confirmation in ASKAS-447; trivial to reword if they'd rather stand behind something else.

For the record: no canonical Jamf `SECURITY.md` template appears to exist yet. §2.5 says AppSec "will maintain" one in the OSRB Confluence space (future tense), a Confluence search finds none, and none of the Jamf public repos checked carries a `SECURITY.md`. This one is offered as a candidate.

## 4. README troubleshooting

New Troubleshooting section: `TF_LOG` usage, exactly what redaction does and does not cover, and why a debug log still warrants a read-through before it's attached to a ticket or left in CI output.

## 5. .gitleaksignore — dead fingerprints

The two `gsx-certificate.p12` false-positive suppressions were pinned to commit `e79e5aeb`, **which no longer exists in history** (`git cat-file -t` fails on it) — presumably invalidated by a rebase. Both suppressions had silently stopped matching, and a full-history scan still reported 2 findings. Repinned to the introducing commit `1335078e`; full-history scan is now clean.

CI never caught this: `gitleaks-action` on push/PR scans only the pushed commits, not full history, so it never revisits the old commit. Full-history scans — i.e. what AppSec run during an OSS review — are the only thing that exposes it. A comment now records how to re-derive the fingerprints after any history rewrite.

## 6. tools/tools.go

Replaced the inherited HashiCorp/IBM scaffold copyright header with a Jamf one. `copywrite` only adds missing headers, so it never rewrote this one.

## Verification

- `go build ./...` — clean
- `go vet ./...` — clean
- `go test ./...` — all pass, including 24 new/updated `tflogger` tests
- `golangci-lint run ./internal/...` — 0 issues
- `govulncheck ./...` — no vulnerabilities
- `gitleaks git --log-opts="--all"` — 1,038 commits, no leaks
- `trufflehog git file://. --results=verified,unknown` — 0 verified, 0 unverified

New tests cover: secret scalars redacted; non-secret lookalikes preserved; whole subtree redacted under a secret key; case-insensitive matching; secrets inside arrays; JSON member order preserved; numeric literals preserved; XML sensitive elements; plist payload secrets redacted while non-secret payload keys survive; `PayloadContent` array-vs-blob; unparseable plist fails closed; opaque / invalid-JSON / invalid-XML / trailing-garbage bodies all withheld; multipart sentinel preserved; redaction ordered before truncation.

## Not included

No SBOM — that card stays blocked on the org-level CRA/SBOM programme (SCA tool decision and format still open with AppSec/OSRB), and building `cyclonedx-gomod` here now risks diverging from whatever the org standardises on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)